### PR TITLE
#61 Refactor: 각 도메인 별 exception에 에러 코드 수정

### DIFF
--- a/src/main/java/leets/weeth/domain/account/application/exception/AccountExistsException.java
+++ b/src/main/java/leets/weeth/domain/account/application/exception/AccountExistsException.java
@@ -1,9 +1,8 @@
 package leets.weeth.domain.account.application.exception;
 
+import leets.weeth.global.common.exception.BusinessLogicException;
 
-import jakarta.persistence.EntityExistsException;
-
-public class AccountExistsException extends EntityExistsException {
-    public AccountExistsException() { super("이미 생성된 장부입니다.");}
+public class AccountExistsException extends BusinessLogicException {
+    public AccountExistsException() { super(400, "이미 생성된 장부입니다.");}
 }
 

--- a/src/main/java/leets/weeth/domain/account/application/exception/AccountNotFoundException.java
+++ b/src/main/java/leets/weeth/domain/account/application/exception/AccountNotFoundException.java
@@ -3,5 +3,5 @@ package leets.weeth.domain.account.application.exception;
 import leets.weeth.global.common.exception.BusinessLogicException;
 
 public class AccountNotFoundException extends BusinessLogicException {
-    public AccountNotFoundException() {super(400, "존재하지 않는 장부입니다.");}
+    public AccountNotFoundException() {super(404, "존재하지 않는 장부입니다.");}
 }

--- a/src/main/java/leets/weeth/domain/account/application/exception/AccountNotFoundException.java
+++ b/src/main/java/leets/weeth/domain/account/application/exception/AccountNotFoundException.java
@@ -1,7 +1,7 @@
 package leets.weeth.domain.account.application.exception;
 
-import jakarta.persistence.EntityNotFoundException;
+import leets.weeth.global.common.exception.BusinessLogicException;
 
-public class AccountNotFoundException extends EntityNotFoundException {
-    public AccountNotFoundException() {super("존재하지 않는 장부입니다.");}
+public class AccountNotFoundException extends BusinessLogicException {
+    public AccountNotFoundException() {super(400, "존재하지 않는 장부입니다.");}
 }

--- a/src/main/java/leets/weeth/domain/account/application/exception/ReceiptNotFoundException.java
+++ b/src/main/java/leets/weeth/domain/account/application/exception/ReceiptNotFoundException.java
@@ -1,9 +1,8 @@
 package leets.weeth.domain.account.application.exception;
 
+import leets.weeth.global.common.exception.BusinessLogicException;
 
-import jakarta.persistence.EntityExistsException;
-
-public class ReceiptNotFoundException extends EntityExistsException {
-    public ReceiptNotFoundException() { super("존재하지 않는 내역입니다.");}
+public class ReceiptNotFoundException extends BusinessLogicException {
+    public ReceiptNotFoundException() { super(400, "존재하지 않는 내역입니다.");}
 }
 

--- a/src/main/java/leets/weeth/domain/account/application/exception/ReceiptNotFoundException.java
+++ b/src/main/java/leets/weeth/domain/account/application/exception/ReceiptNotFoundException.java
@@ -3,6 +3,6 @@ package leets.weeth.domain.account.application.exception;
 import leets.weeth.global.common.exception.BusinessLogicException;
 
 public class ReceiptNotFoundException extends BusinessLogicException {
-    public ReceiptNotFoundException() { super(400, "존재하지 않는 내역입니다.");}
+    public ReceiptNotFoundException() { super(404, "존재하지 않는 내역입니다.");}
 }
 

--- a/src/main/java/leets/weeth/domain/attendance/application/exception/AttendanceNotFoundException.java
+++ b/src/main/java/leets/weeth/domain/attendance/application/exception/AttendanceNotFoundException.java
@@ -3,5 +3,5 @@ package leets.weeth.domain.attendance.application.exception;
 import leets.weeth.global.common.exception.BusinessLogicException;
 
 public class AttendanceNotFoundException extends BusinessLogicException {
-    public AttendanceNotFoundException() {super(400, "출석 정보가 존재하지 않습니다.");}
+    public AttendanceNotFoundException() {super(404, "출석 정보가 존재하지 않습니다.");}
 }

--- a/src/main/java/leets/weeth/domain/attendance/application/exception/AttendanceNotFoundException.java
+++ b/src/main/java/leets/weeth/domain/attendance/application/exception/AttendanceNotFoundException.java
@@ -1,6 +1,7 @@
 package leets.weeth.domain.attendance.application.exception;
-import jakarta.persistence.EntityNotFoundException;
 
-public class AttendanceNotFoundException extends EntityNotFoundException {
-    public AttendanceNotFoundException() {super("출석 정보가 존재하지 않습니다.");}
+import leets.weeth.global.common.exception.BusinessLogicException;
+
+public class AttendanceNotFoundException extends BusinessLogicException {
+    public AttendanceNotFoundException() {super(400, "출석 정보가 존재하지 않습니다.");}
 }

--- a/src/main/java/leets/weeth/domain/board/application/exception/NoticeNotFoundException.java
+++ b/src/main/java/leets/weeth/domain/board/application/exception/NoticeNotFoundException.java
@@ -1,7 +1,7 @@
 package leets.weeth.domain.board.application.exception;
 
-import jakarta.persistence.EntityNotFoundException;
+import leets.weeth.global.common.exception.BusinessLogicException;
 
-public class NoticeNotFoundException extends EntityNotFoundException {
-    public NoticeNotFoundException() {super("존재하지 않는 공지사항입니다.");}
+public class NoticeNotFoundException extends BusinessLogicException {
+    public NoticeNotFoundException() {super(400, "존재하지 않는 공지사항입니다.");}
 }

--- a/src/main/java/leets/weeth/domain/board/application/exception/NoticeNotFoundException.java
+++ b/src/main/java/leets/weeth/domain/board/application/exception/NoticeNotFoundException.java
@@ -3,5 +3,5 @@ package leets.weeth.domain.board.application.exception;
 import leets.weeth.global.common.exception.BusinessLogicException;
 
 public class NoticeNotFoundException extends BusinessLogicException {
-    public NoticeNotFoundException() {super(400, "존재하지 않는 공지사항입니다.");}
+    public NoticeNotFoundException() {super(404, "존재하지 않는 공지사항입니다.");}
 }

--- a/src/main/java/leets/weeth/domain/board/application/exception/PostNotFoundException.java
+++ b/src/main/java/leets/weeth/domain/board/application/exception/PostNotFoundException.java
@@ -4,6 +4,6 @@ import leets.weeth.global.common.exception.BusinessLogicException;
 
 public class PostNotFoundException extends BusinessLogicException {
     public PostNotFoundException() {
-        super(400, "존재하지 않는 게시물입니다.");
+        super(404, "존재하지 않는 게시물입니다.");
     }
 }

--- a/src/main/java/leets/weeth/domain/board/application/exception/PostNotFoundException.java
+++ b/src/main/java/leets/weeth/domain/board/application/exception/PostNotFoundException.java
@@ -1,9 +1,9 @@
 package leets.weeth.domain.board.application.exception;
 
-import jakarta.persistence.EntityNotFoundException;
+import leets.weeth.global.common.exception.BusinessLogicException;
 
-public class PostNotFoundException extends EntityNotFoundException {
+public class PostNotFoundException extends BusinessLogicException {
     public PostNotFoundException() {
-        super("존재하지 않는 게시물입니다.");
+        super(400, "존재하지 않는 게시물입니다.");
     }
 }

--- a/src/main/java/leets/weeth/domain/comment/application/exception/CommentNotFoundException.java
+++ b/src/main/java/leets/weeth/domain/comment/application/exception/CommentNotFoundException.java
@@ -4,6 +4,6 @@ import leets.weeth.global.common.exception.BusinessLogicException;
 
 public class CommentNotFoundException extends BusinessLogicException {
     public CommentNotFoundException() {
-        super(400, "존재하지 않는 댓글입니다.");
+        super(404, "존재하지 않는 댓글입니다.");
     }
 }

--- a/src/main/java/leets/weeth/domain/comment/application/exception/CommentNotFoundException.java
+++ b/src/main/java/leets/weeth/domain/comment/application/exception/CommentNotFoundException.java
@@ -1,9 +1,9 @@
 package leets.weeth.domain.comment.application.exception;
 
-import jakarta.persistence.EntityNotFoundException;
+import leets.weeth.global.common.exception.BusinessLogicException;
 
-public class CommentNotFoundException extends EntityNotFoundException {
+public class CommentNotFoundException extends BusinessLogicException {
     public CommentNotFoundException() {
-        super("존재하지 않는 댓글입니다.");
+        super(400, "존재하지 않는 댓글입니다.");
     }
 }

--- a/src/main/java/leets/weeth/domain/penalty/application/exception/PenaltyNotFoundException.java
+++ b/src/main/java/leets/weeth/domain/penalty/application/exception/PenaltyNotFoundException.java
@@ -1,9 +1,9 @@
 package leets.weeth.domain.penalty.application.exception;
 
-import jakarta.persistence.EntityNotFoundException;
+import leets.weeth.global.common.exception.BusinessLogicException;
 
-public class PenaltyNotFoundException extends EntityNotFoundException {
+public class PenaltyNotFoundException extends BusinessLogicException {
     public PenaltyNotFoundException() {
-        super("존재하지 않는 패널티입니다.");
+        super(400, "존재하지 않는 패널티입니다.");
     }
 }

--- a/src/main/java/leets/weeth/domain/penalty/application/exception/PenaltyNotFoundException.java
+++ b/src/main/java/leets/weeth/domain/penalty/application/exception/PenaltyNotFoundException.java
@@ -4,6 +4,6 @@ import leets.weeth.global.common.exception.BusinessLogicException;
 
 public class PenaltyNotFoundException extends BusinessLogicException {
     public PenaltyNotFoundException() {
-        super(400, "존재하지 않는 패널티입니다.");
+        super(404, "존재하지 않는 패널티입니다.");
     }
 }

--- a/src/main/java/leets/weeth/domain/schedule/application/exception/EventNotFoundException.java
+++ b/src/main/java/leets/weeth/domain/schedule/application/exception/EventNotFoundException.java
@@ -1,9 +1,9 @@
 package leets.weeth.domain.schedule.application.exception;
 
-import jakarta.persistence.EntityNotFoundException;
+import leets.weeth.global.common.exception.BusinessLogicException;
 
-public class EventNotFoundException extends EntityNotFoundException {
+public class EventNotFoundException extends BusinessLogicException {
     public EventNotFoundException() {
-        super("존재하지 않는 일정입니다.");
+        super(400, "존재하지 않는 일정입니다.");
     }
 }

--- a/src/main/java/leets/weeth/domain/schedule/application/exception/EventNotFoundException.java
+++ b/src/main/java/leets/weeth/domain/schedule/application/exception/EventNotFoundException.java
@@ -4,6 +4,6 @@ import leets.weeth.global.common.exception.BusinessLogicException;
 
 public class EventNotFoundException extends BusinessLogicException {
     public EventNotFoundException() {
-        super(400, "존재하지 않는 일정입니다.");
+        super(404, "존재하지 않는 일정입니다.");
     }
 }

--- a/src/main/java/leets/weeth/domain/schedule/application/exception/MeetingNotFoundException.java
+++ b/src/main/java/leets/weeth/domain/schedule/application/exception/MeetingNotFoundException.java
@@ -3,5 +3,5 @@ package leets.weeth.domain.schedule.application.exception;
 import leets.weeth.global.common.exception.BusinessLogicException;
 
 public class MeetingNotFoundException extends BusinessLogicException {
-    public MeetingNotFoundException() {super(400, "존재하지 않는 정기 모임입니다.");}
+    public MeetingNotFoundException() {super(404, "존재하지 않는 정기 모임입니다.");}
 }

--- a/src/main/java/leets/weeth/domain/schedule/application/exception/MeetingNotFoundException.java
+++ b/src/main/java/leets/weeth/domain/schedule/application/exception/MeetingNotFoundException.java
@@ -1,7 +1,7 @@
 package leets.weeth.domain.schedule.application.exception;
 
-import jakarta.persistence.EntityNotFoundException;
+import leets.weeth.global.common.exception.BusinessLogicException;
 
-public class MeetingNotFoundException extends EntityNotFoundException {
-    public MeetingNotFoundException() {super("존재하지 않는 정기 모임입니다.");}
+public class MeetingNotFoundException extends BusinessLogicException {
+    public MeetingNotFoundException() {super(400, "존재하지 않는 정기 모임입니다.");}
 }

--- a/src/main/java/leets/weeth/domain/user/application/exception/CardinalNotFoundException.java
+++ b/src/main/java/leets/weeth/domain/user/application/exception/CardinalNotFoundException.java
@@ -1,7 +1,7 @@
 package leets.weeth.domain.user.application.exception;
 
-import jakarta.persistence.EntityNotFoundException;
+import leets.weeth.global.common.exception.BusinessLogicException;
 
-public class CardinalNotFoundException extends EntityNotFoundException {
-    public CardinalNotFoundException() {super("존재하지 않는 기수입니다.");}
+public class CardinalNotFoundException extends BusinessLogicException {
+    public CardinalNotFoundException() {super(400, "존재하지 않는 기수입니다.");}
 }

--- a/src/main/java/leets/weeth/domain/user/application/exception/CardinalNotFoundException.java
+++ b/src/main/java/leets/weeth/domain/user/application/exception/CardinalNotFoundException.java
@@ -3,5 +3,5 @@ package leets.weeth.domain.user.application.exception;
 import leets.weeth.global.common.exception.BusinessLogicException;
 
 public class CardinalNotFoundException extends BusinessLogicException {
-    public CardinalNotFoundException() {super(400, "존재하지 않는 기수입니다.");}
+    public CardinalNotFoundException() {super(404, "존재하지 않는 기수입니다.");}
 }

--- a/src/main/java/leets/weeth/domain/user/application/exception/DepartmentNotFoundException.java
+++ b/src/main/java/leets/weeth/domain/user/application/exception/DepartmentNotFoundException.java
@@ -1,7 +1,7 @@
 package leets.weeth.domain.user.application.exception;
 
-import jakarta.persistence.EntityNotFoundException;
+import leets.weeth.global.common.exception.BusinessLogicException;
 
-public class DepartmentNotFoundException extends EntityNotFoundException {
-    public DepartmentNotFoundException() {super("존재하지 않는 학과입니다.");}
+public class DepartmentNotFoundException extends BusinessLogicException {
+    public DepartmentNotFoundException() {super(400, "존재하지 않는 학과입니다.");}
 }

--- a/src/main/java/leets/weeth/domain/user/application/exception/DepartmentNotFoundException.java
+++ b/src/main/java/leets/weeth/domain/user/application/exception/DepartmentNotFoundException.java
@@ -3,5 +3,5 @@ package leets.weeth.domain.user.application.exception;
 import leets.weeth.global.common.exception.BusinessLogicException;
 
 public class DepartmentNotFoundException extends BusinessLogicException {
-    public DepartmentNotFoundException() {super(400, "존재하지 않는 학과입니다.");}
+    public DepartmentNotFoundException() {super(404, "존재하지 않는 학과입니다.");}
 }

--- a/src/main/java/leets/weeth/domain/user/application/exception/StudentIdExistsException.java
+++ b/src/main/java/leets/weeth/domain/user/application/exception/StudentIdExistsException.java
@@ -1,7 +1,7 @@
 package leets.weeth.domain.user.application.exception;
 
-import jakarta.persistence.EntityNotFoundException;
+import leets.weeth.global.common.exception.BusinessLogicException;
 
-public class StudentIdExistsException extends EntityNotFoundException {
-    public StudentIdExistsException() {super("이미 가입된 학번입니다.");}
+public class StudentIdExistsException extends BusinessLogicException {
+    public StudentIdExistsException() {super(400, "이미 가입된 학번입니다.");}
 }

--- a/src/main/java/leets/weeth/domain/user/application/exception/TelExistsException.java
+++ b/src/main/java/leets/weeth/domain/user/application/exception/TelExistsException.java
@@ -1,7 +1,7 @@
 package leets.weeth.domain.user.application.exception;
 
-import jakarta.persistence.EntityNotFoundException;
+import leets.weeth.global.common.exception.BusinessLogicException;
 
-public class TelExistsException extends EntityNotFoundException {
-    public TelExistsException() {super("이미 가입된 전화번호 입니다.");}
+public class TelExistsException extends BusinessLogicException {
+    public TelExistsException() {super(400, "이미 가입된 전화번호 입니다.");}
 }

--- a/src/main/java/leets/weeth/domain/user/application/exception/UserExistsException.java
+++ b/src/main/java/leets/weeth/domain/user/application/exception/UserExistsException.java
@@ -1,9 +1,9 @@
 package leets.weeth.domain.user.application.exception;
 
-import jakarta.persistence.EntityNotFoundException;
+import leets.weeth.global.common.exception.BusinessLogicException;
 
-public class UserExistsException extends EntityNotFoundException {
+public class UserExistsException extends BusinessLogicException {
     public UserExistsException() {
-        super("이미 가입된 사용자입니다.");
+        super(400, "이미 가입된 사용자입니다.");
     }
 }

--- a/src/main/java/leets/weeth/domain/user/application/exception/UserNotFoundException.java
+++ b/src/main/java/leets/weeth/domain/user/application/exception/UserNotFoundException.java
@@ -4,6 +4,6 @@ import leets.weeth.global.common.exception.BusinessLogicException;
 
 public class UserNotFoundException extends BusinessLogicException {
     public UserNotFoundException() {
-        super(400, "존재하지 않는 유저입니다.");
+        super(404, "존재하지 않는 유저입니다.");
     }
 }

--- a/src/main/java/leets/weeth/domain/user/application/exception/UserNotFoundException.java
+++ b/src/main/java/leets/weeth/domain/user/application/exception/UserNotFoundException.java
@@ -1,9 +1,9 @@
 package leets.weeth.domain.user.application.exception;
 
-import jakarta.persistence.EntityNotFoundException;
+import leets.weeth.global.common.exception.BusinessLogicException;
 
-public class UserNotFoundException extends EntityNotFoundException {
+public class UserNotFoundException extends BusinessLogicException {
     public UserNotFoundException() {
-        super("존재하지 않는 유저입니다.");
+        super(400, "존재하지 않는 유저입니다.");
     }
 }

--- a/src/main/java/leets/weeth/global/common/exception/BusinessLogicException.java
+++ b/src/main/java/leets/weeth/global/common/exception/BusinessLogicException.java
@@ -3,7 +3,7 @@ package leets.weeth.global.common.exception;
 import lombok.Getter;
 
 @Getter
-public class BusinessLogicException extends RuntimeException {
+public abstract class BusinessLogicException extends RuntimeException {
 
     private final int statusCode;
 


### PR DESCRIPTION
## PR 내용

<br>

## PR 세부사항
- [x] 각 도메인 별 exception에 에러 코드 추가
- [x] 유저 도메인 exception 테스트
    - 기수 입력 안됨 : 아예 입력하지 않은 경우는 bindException가 발생
    - 존재하지 않는 학과
    - 이미 존재하는 학번
    - 이미 존재하는 전화번호
    - 존재하지 않는 유저
    - 생성한 사용자와 일치하지 않음(userId)
- [x] account 도메인 exception 테스트
    - 이미 존재하는 장부
    - 존재하지 않는 장부
    - 존재하지 않는 내역
- [x] attendance 도메인 exception 테스트
    - 출석 코드 불일치
    - 존재하지 않는 출석 정보
- [x] board 도메인  exception 테스트
    - 존재하지 않는 공지사항
    - 존재하지 않는 게시물
- [x] comment 도메인  exception 테스트
    -  존재하지 않는 댓글
- [x] penalty 도메인 exception 테스트
    - 존재하지 않는 패널티
- [x] schedule 도메인 exception 테스트
    - 존재하지 않는 일정
    - 존재하지 않는 정기 모임

<br>

## 체크 리스트

- [x] 리뷰어 설정
- [x] Assignee 설정
- [x] Label 설정
- [x] 제목 양식 맞췄나요? (ex. #0 Feat: 기능 추가)
- [x] 변경 사항에 대한 테스트