### PR TITLE
Feat #71  파일 도메인 분리 및 presigned url 도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ dependencies {
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 
 	// AWS Spring Cloud
-	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+	implementation 'software.amazon.awssdk:s3:2.19.1'
 
 	// ThymeLeaf
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'

--- a/src/main/java/leets/weeth/domain/account/application/usecase/ReceiptUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/account/application/usecase/ReceiptUseCaseImpl.java
@@ -9,7 +9,7 @@ import leets.weeth.domain.account.domain.service.AccountGetService;
 import leets.weeth.domain.account.domain.service.ReceiptDeleteService;
 import leets.weeth.domain.account.domain.service.ReceiptGetService;
 import leets.weeth.domain.account.domain.service.ReceiptSaveService;
-import leets.weeth.domain.file.service.FileSaveService;
+import leets.weeth.domain.file.service.S3Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -22,14 +22,14 @@ public class ReceiptUseCaseImpl implements ReceiptUseCase {
 
     private final ReceiptDeleteService receiptDeleteService;
     private final ReceiptSaveService receiptSaveService;
-    private final FileSaveService fileSaveService;
+    private final S3Service s3Service;
     private final ReceiptMapper mapper;
     private final AccountGetService accountGetService;
     private final ReceiptGetService receiptGetService;
 
     @Override @Transactional
     public void save(ReceiptDTO.Save dto, List<MultipartFile> files) {
-        List<String> images = fileSaveService.uploadFiles(files);
+        List<String> images = s3Service.uploadFiles(files);
         Account account = accountGetService.find(dto.cardinal());
         Receipt receipt = receiptSaveService.save(mapper.from(dto, images, account));
         account.spend(receipt);

--- a/src/main/java/leets/weeth/domain/board/application/usecase/NoticeUsecaseImpl.java
+++ b/src/main/java/leets/weeth/domain/board/application/usecase/NoticeUsecaseImpl.java
@@ -7,7 +7,7 @@ import leets.weeth.domain.board.domain.service.NoticeDeleteService;
 import leets.weeth.domain.board.domain.service.NoticeFindService;
 import leets.weeth.domain.board.domain.service.NoticeSaveService;
 import leets.weeth.domain.board.domain.service.NoticeUpdateService;
-import leets.weeth.domain.file.service.FileSaveService;
+import leets.weeth.domain.file.service.S3Service;
 import leets.weeth.domain.user.domain.entity.User;
 import leets.weeth.domain.user.domain.service.UserGetService;
 import leets.weeth.domain.board.application.exception.NoticeNotFoundException;
@@ -30,7 +30,7 @@ public class NoticeUsecaseImpl implements NoticeUsecase {
     private final NoticeDeleteService noticeDeleteService;
 
     private final UserGetService userGetService;
-    private final FileSaveService fileSaveService;
+    private final S3Service s3Service;
 
     private final NoticeMapper mapper;
 
@@ -39,7 +39,7 @@ public class NoticeUsecaseImpl implements NoticeUsecase {
         User user = userGetService.find(userId);
 
         List<String> fileUrls;
-        fileUrls = fileSaveService.uploadFiles(files);
+        fileUrls = s3Service.uploadFiles(files);
         noticeSaveService.save(mapper.fromNoticeDto(request, fileUrls, user));
     }
 
@@ -78,7 +78,7 @@ public class NoticeUsecaseImpl implements NoticeUsecase {
         Notice notice = validateOwner(noticeId, userId);
 
         List<String> fileUrls = notice.getFileUrls();
-        List<String> uploadedFileUrls = fileSaveService.uploadFiles(files);
+        List<String> uploadedFileUrls = s3Service.uploadFiles(files);
 
         fileUrls.addAll(uploadedFileUrls);
 

--- a/src/main/java/leets/weeth/domain/board/application/usecase/PostUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/board/application/usecase/PostUseCaseImpl.java
@@ -7,7 +7,7 @@ import leets.weeth.domain.board.domain.service.PostDeleteService;
 import leets.weeth.domain.board.domain.service.PostFindService;
 import leets.weeth.domain.board.domain.service.PostSaveService;
 import leets.weeth.domain.board.domain.service.PostUpdateService;
-import leets.weeth.domain.file.service.FileSaveService;
+import leets.weeth.domain.file.service.S3Service;
 import leets.weeth.domain.user.domain.entity.User;
 import leets.weeth.domain.user.domain.service.UserGetService;
 import leets.weeth.domain.board.application.exception.PostNotFoundException;
@@ -30,7 +30,7 @@ public class PostUseCaseImpl implements PostUsecase {
     private final PostDeleteService postDeleteService;
 
     private final UserGetService userGetService;
-    private final FileSaveService fileSaveService;
+    private final S3Service s3Service;
 
     private final PostMapper mapper;
 
@@ -39,7 +39,7 @@ public class PostUseCaseImpl implements PostUsecase {
         User user = userGetService.find(userId);
 
         List<String> fileUrls;
-        fileUrls = fileSaveService.uploadFiles(files);
+        fileUrls = s3Service.uploadFiles(files);
         postSaveService.save(mapper.fromPostDto(request, fileUrls, user));
     }
 
@@ -78,7 +78,7 @@ public class PostUseCaseImpl implements PostUsecase {
         Post post = validateOwner(postId, userId);
 
         List<String> fileUrls = post.getFileUrls();
-        List<String> uploadedFileUrls = fileSaveService.uploadFiles(files);
+        List<String> uploadedFileUrls = s3Service.uploadFiles(files);
 
         fileUrls.addAll(uploadedFileUrls);
 

--- a/src/main/java/leets/weeth/domain/file/application/dto/request/FileSaveRequest.java
+++ b/src/main/java/leets/weeth/domain/file/application/dto/request/FileSaveRequest.java
@@ -1,0 +1,7 @@
+package leets.weeth.domain.file.application.dto.request;
+
+public record FileSaveRequest(
+        String fileName,
+        String fileUrl
+) {
+}

--- a/src/main/java/leets/weeth/domain/file/application/dto/request/FileUpdateRequest.java
+++ b/src/main/java/leets/weeth/domain/file/application/dto/request/FileUpdateRequest.java
@@ -1,0 +1,10 @@
+package leets.weeth.domain.file.application.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record FileUpdateRequest(
+        @NotBlank Long fileId,
+        String fileName,
+        String fileUrl
+) {
+}

--- a/src/main/java/leets/weeth/domain/file/application/dto/response/FileDto.java
+++ b/src/main/java/leets/weeth/domain/file/application/dto/response/FileDto.java
@@ -1,7 +1,0 @@
-package leets.weeth.domain.file.application.dto.response;
-
-public record FileDto(
-        String putUrl,
-        String getUrl
-) {
-}

--- a/src/main/java/leets/weeth/domain/file/application/dto/response/FileDto.java
+++ b/src/main/java/leets/weeth/domain/file/application/dto/response/FileDto.java
@@ -1,0 +1,7 @@
+package leets.weeth.domain.file.application.dto.response;
+
+public record FileDto(
+        String putUrl,
+        String getUrl
+) {
+}

--- a/src/main/java/leets/weeth/domain/file/application/dto/response/FileResponse.java
+++ b/src/main/java/leets/weeth/domain/file/application/dto/response/FileResponse.java
@@ -1,0 +1,8 @@
+package leets.weeth.domain.file.application.dto.response;
+
+public record FileResponse(
+        long fileId,
+        String fileName,
+        String fileUrl
+) {
+}

--- a/src/main/java/leets/weeth/domain/file/application/dto/response/UrlResponse.java
+++ b/src/main/java/leets/weeth/domain/file/application/dto/response/UrlResponse.java
@@ -1,0 +1,7 @@
+package leets.weeth.domain.file.application.dto.response;
+
+public record UrlResponse(
+        String fileName,
+        String putUrl
+) {
+}

--- a/src/main/java/leets/weeth/domain/file/application/mapper/FileMapper.java
+++ b/src/main/java/leets/weeth/domain/file/application/mapper/FileMapper.java
@@ -1,19 +1,26 @@
 package leets.weeth.domain.file.application.mapper;
 
+import leets.weeth.domain.board.domain.entity.Notice;
+import leets.weeth.domain.board.domain.entity.Post;
 import leets.weeth.domain.comment.application.mapper.CommentMapper;
-import leets.weeth.domain.file.application.dto.response.FileDto;
 import leets.weeth.domain.file.application.dto.response.FileResponse;
+import leets.weeth.domain.file.application.dto.response.UrlResponse;
 import leets.weeth.domain.file.domain.entity.File;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import org.mapstruct.MappingConstants;
 import org.mapstruct.ReportingPolicy;
 
 @Mapper(componentModel = MappingConstants.ComponentModel.SPRING, uses = CommentMapper.class, unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface FileMapper {
 
-    File toFile(String fileName, String fileUrl);
+    @Mapping(target = "post", source = "post") // post 매핑
+    File toFile(String fileName, String fileUrl, Post post);
+
+    @Mapping(target = "notice", source = "notice") // post 매핑
+    File toFile(String fileName, String fileUrl, Notice notice);
 
     FileResponse toFileResponse(File file);
 
-    FileDto toFileDto(String putUrl, String getUrl);
+    UrlResponse toUrlResponse(String fileName, String putUrl);
 }

--- a/src/main/java/leets/weeth/domain/file/application/mapper/FileMapper.java
+++ b/src/main/java/leets/weeth/domain/file/application/mapper/FileMapper.java
@@ -14,10 +14,10 @@ import org.mapstruct.ReportingPolicy;
 @Mapper(componentModel = MappingConstants.ComponentModel.SPRING, uses = CommentMapper.class, unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface FileMapper {
 
-    @Mapping(target = "post", source = "post") // post 매핑
+    @Mapping(target = "post", source = "post")
     File toFile(String fileName, String fileUrl, Post post);
 
-    @Mapping(target = "notice", source = "notice") // post 매핑
+    @Mapping(target = "notice", source = "notice")
     File toFile(String fileName, String fileUrl, Notice notice);
 
     FileResponse toFileResponse(File file);

--- a/src/main/java/leets/weeth/domain/file/application/mapper/FileMapper.java
+++ b/src/main/java/leets/weeth/domain/file/application/mapper/FileMapper.java
@@ -1,0 +1,19 @@
+package leets.weeth.domain.file.application.mapper;
+
+import leets.weeth.domain.comment.application.mapper.CommentMapper;
+import leets.weeth.domain.file.application.dto.response.FileDto;
+import leets.weeth.domain.file.application.dto.response.FileResponse;
+import leets.weeth.domain.file.domain.entity.File;
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingConstants;
+import org.mapstruct.ReportingPolicy;
+
+@Mapper(componentModel = MappingConstants.ComponentModel.SPRING, uses = CommentMapper.class, unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface FileMapper {
+
+    File toFile(String fileName, String fileUrl);
+
+    FileResponse toFileResponse(File file);
+
+    FileDto toFileDto(String putUrl, String getUrl);
+}

--- a/src/main/java/leets/weeth/domain/file/application/usecase/FileManageUseCase.java
+++ b/src/main/java/leets/weeth/domain/file/application/usecase/FileManageUseCase.java
@@ -1,0 +1,23 @@
+package leets.weeth.domain.file.application.usecase;
+
+import jakarta.transaction.Transactional;
+import leets.weeth.domain.file.application.dto.response.UrlResponse;
+import leets.weeth.domain.file.domain.service.PreSignedService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class FileManageUseCase {
+
+    private final PreSignedService preSignedService;
+
+    @Transactional
+    public List<UrlResponse> getUrl(List<String> fileNames) {
+        return fileNames.stream()
+                .map(preSignedService::generateUrl)
+                .toList();
+    }
+}

--- a/src/main/java/leets/weeth/domain/file/application/usecase/FileManageUseCase.java
+++ b/src/main/java/leets/weeth/domain/file/application/usecase/FileManageUseCase.java
@@ -14,7 +14,6 @@ public class FileManageUseCase {
 
     private final PreSignedService preSignedService;
 
-    @Transactional
     public List<UrlResponse> getUrl(List<String> fileNames) {
         return fileNames.stream()
                 .map(preSignedService::generateUrl)

--- a/src/main/java/leets/weeth/domain/file/domain/entity/File.java
+++ b/src/main/java/leets/weeth/domain/file/domain/entity/File.java
@@ -1,6 +1,7 @@
 package leets.weeth.domain.file.domain.entity;
 
 import jakarta.persistence.*;
+import leets.weeth.domain.board.domain.entity.Notice;
 import leets.weeth.domain.board.domain.entity.Post;
 import lombok.*;
 
@@ -22,4 +23,13 @@ public class File {
     @ManyToOne
     @JoinColumn(name = "post_id")
     private Post post;
+
+    @ManyToOne
+    @JoinColumn(name = "notice_id")
+    private Notice notice;
+
+    public void update(String fileName, String fileUrl) {
+        this.fileName = fileName;
+        this.fileUrl = fileUrl;
+    }
 }

--- a/src/main/java/leets/weeth/domain/file/domain/entity/File.java
+++ b/src/main/java/leets/weeth/domain/file/domain/entity/File.java
@@ -1,0 +1,25 @@
+package leets.weeth.domain.file.domain.entity;
+
+import jakarta.persistence.*;
+import leets.weeth.domain.board.domain.entity.Post;
+import lombok.*;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Entity
+public class File {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    public Long id;
+
+    private String fileName;
+
+    private String fileUrl;
+
+    @ManyToOne
+    @JoinColumn(name = "post_id")
+    private Post post;
+}

--- a/src/main/java/leets/weeth/domain/file/domain/repository/FileRepository.java
+++ b/src/main/java/leets/weeth/domain/file/domain/repository/FileRepository.java
@@ -3,5 +3,11 @@ package leets.weeth.domain.file.domain.repository;
 import leets.weeth.domain.file.domain.entity.File;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface FileRepository extends JpaRepository<File, Long> {
+
+    List<File> findAllByPostId(Long postId);
+
+    List<File> findAllByNoticeId(Long noticeId);
 }

--- a/src/main/java/leets/weeth/domain/file/domain/repository/FileRepository.java
+++ b/src/main/java/leets/weeth/domain/file/domain/repository/FileRepository.java
@@ -1,0 +1,7 @@
+package leets.weeth.domain.file.domain.repository;
+
+import leets.weeth.domain.file.domain.entity.File;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FileRepository extends JpaRepository<File, Long> {
+}

--- a/src/main/java/leets/weeth/domain/file/domain/service/FileGetService.java
+++ b/src/main/java/leets/weeth/domain/file/domain/service/FileGetService.java
@@ -1,0 +1,23 @@
+package leets.weeth.domain.file.domain.service;
+
+import leets.weeth.domain.file.domain.entity.File;
+import leets.weeth.domain.file.domain.repository.FileRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class FileGetService {
+
+    private final FileRepository fileRepository;
+
+    public List<File> findAllByPost(Long postId) {
+        return fileRepository.findAllByPostId(postId);
+    }
+
+    public List<File> findAllByNotice(Long noticeId) {
+        return fileRepository.findAllByPostId(noticeId);
+    }
+}

--- a/src/main/java/leets/weeth/domain/file/domain/service/FileSaveService.java
+++ b/src/main/java/leets/weeth/domain/file/domain/service/FileSaveService.java
@@ -1,0 +1,16 @@
+package leets.weeth.domain.file.domain.service;
+
+import leets.weeth.domain.file.domain.entity.File;
+import leets.weeth.domain.file.domain.repository.FileRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FileSaveService {
+    private final FileRepository fileRepository;
+
+    public void Save(File file) {
+        fileRepository.save(file);
+    }
+}

--- a/src/main/java/leets/weeth/domain/file/domain/service/FileSaveService.java
+++ b/src/main/java/leets/weeth/domain/file/domain/service/FileSaveService.java
@@ -5,12 +5,18 @@ import leets.weeth.domain.file.domain.repository.FileRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class FileSaveService {
     private final FileRepository fileRepository;
 
-    public void Save(File file) {
+    public void save(File file) {
         fileRepository.save(file);
+    }
+
+    public void save(List<File> files) {
+        fileRepository.saveAll(files);
     }
 }

--- a/src/main/java/leets/weeth/domain/file/domain/service/FileUpdateService.java
+++ b/src/main/java/leets/weeth/domain/file/domain/service/FileUpdateService.java
@@ -1,0 +1,15 @@
+package leets.weeth.domain.file.domain.service;
+
+import leets.weeth.domain.file.application.dto.request.FileUpdateRequest;
+import leets.weeth.domain.file.domain.entity.File;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FileUpdateService {
+
+    public void update(File file, FileUpdateRequest dto) {
+        file.update(dto.fileName(), dto.fileUrl());
+    }
+}

--- a/src/main/java/leets/weeth/domain/file/domain/service/PreSignedService.java
+++ b/src/main/java/leets/weeth/domain/file/domain/service/PreSignedService.java
@@ -1,6 +1,5 @@
 package leets.weeth.domain.file.domain.service;
 
-import leets.weeth.domain.file.application.dto.response.FileDto;
 import leets.weeth.domain.file.application.mapper.FileMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -26,7 +25,7 @@ public class PreSignedService {
     @Value("${cloud.aws.region.static}")
     private String region;
 
-    public FileDto generateUrl(String fileName) {
+    public String generateUrl(String fileName) {
         String key = generateKey(fileName);
 
         PutObjectRequest putObjectRequest = PutObjectRequest.builder()
@@ -42,9 +41,8 @@ public class PreSignedService {
         PresignedPutObjectRequest presignedUrlRequest = s3Presigner.presignPutObject(request);
 
         String putUrl = presignedUrlRequest.url().toString();
-        String getUrl = generateGetUrl(key);
 
-        return fileMapper.toFileDto(putUrl, getUrl);
+        return putUrl;
     }
 
     public String generateGetUrl(String key) {

--- a/src/main/java/leets/weeth/domain/file/domain/service/PreSignedService.java
+++ b/src/main/java/leets/weeth/domain/file/domain/service/PreSignedService.java
@@ -1,0 +1,59 @@
+package leets.weeth.domain.file.domain.service;
+
+import leets.weeth.domain.file.application.dto.response.FileDto;
+import leets.weeth.domain.file.application.mapper.FileMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+import java.time.Duration;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class PreSignedService {
+
+    private final S3Presigner s3Presigner;
+    private final FileMapper fileMapper;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    public FileDto generateUrl(String fileName) {
+        String key = generateKey(fileName);
+
+        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                .bucket(bucket)
+                .key(key)
+                .build();
+
+        PutObjectPresignRequest request = PutObjectPresignRequest.builder()
+                .signatureDuration(Duration.ofMinutes(5))
+                .putObjectRequest(putObjectRequest)
+                .build();
+
+        PresignedPutObjectRequest presignedUrlRequest = s3Presigner.presignPutObject(request);
+
+        String putUrl = presignedUrlRequest.url().toString();
+        String getUrl = generateGetUrl(key);
+
+        return fileMapper.toFileDto(putUrl, getUrl);
+    }
+
+    public String generateGetUrl(String key) {
+        return String.format("https://%s.s3.%s.amazonaws.com/%s", bucket, region, key);
+    }
+
+    // 파일 이름을 고유하게 생성하는 메서드
+    private String generateKey(String originalFileName) {
+        String uuid = UUID.randomUUID().toString();
+        return uuid + "_" + originalFileName.replaceAll("\\s+", "_");
+    }
+}

--- a/src/main/java/leets/weeth/domain/file/domain/service/PreSignedService.java
+++ b/src/main/java/leets/weeth/domain/file/domain/service/PreSignedService.java
@@ -1,5 +1,6 @@
 package leets.weeth.domain.file.domain.service;
 
+import leets.weeth.domain.file.application.dto.response.UrlResponse;
 import leets.weeth.domain.file.application.mapper.FileMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -25,7 +26,7 @@ public class PreSignedService {
     @Value("${cloud.aws.region.static}")
     private String region;
 
-    public String generateUrl(String fileName) {
+    public UrlResponse generateUrl(String fileName) {
         String key = generateKey(fileName);
 
         PutObjectRequest putObjectRequest = PutObjectRequest.builder()
@@ -42,7 +43,7 @@ public class PreSignedService {
 
         String putUrl = presignedUrlRequest.url().toString();
 
-        return putUrl;
+        return fileMapper.toUrlResponse(fileName, putUrl);
     }
 
     public String generateGetUrl(String key) {

--- a/src/main/java/leets/weeth/domain/file/presentation/FileController.java
+++ b/src/main/java/leets/weeth/domain/file/presentation/FileController.java
@@ -1,0 +1,31 @@
+package leets.weeth.domain.file.presentation;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import leets.weeth.domain.file.application.dto.response.UrlResponse;
+import leets.weeth.domain.file.application.usecase.FileManageUseCase;
+import leets.weeth.global.common.response.CommonResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+import static leets.weeth.domain.user.presentation.ResponseMessage.USER_APPLY_SUCCESS;
+
+@Tag(name = "FileController")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/files")
+public class FileController {
+
+    private final FileManageUseCase fileManageUseCase;
+
+    @GetMapping("/")
+    @Operation(summary = "파일 업로드를 위한 presigned url을 요청하는 API 입니다.")
+    public CommonResponse<List<UrlResponse>> getUrl(@RequestParam(required = false) List<String> fileName) {
+        return CommonResponse.createSuccess(USER_APPLY_SUCCESS.getMessage(), fileManageUseCase.getUrl(fileName));
+    }
+}

--- a/src/main/java/leets/weeth/domain/file/presentation/FileController.java
+++ b/src/main/java/leets/weeth/domain/file/presentation/FileController.java
@@ -13,8 +13,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
-import static leets.weeth.domain.user.presentation.ResponseMessage.USER_APPLY_SUCCESS;
-
 @Tag(name = "FileController")
 @RestController
 @RequiredArgsConstructor
@@ -26,6 +24,6 @@ public class FileController {
     @GetMapping("/")
     @Operation(summary = "파일 업로드를 위한 presigned url을 요청하는 API 입니다.")
     public CommonResponse<List<UrlResponse>> getUrl(@RequestParam(required = false) List<String> fileName) {
-        return CommonResponse.createSuccess(USER_APPLY_SUCCESS.getMessage(), fileManageUseCase.getUrl(fileName));
+        return CommonResponse.createSuccess(ResponseMessage.PRESIGNED_URL_GET_SUCCESS.getMessage(), fileManageUseCase.getUrl(fileName));
     }
 }

--- a/src/main/java/leets/weeth/domain/file/presentation/ResponseMessage.java
+++ b/src/main/java/leets/weeth/domain/file/presentation/ResponseMessage.java
@@ -1,0 +1,14 @@
+package leets.weeth.domain.file.presentation;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ResponseMessage {
+
+    PRESIGNED_URL_GET_SUCCESS("Presigned Url 반환에 성공했습니다");
+
+    private final String message;
+
+}

--- a/src/main/java/leets/weeth/global/config/AwsS3Config.java
+++ b/src/main/java/leets/weeth/global/config/AwsS3Config.java
@@ -1,14 +1,15 @@
 package leets.weeth.global.config;
 
-import com.amazonaws.auth.AWSCredentials;
-import com.amazonaws.auth.AWSStaticCredentialsProvider;
-import com.amazonaws.auth.BasicAWSCredentials;
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @Configuration
 @RequiredArgsConstructor
@@ -23,10 +24,20 @@ public class AwsS3Config {
     private String region;
 
     @Bean
-    public AmazonS3 s3Client() {
-        AWSCredentials credentials = new BasicAWSCredentials(accessKey, accessSecret);
-        return AmazonS3ClientBuilder.standard()
-                .withCredentials(new AWSStaticCredentialsProvider(credentials))
-                .withRegion(region).build();
+    public S3Client s3Client() {
+        AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKey, accessSecret);
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(credentials))
+                .build();
+    }
+
+    @Bean
+    public S3Presigner s3Presigner() {
+        AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKey, accessSecret);
+        return S3Presigner.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(credentials))
+                .build();
     }
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -10,7 +10,7 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect
     hibernate:
-      ddl-auto: validate
+      ddl-auto: update
   data:
     redis:
       host: ${REDIS_HOST}


### PR DESCRIPTION
## PR 내용
- 기존 post, notice, receipt 내부에 url을 저장하던 파일을 도메인을 분리하였습니다
- 우선 post, notice 먼저 분리하고, 영수증은 차후 요구사항 확정 후 작업할 예정입니다
- post, notice CRUD 작업은 다음 PR에서 할 예정입니다
<br>

## PR 세부사항
- File 엔티티 생성
- presigned Url 반환으로 파일 업로드를 프론트로 이전

- 프론트에서 첨부된 fileName을 주면 해당 UUID와 붙여서 유일한 key로 만들어 S3에 업로드할 수 있는 서명된  url을 생성해 반환합니다
- 프론트는 해당 url에 이미지를 첨부해 "put" 요청으로 S3에 파일을 업로드할 수 있습니다.
- url의 amazonaws.com 뒷부분을 제거하면 객체 url이기 때문에 해당 url로 get 요청을 보내면 파일을 조회할 수 있습니다.
<br>

## 관련 스크린샷
<img width="1187" alt="image" src="https://github.com/user-attachments/assets/87fd9774-9e48-4f1d-beb6-fab2d9bf8a93">

<br>

## 주의사항
- 아직 post, notice를 생성, 수정, 조회, 삭제하는 로직은 구현하지 않앗고, 다음 작업에서 구현할 예정입니다.
<br>

## 체크 리스트

- [x] 리뷰어 설정
- [x] Assignee 설정
- [x] Label 설정
- [x] 제목 양식 맞췄나요? (ex. #0 Feat: 기능 추가)
- [x] 변경 사항에 대한 테스트