### PR TITLE
Refactor #54 CI/CD 파일 수정 및 서버 재배포 관련 설정

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -1,0 +1,75 @@
+name: Weeth-BE CI/CD
+
+on:
+  push:
+    branches: [ "develop" ]
+  pull_request:
+    branches: [ "develop" ]
+    types: [opened, synchronize, reopened]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      # gradle caching
+      - name: Gradle Caching
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*gradle*','**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      # gradle 빌드
+      - name: Build with Gradle Wrapper
+        run: ./gradlew build
+
+      # 빌드된 JAR 파일 확인
+      - name: List JAR files
+        run: ls build/libs
+
+      # Docker build & push
+      - name: Docker build & push
+        run: |
+          docker login -u ${{ secrets.DEV_DOCKER_USER_EMAIL }} -p ${{ secrets.DEV_DOCKER_USER_TOKEN }}
+          docker build -t ${{ secrets.DEV_DOCKER_USER_NAME }}/weeth .
+          docker push ${{ secrets.DEV_DOCKER_USER_NAME }}/weeth
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.ref == 'refs/heads/develop'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Deploy to server
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.DEV_EC2_SECRET_HOST }}
+          username: ubuntu
+          key: ${{ secrets.DEV_EC2_SECRET_PEM }}
+          envs: GITHUB_SHA
+          script: |
+            EXISTING_CONTAINER_ID=$(sudo docker ps -q -f "publish=8080" -f "status=running")
+            if [ ! -z "$EXISTING_CONTAINER_ID" ]; then
+              sudo docker stop $EXISTING_CONTAINER_ID
+              sudo docker rm $EXISTING_CONTAINER_ID
+            fi
+
+            sudo docker pull ${{ secrets.DEV_DOCKER_USER_NAME }}/weeth
+            sudo docker run --name spring -d -p 8080:8080 --env-file ./weeth-dev.env -e TZ=Asia/Seoul ${{ secrets.DEV_DOCKER_USER_NAME }}/weeth
+            sudo docker image prune -a -f

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -45,13 +45,13 @@ jobs:
       - name: Docker build & push
         run: |
           docker login -u ${{ secrets.DEV_DOCKER_USER_EMAIL }} -p ${{ secrets.DEV_DOCKER_USER_TOKEN }}
-          docker build -t ${{ secrets.DEV_DOCKER_USER_NAME }}/weeth .
+          docker build -f Dockerfile-dev -t ${{ secrets.DEV_DOCKER_USER_NAME }}/weeth .
           docker push ${{ secrets.DEV_DOCKER_USER_NAME }}/weeth
 
   deploy:
     runs-on: ubuntu-latest
     needs: build
-    if: github.ref == 'refs/heads/develop'
+    if: github.event_name == 'push'
 
     steps:
       - uses: actions/checkout@v4
@@ -67,6 +67,11 @@ jobs:
             EXISTING_CONTAINER_ID=$(sudo docker ps -q -f "publish=8080" -f "status=running")
             if [ ! -z "$EXISTING_CONTAINER_ID" ]; then
               sudo docker stop $EXISTING_CONTAINER_ID
+              sudo docker rm $EXISTING_CONTAINER_ID
+            fi
+            
+            EXISTING_CONTAINER_ID=$(sudo docker ps -q -f "status=exited")
+            if [ ! -z "$EXISTING_CONTAINER_ID" ]; then
               sudo docker rm $EXISTING_CONTAINER_ID
             fi
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 HELP.md
+weeth-dev.env
 .gradle
 build/
 !gradle/wrapper/gradle-wrapper.jar

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 HELP.md
-weeth-dev.env
 .gradle
 build/
 !gradle/wrapper/gradle-wrapper.jar


### PR DESCRIPTION
## PR 내용
weeth rds랑 ec2 연결해놓았고, develop 서버 CI/CD 구성 수정 및 빌드 및 배포 조건 설정 완료했습니다.
개인 레포(test1)에서 테스트 한뒤에 weeth-be 레포에서 작업했습니다. 
해당 로직이 확실하게 맞는지 1차로 피드백 받고 추가적인 작업 진행하려고 합니다
<br>

## PR 세부사항
기존 환경변수에 추가로 새로운 환경변수들, 깃헙 환경변수 설정에 업로드 해놨습니다
메인 서버와 별개로 진행되는 서버기 때문에, develop 브랜치에 직접 푸시, pr이 생성됐을때만
cicd가 작동하도록 코드를 구성했습니다.

빌드: develop 브랜치에 대한 PR이 생성되거나 푸시될 때만 빌드가 진행됩니다.
배포: develop 브랜치에 직접 푸시될 때만 배포가 이루어집니다. 
<br>

## 관련 스크린샷
![image](https://github.com/user-attachments/assets/59c2a6e9-5ab9-45ae-ad1e-2f57b21ba5eb)

<br>

## 주의사항
노션에 ec2에 들어가는 환경변수랑 깃허브 환경변수 내용들도 업로드 해놓았습니다.
미완성 pr입니다. 빌드 + 배포 코드 내용들이랑 weeth-dev.env 파일관리 등 피드백 내용 달아주시면 정말정말 감사드리겠습니다......
<br>

## 체크 리스트

- [x] 리뷰어 설정
- [x] Assignee 설정
- [x] Label 설정
- [x] 제목 양식 맞췄나요? (ex. #0 Feat: 기능 추가)
- [x] 변경 사항에 대한 테스트