### PR TITLE
Feat 63 소셜 로그인

### DIFF
--- a/src/main/java/leets/weeth/domain/user/application/dto/request/UserRequestDto.java
+++ b/src/main/java/leets/weeth/domain/user/application/dto/request/UserRequestDto.java
@@ -6,6 +6,10 @@ import jakarta.validation.constraints.NotNull;
 
 public class UserRequestDto {
 
+    public record login (
+            @NotBlank String authCode
+    ){}
+
     public record SignUp (
             @NotBlank String name,
             @Email @NotBlank String email,

--- a/src/main/java/leets/weeth/domain/user/application/dto/response/UserResponseDto.java
+++ b/src/main/java/leets/weeth/domain/user/application/dto/response/UserResponseDto.java
@@ -9,6 +9,13 @@ import java.util.List;
 
 public class UserResponseDto {
 
+    public record SocialLoginResponse(
+            Long id,
+            String accessToken,
+            String refreshToken
+    ) {
+    }
+
     public record Response(
             Integer id,
             String name,
@@ -19,9 +26,10 @@ public class UserResponseDto {
             List<Integer> cardinals,
             Position position,
             Role role
-    ) {}
+    ) {
+    }
 
-    public record AdminResponse (
+    public record AdminResponse(
             Integer id,
             String name,
             String email,
@@ -38,11 +46,7 @@ public class UserResponseDto {
             Integer penaltyCount,
             LocalDateTime createdAt,
             LocalDateTime modifiedAt
-    ) {}
-
-    public record refreshResponse(
-            String accessToken,
-            String refreshToken
-    ){}
+    ) {
+    }
 
 }

--- a/src/main/java/leets/weeth/domain/user/application/usecase/UserManageUseCase.java
+++ b/src/main/java/leets/weeth/domain/user/application/usecase/UserManageUseCase.java
@@ -1,9 +1,10 @@
 package leets.weeth.domain.user.application.usecase;
 
 import jakarta.servlet.http.HttpServletRequest;
-import leets.weeth.domain.user.application.dto.request.UserRequestDto;
-import leets.weeth.domain.user.application.dto.response.UserResponseDto;
+import leets.weeth.global.auth.jwt.application.dto.JwtDto;
+
+import static leets.weeth.domain.user.application.dto.request.UserRequestDto.refreshRequest;
 
 public interface UserManageUseCase {
-    UserResponseDto.refreshResponse refresh(UserRequestDto.refreshRequest dto, HttpServletRequest request);
+    JwtDto refresh(refreshRequest dto, HttpServletRequest request);
 }

--- a/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCase.java
+++ b/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCase.java
@@ -1,7 +1,6 @@
 package leets.weeth.domain.user.application.usecase;
 
 import leets.weeth.domain.user.application.dto.request.UserRequestDto;
-import leets.weeth.domain.user.application.dto.response.UserResponseDto;
 
 import java.util.List;
 import java.util.Map;
@@ -11,6 +10,8 @@ import static leets.weeth.domain.user.application.dto.response.UserResponseDto.*
 
 
 public interface UserUseCase {
+
+    SocialLoginResponse login(UserRequestDto.login dto);
 
     void apply(SignUp dto);
 

--- a/src/main/java/leets/weeth/domain/user/domain/service/UserGetService.java
+++ b/src/main/java/leets/weeth/domain/user/domain/service/UserGetService.java
@@ -20,6 +20,11 @@ public class UserGetService {
                 .orElseThrow(UserNotFoundException::new);
     }
 
+    public User find(String email){
+        return userRepository.findByEmail(email)
+                .orElseThrow(UserNotFoundException::new);
+    }
+
     public Boolean check(String email) {
         return !userRepository.existsByEmail(email);
     }

--- a/src/main/java/leets/weeth/domain/user/presentation/UserController.java
+++ b/src/main/java/leets/weeth/domain/user/presentation/UserController.java
@@ -3,18 +3,20 @@ package leets.weeth.domain.user.presentation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
-import leets.weeth.domain.user.application.dto.request.UserRequestDto;
-import leets.weeth.domain.user.application.dto.response.UserResponseDto;
 import leets.weeth.domain.user.application.usecase.UserManageUseCase;
 import leets.weeth.domain.user.application.usecase.UserUseCase;
 import leets.weeth.domain.user.domain.service.UserGetService;
 import leets.weeth.global.auth.annotation.CurrentUser;
+import leets.weeth.global.auth.jwt.application.dto.JwtDto;
 import leets.weeth.global.common.response.CommonResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.Map;
+
+import static leets.weeth.domain.user.application.dto.request.UserRequestDto.*;
+import static leets.weeth.domain.user.application.dto.response.UserResponseDto.*;
 
 
 @Tag(name = "UserController", description = "사용자 관련 컨트롤러")
@@ -27,8 +29,13 @@ public class UserController {
     private final UserManageUseCase userManageUseCase;
     private final UserGetService userGetService;
 
+    @PostMapping("/social-login")
+    public CommonResponse<SocialLoginResponse> login(@RequestBody @Valid login dto) {
+        return CommonResponse.createSuccess(userUseCase.login(dto));
+    }
+
     @PostMapping("/apply")
-    public CommonResponse<Void> apply(@RequestBody @Valid UserRequestDto.SignUp dto) {
+    public CommonResponse<Void> apply(@RequestBody @Valid SignUp dto) {
         userUseCase.apply(dto);
         return CommonResponse.createSuccess();
     }
@@ -39,17 +46,17 @@ public class UserController {
     }
 
     @GetMapping("/all")
-    public CommonResponse<Map<Integer, List<UserResponseDto.Response>>> findAll() {
+    public CommonResponse<Map<Integer, List<Response>>> findAll() {
         return CommonResponse.createSuccess(userUseCase.findAll());
     }
 
     @GetMapping
-    public CommonResponse<UserResponseDto.Response> find(@CurrentUser Long userId) {
+    public CommonResponse<Response> find(@CurrentUser Long userId) {
         return CommonResponse.createSuccess(userUseCase.find(userId));
     }
 
     @PatchMapping
-    public CommonResponse<Void> update(@RequestBody @Valid UserRequestDto.Update dto, @CurrentUser Long userId) {
+    public CommonResponse<Void> update(@RequestBody @Valid Update dto, @CurrentUser Long userId) {
         userUseCase.update(dto, userId);
         return CommonResponse.createSuccess();
     }
@@ -61,7 +68,7 @@ public class UserController {
     }
 
     @PostMapping("/refresh")
-    public CommonResponse<UserResponseDto.refreshResponse> refresh(@Valid @RequestBody UserRequestDto.refreshRequest dto, HttpServletRequest request) {
+    public CommonResponse<JwtDto> refresh(@Valid @RequestBody refreshRequest dto, HttpServletRequest request) {
         return CommonResponse.createSuccess(userManageUseCase.refresh(dto, request));
     }
 }

--- a/src/main/java/leets/weeth/global/auth/jwt/application/dto/JwtDto.java
+++ b/src/main/java/leets/weeth/global/auth/jwt/application/dto/JwtDto.java
@@ -1,0 +1,7 @@
+package leets.weeth.global.auth.jwt.application.dto;
+
+public record JwtDto(
+    String accessToken,
+    String refreshToken
+) {
+}

--- a/src/main/java/leets/weeth/global/auth/jwt/application/usecase/JwtManageUseCase.java
+++ b/src/main/java/leets/weeth/global/auth/jwt/application/usecase/JwtManageUseCase.java
@@ -1,0 +1,50 @@
+package leets.weeth.global.auth.jwt.application.usecase;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import leets.weeth.global.auth.jwt.application.dto.JwtDto;
+import leets.weeth.global.auth.jwt.service.JwtRedisService;
+import leets.weeth.global.auth.jwt.service.JwtProvider;
+import leets.weeth.global.auth.jwt.service.JwtService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+
+@Service
+@RequiredArgsConstructor
+public class JwtManageUseCase {
+
+    private final JwtProvider jwtProvider;
+    private final JwtService jwtService;
+    private final JwtRedisService jwtRedisService;
+
+    // 토큰 발급
+    public JwtDto create(Long id, String email){
+        return new JwtDto(jwtProvider.createAccessToken(id, email), jwtProvider.createRefreshToken(id));
+    }
+
+    // 토큰 헤더로 전송
+    public void sendToken(JwtDto dto, HttpServletResponse response) throws IOException {
+        jwtService.sendAccessAndRefreshToken(response, dto.accessToken(), dto.refreshToken());
+    }
+
+    // 리프레시 토큰 업데이트
+    public void updateToken(String email, String refreshToken){
+        jwtRedisService.set(email, refreshToken);
+    }
+    // 토큰 재발급
+    public JwtDto reIssueToken(String email, HttpServletRequest request){
+        String requestToken = jwtService.extractRefreshToken(request);
+        jwtProvider.validate(requestToken);
+
+        Long userId = jwtService.extractId(requestToken).get();
+
+        jwtRedisService.validateRefreshToken(email, requestToken);
+
+        JwtDto token = create(userId, email);
+        jwtRedisService.set(email, token.refreshToken());
+
+        return token;
+    }
+}

--- a/src/main/java/leets/weeth/global/auth/jwt/exception/InvalidTokenException.java
+++ b/src/main/java/leets/weeth/global/auth/jwt/exception/InvalidTokenException.java
@@ -4,6 +4,6 @@ import leets.weeth.global.common.exception.BusinessLogicException;
 
 public class InvalidTokenException extends BusinessLogicException {
     public InvalidTokenException() {
-        super(400, "올바르지 않은 Refresh Token 입니다.");
+        super(400, "올바르지 않은 Token 입니다.");
     }
 }

--- a/src/main/java/leets/weeth/global/auth/jwt/filter/JwtAuthenticationProcessingFilter.java
+++ b/src/main/java/leets/weeth/global/auth/jwt/filter/JwtAuthenticationProcessingFilter.java
@@ -5,7 +5,8 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import leets.weeth.domain.user.domain.entity.User;
-import leets.weeth.domain.user.domain.repository.UserRepository;
+import leets.weeth.domain.user.domain.service.UserGetService;
+import leets.weeth.global.auth.jwt.service.JwtProvider;
 import leets.weeth.global.auth.jwt.service.JwtService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -24,8 +25,9 @@ public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
 
     private static final String NO_CHECK_URL = "/api/v1/login";
 
+    private final JwtProvider jwtProvider;
     private final JwtService jwtService;
-    private final UserRepository userRepository;
+    private final UserGetService userGetService;
 
     private GrantedAuthoritiesMapper authoritiesMapper = new NullAuthoritiesMapper();
 
@@ -35,69 +37,14 @@ public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
             filterChain.doFilter(request, response);
             return;
         }
-
-        String refreshToken = jwtService.extractRefreshToken(request)
-                .filter(jwtService::isTokenValid)
-                .orElse(null);
-
-        if (refreshToken != null) {
-            checkAccessTokenAndRefreshToken(request, response, filterChain, refreshToken);
-            return;
+        // 유저 캐싱 도입
+        String accessToken = jwtService.extractAccessToken(request).get();
+        if (jwtProvider.validate(accessToken)) {
+            saveAuthentication(find(accessToken));
         }
-
-        checkAccessTokenAndAuthentication(request, response, filterChain);
-
-    }
-
-    public void checkAccessTokenAndRefreshToken(HttpServletRequest request, HttpServletResponse response,
-                                                FilterChain filterChain, String refreshToken) throws ServletException, IOException {
-        log.info("checkAccessTokenAndRefreshToken() 호출");
-
-        String accessToken = jwtService.extractAccessToken(request)
-                .filter(jwtService::isTokenValid)
-                .orElse(null);
-
-        if (accessToken == null) {
-            checkRefreshTokenAndReIssueAccessToken(response, refreshToken);
-        } else {
-            jwtService.extractEmail(accessToken)
-                    .ifPresent(email -> userRepository.findByEmail(email)
-                            .ifPresent(this::saveAuthentication));
-
-            filterChain.doFilter(request, response);
-        }
-
-
-    }
-
-    public void checkRefreshTokenAndReIssueAccessToken(HttpServletResponse response, String refreshToken) {
-        userRepository.findByRefreshToken(refreshToken)
-                .ifPresent(user -> {
-                    String reIssuedRefreshToken = reIssueRefreshToken(user);
-                    String accessToken = jwtService.createAccessToken(user.getId(), user.getEmail());
-                    jwtService.sendAccessAndRefreshToken(response, accessToken, reIssuedRefreshToken);
-                    jwtService.sendAccessToken(response, accessToken);
-                });
-    }
-
-    private String reIssueRefreshToken(User user) {
-        String reIssuedRefreshToken = jwtService.createRefreshToken();
-        user.updateRefreshToken(reIssuedRefreshToken);
-        userRepository.saveAndFlush(user);
-        return reIssuedRefreshToken;
-    }
-
-    // 보기 편하게 수정
-    public void checkAccessTokenAndAuthentication(HttpServletRequest request, HttpServletResponse response,
-                                                  FilterChain filterChain) throws ServletException, IOException {
-        log.info("checkAccessTokenAndAuthentication() 호출");
-        jwtService.extractAccessToken(request)
-                .filter(jwtService::validate)
-                .ifPresent(accessToken -> jwtService.extractEmail(accessToken)
-                        .ifPresent(email -> userRepository.findByEmail(email)
-                                .ifPresent(this::saveAuthentication)));
 
         filterChain.doFilter(request, response);
+
     }
 
     public void saveAuthentication(User myUser) {
@@ -114,5 +61,10 @@ public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
                         authoritiesMapper.mapAuthorities(userDetailsUser.getAuthorities()));
 
         SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    private User find(String accessToken) {
+        String email = jwtService.extractEmail(accessToken).get();
+        return userGetService.find(email);
     }
 }

--- a/src/main/java/leets/weeth/global/auth/jwt/service/JwtProvider.java
+++ b/src/main/java/leets/weeth/global/auth/jwt/service/JwtProvider.java
@@ -1,0 +1,57 @@
+package leets.weeth.global.auth.jwt.service;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import leets.weeth.global.auth.jwt.exception.InvalidTokenException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.Date;
+
+@Service
+@Slf4j
+public class JwtProvider {
+
+    private static final String ACCESS_TOKEN_SUBJECT = "AccessToken";
+    private static final String REFRESH_TOKEN_SUBJECT = "RefreshToken";
+    private static final String EMAIL_CLAIM = "email";
+    private static final String ID_CLAIM = "id";
+
+    @Value("${weeth.jwt.key}")
+    private String key;
+    @Value("${weeth.jwt.access.expiration}")
+    private Long accessTokenExpirationPeriod;
+    @Value("${weeth.jwt.refresh.expiration}")
+    private Long refreshTokenExpirationPeriod;
+
+    public String createAccessToken(Long id, String email) {
+        Date now = new Date();
+        return JWT.create()
+                .withSubject(ACCESS_TOKEN_SUBJECT)
+                .withExpiresAt(new Date(now.getTime() + accessTokenExpirationPeriod))
+                .withClaim(ID_CLAIM, id)
+                .withClaim(EMAIL_CLAIM, email)
+                .sign(Algorithm.HMAC512(key));
+    }
+
+    public String createRefreshToken(Long id) {
+        Date now = new Date();
+        return JWT.create()
+                .withSubject(REFRESH_TOKEN_SUBJECT)
+                .withExpiresAt(new Date(now.getTime() + refreshTokenExpirationPeriod))
+                .withClaim(ID_CLAIM, id)
+                .sign(Algorithm.HMAC512(key));
+    }
+
+    public boolean validate(String token) {
+        try {
+            JWT.require(Algorithm.HMAC512(key)).build().verify(token);
+            return true;
+        } catch (Exception e) {
+            log.error("유효하지 않은 토큰입니다. {}", e.getMessage());
+            throw new InvalidTokenException();
+        }
+    }
+
+}

--- a/src/main/java/leets/weeth/global/auth/jwt/service/JwtRedisService.java
+++ b/src/main/java/leets/weeth/global/auth/jwt/service/JwtRedisService.java
@@ -3,6 +3,7 @@ package leets.weeth.global.auth.jwt.service;
 import leets.weeth.global.auth.jwt.exception.InvalidTokenException;
 import leets.weeth.global.auth.jwt.exception.RedisTokenNotFoundException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
@@ -10,6 +11,7 @@ import org.springframework.stereotype.Service;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class JwtRedisService {
@@ -24,6 +26,7 @@ public class JwtRedisService {
     public void set(String email, String refreshToken) {
         String key = getKey(email);
         redisTemplate.opsForValue().set(key, refreshToken, expirationTime, TimeUnit.MILLISECONDS);
+        log.info("Refresh Token 저장/업데이트: {}", key);
     }
 
     public void delete(String email) {

--- a/src/main/java/leets/weeth/global/auth/kakao/KakaoAuthService.java
+++ b/src/main/java/leets/weeth/global/auth/kakao/KakaoAuthService.java
@@ -1,0 +1,54 @@
+package leets.weeth.global.auth.kakao;
+
+import leets.weeth.global.auth.kakao.dto.KakaoTokenResponse;
+import leets.weeth.global.auth.kakao.dto.KakaoUserInfoResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+
+@Service
+@Slf4j
+public class KakaoAuthService {
+
+    @Value("${auth.kakao.client_id}")
+    private String kakaoClientId;
+    @Value("${auth.kakao.redirect_uri}")
+    private String redirectUri;
+    @Value("${auth.kakao.grant_type}")
+    private String grantType;
+    @Value("${auth.kakao.token_uri}")
+    private String tokenUri;
+    @Value("${auth.kakao.user_info_uri}")
+    private String userInfoUri;
+
+
+    private final RestClient restClient = RestClient.create();
+
+    public KakaoTokenResponse getKakaoToken(String authCode) {
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", grantType);
+        body.add("client_id", kakaoClientId);
+        body.add("redirect_uri", redirectUri);
+        body.add("code", authCode);
+
+        return restClient.post()
+                .uri(tokenUri)
+                .body(body)
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .retrieve()
+                .body(KakaoTokenResponse.class);
+    }
+
+    public KakaoUserInfoResponse getUserInfo(String accessToken) {
+        return restClient.get()
+                .uri(userInfoUri)
+                .header("Authorization", "Bearer " + accessToken)
+                .retrieve()
+                .body(KakaoUserInfoResponse.class);
+
+    }
+}

--- a/src/main/java/leets/weeth/global/auth/kakao/dto/KakaoAccount.java
+++ b/src/main/java/leets/weeth/global/auth/kakao/dto/KakaoAccount.java
@@ -1,0 +1,8 @@
+package leets.weeth.global.auth.kakao.dto;
+
+public record KakaoAccount(
+        Boolean is_email_valid,
+        Boolean is_email_verified,
+        String email
+) {
+}

--- a/src/main/java/leets/weeth/global/auth/kakao/dto/KakaoTokenResponse.java
+++ b/src/main/java/leets/weeth/global/auth/kakao/dto/KakaoTokenResponse.java
@@ -1,0 +1,10 @@
+package leets.weeth.global.auth.kakao.dto;
+
+public record KakaoTokenResponse(
+        String token_type,
+        String access_token,
+        Integer expires_in,
+        String refresh_token,
+        Integer refresh_token_expires_in
+) {
+}

--- a/src/main/java/leets/weeth/global/auth/kakao/dto/KakaoUserInfoResponse.java
+++ b/src/main/java/leets/weeth/global/auth/kakao/dto/KakaoUserInfoResponse.java
@@ -1,0 +1,7 @@
+package leets.weeth.global.auth.kakao.dto;
+
+public record KakaoUserInfoResponse(
+        Long id,
+        KakaoAccount kakao_account
+) {
+}

--- a/src/main/java/leets/weeth/global/auth/login/handler/ErrorMessage.java
+++ b/src/main/java/leets/weeth/global/auth/login/handler/ErrorMessage.java
@@ -1,0 +1,15 @@
+package leets.weeth.global.auth.login.handler;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorMessage {
+
+    LOGIN_FAIL(400, "로그인에 실패했습니다."),
+    LOGIN_SUCCESS(200, "로그인에 성공했습니다.");
+
+    private final int code;
+    private final String message;
+}

--- a/src/main/java/leets/weeth/global/auth/login/handler/LoginFailureHandler.java
+++ b/src/main/java/leets/weeth/global/auth/login/handler/LoginFailureHandler.java
@@ -1,12 +1,16 @@
 package leets.weeth.global.auth.login.handler;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import leets.weeth.global.common.response.CommonResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
 
 import java.io.IOException;
+
+import static leets.weeth.global.auth.login.handler.ErrorMessage.LOGIN_FAIL;
 
 @Slf4j
 public class LoginFailureHandler extends SimpleUrlAuthenticationFailureHandler {
@@ -18,12 +22,29 @@ public class LoginFailureHandler extends SimpleUrlAuthenticationFailureHandler {
         response.setCharacterEncoding("UTF-8");
         response.setContentType("text/plain;charset=UTF-8");
 
-        if(exception.getMessage() != null)
-            response.getWriter().write(exception.getMessage());
+        if (exception.getMessage() != null)
+            setResponse(response, exception.getMessage());
         else
-            response.getWriter().write("이메일이나 비밀번호를 확인해주세요.");
+            setResponse(response);
 
-        log.info("로그인에 실패했습니다. 메시지 : {}", exception.getMessage());
+    }
+
+    private void setResponse(HttpServletResponse response) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        String message = new ObjectMapper().writeValueAsString(CommonResponse.createFailure(LOGIN_FAIL.getCode(), LOGIN_FAIL.getMessage()));
+        response.getWriter().write(message);
+    }
+
+    private void setResponse(HttpServletResponse response, String errorMessage) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        String message = new ObjectMapper().writeValueAsString(CommonResponse.createFailure(LOGIN_FAIL.getCode(), errorMessage));
+        response.getWriter().write(message);
     }
 }
 

--- a/src/main/java/leets/weeth/global/auth/login/handler/LoginSuccessHandler.java
+++ b/src/main/java/leets/weeth/global/auth/login/handler/LoginSuccessHandler.java
@@ -3,52 +3,45 @@ package leets.weeth.global.auth.login.handler;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import leets.weeth.domain.user.domain.entity.User;
-import leets.weeth.domain.user.domain.repository.UserRepository;
-import leets.weeth.global.auth.jwt.service.JwtService;
+import leets.weeth.domain.user.domain.service.UserGetService;
+import leets.weeth.global.auth.jwt.application.dto.JwtDto;
+import leets.weeth.global.auth.jwt.application.usecase.JwtManageUseCase;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 
-import java.util.Optional;
+import java.io.IOException;
 
 @Slf4j
 @RequiredArgsConstructor
 public class LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
-    private final JwtService jwtService;
-    private final UserRepository userRepository;
-
-    @Value("${weeth.jwt.access.expiration}")
-    private String accessTokenExpiration;
+    private final JwtManageUseCase jwtManageUseCase;
+    private final UserGetService userGetService;
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
-                                        Authentication authentication) {
+                                        Authentication authentication) throws IOException {
         String email = extractEmail(authentication); // 인증 정보에서 email 추출
-        Optional<User> optionalUser = userRepository.findByEmail(email);
+        // 유저 캐싱 도입
+        User user = userGetService.find(email);
+        Long userId = user.getId();
 
-        String accessToken = jwtService.createAccessToken(optionalUser.get().getId(), email); // JwtService의 createAccessToken을 사용하여 AccessToken 발급
-        String refreshToken = jwtService.createRefreshToken(); // JwtService의 createRefreshToken을 사용하여 RefreshToken 발급
+        JwtDto token = jwtManageUseCase.create(userId, email);
 
-        jwtService.sendAccessAndRefreshToken(response, accessToken, refreshToken); // 응답 헤더에 AccessToken, RefreshToken 실어서 응답
+        // 바디에 담아서 보내기
+        jwtManageUseCase.sendToken(token, response); // 응답 헤더에 AccessToken, RefreshToken 실어서 응답
 
-        optionalUser
-                .ifPresent(user -> {
-                    user.updateRefreshToken(refreshToken);
-                    userRepository.saveAndFlush(user);
-                });
-
-        log.info("로그인에 성공하였습니다. 아이디 : {}", email);
-        log.info("로그인에 성공하였습니다. AccessToken : {}", accessToken);
-        log.info("발급된 AccessToken 만료 기간 : {}", accessTokenExpiration);
+        // Redis에서 업데이트
+        jwtManageUseCase.updateToken(email, token.refreshToken());
     }
 
     private String extractEmail(Authentication authentication) {
         UserDetails userDetails = (UserDetails) authentication.getPrincipal();
         return userDetails.getUsername();
     }
+
 }
 

--- a/src/main/java/leets/weeth/global/config/WebMvcConfig.java
+++ b/src/main/java/leets/weeth/global/config/WebMvcConfig.java
@@ -13,7 +13,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class WebMvcConfig implements WebMvcConfigurer {
 
-    private final JwtService jwtService;;
+    private final JwtService jwtService;
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,3 +15,11 @@ springdoc:
   swagger-ui:
     operations-sorter: method
     tags-sorter: alpha
+
+auth:
+  kakao:
+    client_id: ${KAKAO_CLIENT_ID}
+    redirect_uri: ${KAKAO_REDIRECT_URI}
+    grant_type: ${KAKAO_GRANT_TYPE}
+    token_uri: ${KAKAO_TOKEN_URI}
+    user_info_uri: ${KAKAO_USER_INFO_URI}


### PR DESCRIPTION
## PR 내용
- 카카오 소셜 로그인 구현
- 로그인시 JWT 토큰을 바디로 반환하도록 수정

## PR 세부사항
- 카카오 소셜 로그인 구현 했습니다.
- 로그인을 위해서는 redirectUri를 넣은 카카오 서버에 카카오 계정으로 로그인 후에 받은 authCode를 우리 서버로 요청을 하면 카카오 토큰 서버에 token을 요청하고 그 토큰을 받아 카카오 유저 서버에 요청을 보내 유저의 email을 받아옵니다
- 기존 JwtService가 너무 복잡해져 책임에 맞게 분리하였고, 이를 하나의 UseCase에서 관리할 수 있도록 구성해봤습니다
- 코드가 이해하기 어렵다면 언제든지 질문을 해주시고, 수정하겠습니다
- 해당 브랜치는 jwt-로직 수정에서 분기된 브랜치이므로 해당 PR이 머지된 후 jwt 로직 수정 브랜치를 머지하겠습니다
<br>

## 관련 스크린샷
<img width="1071" alt="image" src="https://github.com/user-attachments/assets/5a101fde-f3b6-4a1b-a67b-a5e869c06335">

<br>

## 주의사항

<br>

## 체크 리스트

- [x] 리뷰어 설정
- [x] Assignee 설정
- [x] Label 설정
- [x] 제목 양식 맞췄나요? (ex. #0 Feat: 기능 추가)
- [x] 변경 사항에 대한 테스트