### PR TITLE
#46 Refactor: 대댓글 중복제거 코드 리팩토링

### DIFF
--- a/src/main/java/leets/weeth/domain/board/application/dto/NoticeDTO.java
+++ b/src/main/java/leets/weeth/domain/board/application/dto/NoticeDTO.java
@@ -32,4 +32,15 @@ public class NoticeDTO {
             List<String> fileUrls,
             List<CommentDTO.Response> comments
     ){}
+
+    @Builder
+    public record ResponseAll(
+            Long id,
+            String name,
+            String title,
+            String content,
+            LocalDateTime time,//modifiedAt
+            Integer commentCount
+    ){}
+
 }

--- a/src/main/java/leets/weeth/domain/board/application/dto/PostDTO.java
+++ b/src/main/java/leets/weeth/domain/board/application/dto/PostDTO.java
@@ -33,4 +33,14 @@ public class PostDTO {
             List<CommentDTO.Response> comments
     ){}
 
+    @Builder
+    public record ResponseAll(
+            Long id,
+            String name,
+            String title,
+            String content,
+            LocalDateTime time,//modifiedAt
+            Integer commentCount
+    ){}
+
 }

--- a/src/main/java/leets/weeth/domain/board/application/mapper/NoticeMapper.java
+++ b/src/main/java/leets/weeth/domain/board/application/mapper/NoticeMapper.java
@@ -43,7 +43,7 @@ public interface NoticeMapper {
         return comments.stream()
                 .filter(comment -> comment.getParent() == null) // 부모 댓글만 필터링
                 .map(this::mapCommentWithChildren) // 자식 댓글 포함하여 매핑
-                .collect(Collectors.toList());
+                .toList();
     }
 
     default CommentDTO.Response mapCommentWithChildren(Comment comment) {

--- a/src/main/java/leets/weeth/domain/board/application/mapper/NoticeMapper.java
+++ b/src/main/java/leets/weeth/domain/board/application/mapper/NoticeMapper.java
@@ -21,9 +21,11 @@ public interface NoticeMapper {
     })
     Notice fromNoticeDto(NoticeDTO.Save dto, List<String> fileUrls, User user);
 
-//    @Mapping(target = "id", source = "noticeId")
-//    @Mapping(target = "user", source = "user")
-//    Notice update(Long noticeId, NoticeDTO.Update dto, List<String> fileUrls, User user);
+    @Mappings({
+            @Mapping(target = "name", source = "user.name"),
+            @Mapping(target = "time", source = "modifiedAt")
+    })
+    NoticeDTO.ResponseAll toAll(Notice notice);
 
     @Mappings({
             @Mapping(target = "name", source = "user.name"),
@@ -66,7 +68,4 @@ public interface NoticeMapper {
         return response.build();
     }
 
-    @Mapping(target = "name", source = "user.name")
-    @Mapping(target = "time", source = "modifiedAt")
-    CommentDTO.Response mapComment(Comment comment);
 }

--- a/src/main/java/leets/weeth/domain/board/application/mapper/PostMapper.java
+++ b/src/main/java/leets/weeth/domain/board/application/mapper/PostMapper.java
@@ -43,7 +43,7 @@ public interface PostMapper {
         return comments.stream()
                 .filter(comment -> comment.getParent() == null) // 부모 댓글만 필터링
                 .map(this::mapCommentWithChildren) // 자식 댓글 포함하여 매핑
-                .collect(Collectors.toList());
+                .toList();
     }
 
     default CommentDTO.Response mapCommentWithChildren(Comment comment) {
@@ -67,9 +67,5 @@ public interface PostMapper {
 
         return response.build();
     }
-
-    @Mapping(target = "name", source = "user.name")
-    @Mapping(target = "time", source = "modifiedAt")
-    CommentDTO.Response mapComment(Comment comment);
 
 }

--- a/src/main/java/leets/weeth/domain/board/application/mapper/PostMapper.java
+++ b/src/main/java/leets/weeth/domain/board/application/mapper/PostMapper.java
@@ -21,9 +21,11 @@ public interface PostMapper {
     })
     Post fromPostDto(PostDTO.Save dto, List<String> fileUrls, User user);
 
-//    @Mapping(target = "id", source = "postId")
-//    @Mapping(target = "user", source = "user")
-//    Post update(Long postId, PostDTO.Update dto, User user);
+    @Mappings({
+            @Mapping(target = "name", source = "user.name"),
+            @Mapping(target = "time", source = "modifiedAt")
+    })
+    PostDTO.ResponseAll toAll(Post post);
 
     @Mappings({
             @Mapping(target = "name", source = "user.name"),

--- a/src/main/java/leets/weeth/domain/board/application/usecase/NoticeUsecase.java
+++ b/src/main/java/leets/weeth/domain/board/application/usecase/NoticeUsecase.java
@@ -13,7 +13,7 @@ public interface NoticeUsecase {
 
     NoticeDTO.Response findNotice(Long noticeId);
 
-    List<NoticeDTO.Response> findNotices(Long noticeId, Integer count);
+    List<NoticeDTO.ResponseAll> findNotices(Long noticeId, Integer count);
 
     void update(Long noticeId, NoticeDTO.Update dto, List<MultipartFile> files, Long userId) throws UserNotMatchException;
 

--- a/src/main/java/leets/weeth/domain/board/application/usecase/NoticeUsecaseImpl.java
+++ b/src/main/java/leets/weeth/domain/board/application/usecase/NoticeUsecaseImpl.java
@@ -50,7 +50,7 @@ public class NoticeUsecaseImpl implements NoticeUsecase {
     }
 
     @Override
-    public List<NoticeDTO.Response> findNotices(Long noticeId, Integer count) {
+    public List<NoticeDTO.ResponseAll> findNotices(Long noticeId, Integer count) {
 
         Long finalNoticeId = noticeFindService.findFinalNoticeId();
 
@@ -66,7 +66,7 @@ public class NoticeUsecaseImpl implements NoticeUsecase {
         List<Notice> notices = noticeFindService.findRecentNotices(noticeId, pageable);
 
         return notices.stream()
-                .map(mapper::toNoticeDto)
+                .map(mapper::toAll)
                 .toList();
     }
 

--- a/src/main/java/leets/weeth/domain/board/application/usecase/PostUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/board/application/usecase/PostUseCaseImpl.java
@@ -52,7 +52,7 @@ public class PostUseCaseImpl implements PostUsecase {
     }
 
     @Override
-    public List<PostDTO.Response> findPosts(Long postId, Integer count) {
+    public List<PostDTO.ResponseAll> findPosts(Long postId, Integer count) {
 
         Long finalPostId = postFindService.findFinalPostId();
 
@@ -68,7 +68,7 @@ public class PostUseCaseImpl implements PostUsecase {
         List<Post> posts = postFindService.findRecentPosts(postId, pageable);
 
         return posts.stream()
-                .map(mapper::toPostDto)
+                .map(mapper::toAll)
                 .toList();
     }
 

--- a/src/main/java/leets/weeth/domain/board/application/usecase/PostUsecase.java
+++ b/src/main/java/leets/weeth/domain/board/application/usecase/PostUsecase.java
@@ -13,7 +13,7 @@ public interface PostUsecase {
 
     PostDTO.Response findPost(Long postId);
 
-    List<PostDTO.Response> findPosts(Long postId, Integer count);
+    List<PostDTO.ResponseAll> findPosts(Long postId, Integer count);
 
     void update(Long postId, PostDTO.Update dto, List<MultipartFile> files, Long userId) throws UserNotMatchException;
 

--- a/src/main/java/leets/weeth/domain/board/presentation/NoticeController.java
+++ b/src/main/java/leets/weeth/domain/board/presentation/NoticeController.java
@@ -17,7 +17,7 @@ public class NoticeController {
     private final NoticeUsecase noticeUsecase;
 
     @GetMapping
-    public CommonResponse<List<NoticeDTO.Response>> findNotices(@RequestParam(required = false) Long noticeId, @RequestParam Integer count) {
+    public CommonResponse<List<NoticeDTO.ResponseAll>> findNotices(@RequestParam(required = false) Long noticeId, @RequestParam Integer count) {
         return CommonResponse.createSuccess(noticeUsecase.findNotices(noticeId, count));
     }
 

--- a/src/main/java/leets/weeth/domain/board/presentation/PostController.java
+++ b/src/main/java/leets/weeth/domain/board/presentation/PostController.java
@@ -30,7 +30,7 @@ public class PostController {
     }
 
     @GetMapping
-    public CommonResponse<List<PostDTO.Response>> findPosts(@RequestParam(required = false) Long postId, @RequestParam Integer count) {
+    public CommonResponse<List<PostDTO.ResponseAll>> findPosts(@RequestParam(required = false) Long postId, @RequestParam Integer count) {
         return CommonResponse.createSuccess(postUsecase.findPosts(postId, count));
     }
 

--- a/src/main/java/leets/weeth/domain/comment/application/mapper/CommentMapper.java
+++ b/src/main/java/leets/weeth/domain/comment/application/mapper/CommentMapper.java
@@ -7,6 +7,9 @@ import leets.weeth.domain.comment.domain.entity.Comment;
 import leets.weeth.domain.user.domain.entity.User;
 import org.mapstruct.*;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Mapper(componentModel = MappingConstants.ComponentModel.SPRING, unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface CommentMapper {
 

--- a/src/main/java/leets/weeth/domain/comment/application/mapper/CommentMapper.java
+++ b/src/main/java/leets/weeth/domain/comment/application/mapper/CommentMapper.java
@@ -7,9 +7,6 @@ import leets.weeth.domain.comment.domain.entity.Comment;
 import leets.weeth.domain.user.domain.entity.User;
 import org.mapstruct.*;
 
-import java.util.ArrayList;
-import java.util.List;
-
 @Mapper(componentModel = MappingConstants.ComponentModel.SPRING, unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface CommentMapper {
 
@@ -22,7 +19,7 @@ public interface CommentMapper {
             @Mapping(target = "user", source = "user"),
             @Mapping(target = "parent", source = "parent"),
             @Mapping(target = "content", source = "dto.content"),
-            @Mapping(target = "post", source = "post"),
+            @Mapping(target = "post", source = "post")
     })
     Comment fromCommentDto(CommentDTO.Save dto, Post post, User user, Comment parent);
 
@@ -35,13 +32,11 @@ public interface CommentMapper {
             @Mapping(target = "user", source = "user"),
             @Mapping(target = "parent", source = "parent"),
             @Mapping(target = "content", source = "dto.content"),
-            @Mapping(target = "notice", source = "notice"),
-
+            @Mapping(target = "notice", source = "notice")
     })
     Comment fromCommentDto(CommentDTO.Save dto, Notice notice, User user, Comment parent);
 
     @Mapping(target = "name", source = "user.name")
     @Mapping(target = "time", source = "modifiedAt")
     CommentDTO.Response toCommentDto(Comment comment);
-
 }

--- a/src/main/java/leets/weeth/domain/comment/application/usecase/NoticeCommentUsecaseImpl.java
+++ b/src/main/java/leets/weeth/domain/comment/application/usecase/NoticeCommentUsecaseImpl.java
@@ -54,6 +54,7 @@ public class NoticeCommentUsecaseImpl implements NoticeCommentUsecase {
         notice.incrementCommentCount();
     }
 
+
     @Override
     @Transactional
     public void updateNoticeComment(CommentDTO.Update dto, Long noticeId, Long commentId, Long userId) throws UserNotMatchException {


### PR DESCRIPTION
## 무엇을 개발했나요?
- 대댓글 중복 반환되는 부분로직 리팩토링
- 기존 로직대로 반환시 대댓글이 일반 댓글로도 중복 반환되는 문제가 있었음
- 자식 댓글은 자식 댓글로만 표시되는 필터링 추가
- mapper 구현체를 직접 수정할 수 없어 필터링 하는 코드를 mapper 인터페이스에 구현
- 인터페이스 한계로 commentMapper를 직접 주입할 수 없어 해당 코드를 noticeMapper, postMapper에 구현하였음