### PR TITLE
 Refactor #53 CICD 및 서버 배포 설정 수정

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -2,8 +2,10 @@ name: Weeth-BE CICD
 
 on:
   push:
-    branches: [ "main" ]
-
+    branches:
+      - "main"
+      - "develop"   # develop 브랜치에도 빌드 실행
+      - "Refactor/*"  # Refactor로 시작하는 브랜치에도 빌드 실행
 
 jobs:
   build:
@@ -43,26 +45,21 @@ jobs:
           docker build -t ${{ secrets.DOCKER_USER_NAME }}/weeth .
           docker push ${{ secrets.DOCKER_USER_NAME }}/weeth
 
-      # EC2 ssh 연결 후 이미지 pull
-      - name: Deploy to server
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build  # CI 파이프라인의 build 작업이 끝나야 deploy가 실행됨
+
+    steps:
+      # EC2 서버로 배포
+      - name: Deploy to EC2
         uses: appleboy/ssh-action@master
         with:
           host: ${{ secrets.EC2_SECRET_HOST }}
-          username: ubuntu
+          username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SECRET_PEM }}
-          envs: GITHUB_SHA
+          port: 22
           script: |
-            EXISTING_CONTAINER_ID=$(sudo docker ps -q -f "publish=8080" -f "status=running")
-            if [ ! -z "$EXISTING_CONTAINER_ID" ]; then
-              sudo docker stop $EXISTING_CONTAINER_ID
-              sudo docker rm $EXISTING_CONTAINER_ID
-            fi
-
-            EXISTING_CONTAINER_ID=$(sudo docker ps -q -f "status=exited")
-            if [ ! -z "$EXISTING_CONTAINER_ID" ]; then
-              sudo docker rm $EXISTING_CONTAINER_ID
-            fi
-            
-            sudo docker pull ${{ secrets.DOCKER_USER_NAME }}/weeth
-            sudo docker run --name spring -d -p 8080:8080 --env-file ./weeth.env -e TZ=Asia/Seoul ${{ secrets.DOCKER_USER_NAME }}/weeth
-            sudo docker image prune -a -f
+            # 이동 경로
+            cd /home/ubuntu
+            # deploy.sh 실행
+            sudo ./deploy.sh


### PR DESCRIPTION
## PR 내용
- CICD 파이프라인 수정 및 EC2 서버 배포를 위한 환경 설정을 변경했습니다.
- 새로운 서버 배포를 위해 기존 환경 변수와 배포 스크립트를 수정했습니다.
<br>

## PR 세부사항
- CICD 파이프라인 수정: 기존 배포 설정에서 새로운 EC2 인스턴스 및 RDS 환경을 반영하여 GitHub Actions의 .yml 파일을 수정했습니다. 이를 통해 자동 배포가 가능하도록 설정을 변경했습니다.
- EC2_SECRET_HOST, EC2_SECRET_PEM 등 환경 변수를 새로 적용하였으며, 이로 인해 새로 생성된 서버로의 배포가 가능해졌습니다.
- 도커 이미지를 새로 빌드하여 weeth/weeth-be 레포지토리로 푸시하는 과정도 추가했습니다.
- 서버 배포 스크립트 수정: EC2 서버에서 실행되는 deploy.sh 스크립트를 수정하여 새로운 환경 변수에 맞춰 서버가 자동으로 배포되도록 변경했습니다.
- 기존 컨테이너 종료 후 새 이미지를 받아와 실행하는 로직을 추가했습니다.
- 불필요한 이미지 파일들을 정리하는 docker image prune -a -f 명령어로 서버 디스크 용량을 절약하는 설정도 추가되었습니다.
<br>

## 관련 스크린샷

<br>

## 주의사항
- 기존에 있던 도커 로그인 토큰을 새로 발급받아 변경했습니다.
- 각종 환경 변수들도 변경됐으니 참고해주세요
- 일단 22번 포트로 실행해보고 빌드 성공하면 해당 내용은 추후에 변경하겠습니다
<br>

## 체크 리스트

- [x] 리뷰어 설정
- [x] Assignee 설정
- [x] Label 설정
- [x] 제목 양식 맞췄나요? (ex. #0 Feat: 기능 추가)
- [x] 변경 사항에 대한 테스트