### PR TITLE
Feat #73 post,notice, receipt 파일 업로드 수정

### DIFF
--- a/src/main/java/leets/weeth/domain/account/application/dto/ReceiptDTO.java
+++ b/src/main/java/leets/weeth/domain/account/application/dto/ReceiptDTO.java
@@ -15,7 +15,7 @@ public class ReceiptDTO {
         String description,
         Integer amount,
         LocalDate date,
-        List<FileResponse> files
+        List<FileResponse> fileUrls
     ) {}
 
     public record Save(

--- a/src/main/java/leets/weeth/domain/account/application/dto/ReceiptDTO.java
+++ b/src/main/java/leets/weeth/domain/account/application/dto/ReceiptDTO.java
@@ -1,6 +1,9 @@
 package leets.weeth.domain.account.application.dto;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
+import leets.weeth.domain.file.application.dto.request.FileSaveRequest;
+import leets.weeth.domain.file.application.dto.response.FileResponse;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -12,13 +15,14 @@ public class ReceiptDTO {
         String description,
         Integer amount,
         LocalDate date,
-        List<String> images
+        List<FileResponse> files
     ) {}
 
     public record Save(
             String description,
             @NotNull Integer amount,
             @NotNull LocalDate date,
-            @NotNull Integer cardinal
+            @NotNull Integer cardinal,
+            @Valid List<@NotNull FileSaveRequest> files
     ) {}
 }

--- a/src/main/java/leets/weeth/domain/account/application/mapper/ReceiptMapper.java
+++ b/src/main/java/leets/weeth/domain/account/application/mapper/ReceiptMapper.java
@@ -3,6 +3,7 @@ package leets.weeth.domain.account.application.mapper;
 import leets.weeth.domain.account.application.dto.ReceiptDTO;
 import leets.weeth.domain.account.domain.entity.Account;
 import leets.weeth.domain.account.domain.entity.Receipt;
+import leets.weeth.domain.file.application.dto.response.FileResponse;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingConstants;
@@ -15,8 +16,10 @@ public interface ReceiptMapper {
 
     List<ReceiptDTO.Response> to(List<Receipt> account);
 
+    ReceiptDTO.Response to(Receipt receipt, List<FileResponse> files);
+
     @Mapping(target = "id", ignore = true)
     @Mapping(target = "description", source = "dto.description")
     @Mapping(target = "account", source = "account")
-    Receipt from(ReceiptDTO.Save dto, List<String> images, Account account);
+    Receipt from(ReceiptDTO.Save dto, Account account);
 }

--- a/src/main/java/leets/weeth/domain/account/application/mapper/ReceiptMapper.java
+++ b/src/main/java/leets/weeth/domain/account/application/mapper/ReceiptMapper.java
@@ -16,7 +16,7 @@ public interface ReceiptMapper {
 
     List<ReceiptDTO.Response> to(List<Receipt> account);
 
-    ReceiptDTO.Response to(Receipt receipt, List<FileResponse> files);
+    ReceiptDTO.Response to(Receipt receipt, List<FileResponse> fileUrls);
 
     @Mapping(target = "id", ignore = true)
     @Mapping(target = "description", source = "dto.description")

--- a/src/main/java/leets/weeth/domain/account/application/usecase/ReceiptUseCase.java
+++ b/src/main/java/leets/weeth/domain/account/application/usecase/ReceiptUseCase.java
@@ -6,7 +6,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 
 public interface ReceiptUseCase {
-    void save(ReceiptDTO.Save dto, List<MultipartFile> images);
+    void save(ReceiptDTO.Save dto);
 
     void delete(Long id);
 }

--- a/src/main/java/leets/weeth/domain/account/presentation/ReceiptAdminController.java
+++ b/src/main/java/leets/weeth/domain/account/presentation/ReceiptAdminController.java
@@ -24,10 +24,10 @@ public class ReceiptAdminController {
 
     private final ReceiptUseCase receiptUseCase;
 
-    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PostMapping
     @Operation(summary="회비 사용 내역 기입")
-    public CommonResponse<Void> save(@RequestPart @Valid ReceiptDTO.Save dto, @RequestPart(required = false) List<MultipartFile> images) {
-        receiptUseCase.save(dto, images);
+    public CommonResponse<Void> save(@RequestBody @Valid ReceiptDTO.Save dto) {
+        receiptUseCase.save(dto);
         return CommonResponse.createSuccess(RECEIPT_SAVE_SUCCESS.getMessage());
     }
 

--- a/src/main/java/leets/weeth/domain/board/application/dto/NoticeDTO.java
+++ b/src/main/java/leets/weeth/domain/board/application/dto/NoticeDTO.java
@@ -25,7 +25,7 @@ public class NoticeDTO {
     public record Update(
             @NotNull String title,
             @NotNull String content,
-            @Valid List<@NotNull FileUpdateRequest> files
+            @Valid List<@NotNull FileSaveRequest> files
     ) {
     }
 

--- a/src/main/java/leets/weeth/domain/board/application/dto/NoticeDTO.java
+++ b/src/main/java/leets/weeth/domain/board/application/dto/NoticeDTO.java
@@ -1,5 +1,6 @@
 package leets.weeth.domain.board.application.dto;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import leets.weeth.domain.comment.application.dto.CommentDTO;
 import leets.weeth.domain.file.application.dto.request.FileSaveRequest;
@@ -16,15 +17,17 @@ public class NoticeDTO {
     public record Save(
             @NotNull String title,
             @NotNull String content,
-            List<FileSaveRequest> files
-    ){}
+            @Valid List<@NotNull FileUpdateRequest> files
+    ) {
+    }
 
     @Builder
     public record Update(
             @NotNull String title,
             @NotNull String content,
-            List<FileUpdateRequest> files
-    ){}
+            @Valid List<@NotNull FileUpdateRequest> files
+    ) {
+    }
 
     @Builder
     public record Response(
@@ -36,7 +39,8 @@ public class NoticeDTO {
             Integer commentCount,
             List<CommentDTO.Response> comments,
             List<FileResponse> files
-    ){}
+    ) {
+    }
 
     @Builder
     public record ResponseAll(
@@ -46,6 +50,7 @@ public class NoticeDTO {
             String content,
             LocalDateTime time,//modifiedAt
             Integer commentCount
-    ){}
+    ) {
+    }
 
 }

--- a/src/main/java/leets/weeth/domain/board/application/dto/NoticeDTO.java
+++ b/src/main/java/leets/weeth/domain/board/application/dto/NoticeDTO.java
@@ -4,6 +4,7 @@ import jakarta.validation.constraints.NotNull;
 import leets.weeth.domain.comment.application.dto.CommentDTO;
 import leets.weeth.domain.file.application.dto.request.FileSaveRequest;
 import leets.weeth.domain.file.application.dto.request.FileUpdateRequest;
+import leets.weeth.domain.file.application.dto.response.FileResponse;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
@@ -33,8 +34,8 @@ public class NoticeDTO {
             String content,
             LocalDateTime time,//modifiedAt
             Integer commentCount,
-            List<String> fileUrls,
-            List<CommentDTO.Response> comments
+            List<CommentDTO.Response> comments,
+            List<FileResponse> files
     ){}
 
     @Builder

--- a/src/main/java/leets/weeth/domain/board/application/dto/NoticeDTO.java
+++ b/src/main/java/leets/weeth/domain/board/application/dto/NoticeDTO.java
@@ -2,6 +2,8 @@ package leets.weeth.domain.board.application.dto;
 
 import jakarta.validation.constraints.NotNull;
 import leets.weeth.domain.comment.application.dto.CommentDTO;
+import leets.weeth.domain.file.application.dto.request.FileSaveRequest;
+import leets.weeth.domain.file.application.dto.request.FileUpdateRequest;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
@@ -12,13 +14,15 @@ public class NoticeDTO {
     @Builder
     public record Save(
             @NotNull String title,
-            @NotNull String content
+            @NotNull String content,
+            List<FileSaveRequest> files
     ){}
 
     @Builder
     public record Update(
             @NotNull String title,
-            @NotNull String content
+            @NotNull String content,
+            List<FileUpdateRequest> files
     ){}
 
     @Builder

--- a/src/main/java/leets/weeth/domain/board/application/dto/NoticeDTO.java
+++ b/src/main/java/leets/weeth/domain/board/application/dto/NoticeDTO.java
@@ -17,7 +17,7 @@ public class NoticeDTO {
     public record Save(
             @NotNull String title,
             @NotNull String content,
-            @Valid List<@NotNull FileUpdateRequest> files
+            @Valid List<@NotNull FileSaveRequest> files
     ) {
     }
 

--- a/src/main/java/leets/weeth/domain/board/application/dto/NoticeDTO.java
+++ b/src/main/java/leets/weeth/domain/board/application/dto/NoticeDTO.java
@@ -25,7 +25,7 @@ public class NoticeDTO {
     public record Update(
             @NotNull String title,
             @NotNull String content,
-            @Valid List<@NotNull FileUpdateRequest> fileUrls
+            @Valid List<@NotNull FileUpdateRequest> files
     ) {
     }
 
@@ -38,7 +38,7 @@ public class NoticeDTO {
             LocalDateTime time,//modifiedAt
             Integer commentCount,
             List<CommentDTO.Response> comments,
-            List<FileResponse> files
+            List<FileResponse> fileUrls
     ) {
     }
 

--- a/src/main/java/leets/weeth/domain/board/application/dto/NoticeDTO.java
+++ b/src/main/java/leets/weeth/domain/board/application/dto/NoticeDTO.java
@@ -25,7 +25,7 @@ public class NoticeDTO {
     public record Update(
             @NotNull String title,
             @NotNull String content,
-            @Valid List<@NotNull FileUpdateRequest> files
+            @Valid List<@NotNull FileUpdateRequest> fileUrls
     ) {
     }
 

--- a/src/main/java/leets/weeth/domain/board/application/dto/PostDTO.java
+++ b/src/main/java/leets/weeth/domain/board/application/dto/PostDTO.java
@@ -4,6 +4,7 @@ import jakarta.validation.constraints.NotNull;
 import leets.weeth.domain.comment.application.dto.CommentDTO;
 import leets.weeth.domain.file.application.dto.request.FileSaveRequest;
 import leets.weeth.domain.file.application.dto.request.FileUpdateRequest;
+import leets.weeth.domain.file.application.dto.response.FileResponse;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
@@ -33,8 +34,8 @@ public class PostDTO {
             String content,
             LocalDateTime time,//modifiedAt
             Integer commentCount,
-            List<String> fileUrls,
-            List<CommentDTO.Response> comments
+            List<CommentDTO.Response> comments,
+            List<FileResponse> files
     ){}
 
     @Builder

--- a/src/main/java/leets/weeth/domain/board/application/dto/PostDTO.java
+++ b/src/main/java/leets/weeth/domain/board/application/dto/PostDTO.java
@@ -2,6 +2,8 @@ package leets.weeth.domain.board.application.dto;
 
 import jakarta.validation.constraints.NotNull;
 import leets.weeth.domain.comment.application.dto.CommentDTO;
+import leets.weeth.domain.file.application.dto.request.FileSaveRequest;
+import leets.weeth.domain.file.application.dto.request.FileUpdateRequest;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
@@ -12,13 +14,15 @@ public class PostDTO {
     @Builder
     public record Save(
             @NotNull String title,
-            @NotNull String content
+            @NotNull String content,
+            List<FileSaveRequest> files
     ){}
 
     @Builder
     public record Update(
             @NotNull String title,
-            @NotNull String content
+            @NotNull String content,
+            List<FileUpdateRequest> files
     ){}
 
     @Builder

--- a/src/main/java/leets/weeth/domain/board/application/dto/PostDTO.java
+++ b/src/main/java/leets/weeth/domain/board/application/dto/PostDTO.java
@@ -24,7 +24,7 @@ public class PostDTO {
     public record Update(
             @NotNull String title,
             @NotNull String content,
-            @Valid List<@NotNull FileUpdateRequest> files
+            @Valid List<@NotNull FileUpdateRequest> fileUrls
     ){}
 
     @Builder

--- a/src/main/java/leets/weeth/domain/board/application/dto/PostDTO.java
+++ b/src/main/java/leets/weeth/domain/board/application/dto/PostDTO.java
@@ -24,7 +24,7 @@ public class PostDTO {
     public record Update(
             @NotNull String title,
             @NotNull String content,
-            @Valid List<@NotNull FileUpdateRequest> files
+            @Valid List<@NotNull FileSaveRequest> files
     ){}
 
     @Builder

--- a/src/main/java/leets/weeth/domain/board/application/dto/PostDTO.java
+++ b/src/main/java/leets/weeth/domain/board/application/dto/PostDTO.java
@@ -1,5 +1,6 @@
 package leets.weeth.domain.board.application.dto;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import leets.weeth.domain.comment.application.dto.CommentDTO;
 import leets.weeth.domain.file.application.dto.request.FileSaveRequest;
@@ -16,14 +17,14 @@ public class PostDTO {
     public record Save(
             @NotNull String title,
             @NotNull String content,
-            List<FileSaveRequest> files
+            @Valid List<@NotNull FileSaveRequest> files
     ){}
 
     @Builder
     public record Update(
             @NotNull String title,
             @NotNull String content,
-            List<FileUpdateRequest> files
+            @Valid List<@NotNull FileUpdateRequest> files
     ){}
 
     @Builder

--- a/src/main/java/leets/weeth/domain/board/application/dto/PostDTO.java
+++ b/src/main/java/leets/weeth/domain/board/application/dto/PostDTO.java
@@ -24,7 +24,7 @@ public class PostDTO {
     public record Update(
             @NotNull String title,
             @NotNull String content,
-            @Valid List<@NotNull FileUpdateRequest> fileUrls
+            @Valid List<@NotNull FileUpdateRequest> files
     ){}
 
     @Builder
@@ -36,7 +36,7 @@ public class PostDTO {
             LocalDateTime time,//modifiedAt
             Integer commentCount,
             List<CommentDTO.Response> comments,
-            List<FileResponse> files
+            List<FileResponse> fileUrls
     ){}
 
     @Builder

--- a/src/main/java/leets/weeth/domain/board/application/mapper/NoticeMapper.java
+++ b/src/main/java/leets/weeth/domain/board/application/mapper/NoticeMapper.java
@@ -5,6 +5,8 @@ import leets.weeth.domain.board.domain.entity.Notice;
 import leets.weeth.domain.comment.application.dto.CommentDTO;
 import leets.weeth.domain.comment.application.mapper.CommentMapper;
 import leets.weeth.domain.comment.domain.entity.Comment;
+import leets.weeth.domain.file.application.dto.response.FileResponse;
+import leets.weeth.domain.file.domain.entity.File;
 import leets.weeth.domain.user.domain.entity.User;
 import org.mapstruct.*;
 
@@ -28,11 +30,11 @@ public interface NoticeMapper {
     NoticeDTO.ResponseAll toAll(Notice notice);
 
     @Mappings({
-            @Mapping(target = "name", source = "user.name"),
+            @Mapping(target = "name", source = "notice.user.name"),
             @Mapping(target = "comments", expression = "java(filterParentComments(notice.getComments()))"),
-            @Mapping(target = "time", source = "modifiedAt")
+            @Mapping(target = "time", source = "notice.modifiedAt")
     })
-    NoticeDTO.Response toNoticeDto(Notice notice);
+    NoticeDTO.Response toNoticeDto(Notice notice, List<FileResponse> files);
 
     default List<CommentDTO.Response> filterParentComments(List<Comment> comments) {
         if (comments == null || comments.isEmpty()) {

--- a/src/main/java/leets/weeth/domain/board/application/mapper/NoticeMapper.java
+++ b/src/main/java/leets/weeth/domain/board/application/mapper/NoticeMapper.java
@@ -34,7 +34,7 @@ public interface NoticeMapper {
             @Mapping(target = "comments", expression = "java(filterParentComments(notice.getComments()))"),
             @Mapping(target = "time", source = "notice.modifiedAt")
     })
-    NoticeDTO.Response toNoticeDto(Notice notice, List<FileResponse> files);
+    NoticeDTO.Response toNoticeDto(Notice notice, List<FileResponse> fileUrls);
 
     default List<CommentDTO.Response> filterParentComments(List<Comment> comments) {
         if (comments == null || comments.isEmpty()) {

--- a/src/main/java/leets/weeth/domain/board/application/mapper/NoticeMapper.java
+++ b/src/main/java/leets/weeth/domain/board/application/mapper/NoticeMapper.java
@@ -19,7 +19,7 @@ public interface NoticeMapper {
             @Mapping(target = "id", ignore = true),
             @Mapping(target = "user", source = "user")
     })
-    Notice fromNoticeDto(NoticeDTO.Save dto, List<String> fileUrls, User user);
+    Notice fromNoticeDto(NoticeDTO.Save dto, User user);
 
     @Mappings({
             @Mapping(target = "name", source = "user.name"),

--- a/src/main/java/leets/weeth/domain/board/application/mapper/PostMapper.java
+++ b/src/main/java/leets/weeth/domain/board/application/mapper/PostMapper.java
@@ -33,7 +33,7 @@ public interface PostMapper {
             @Mapping(target = "comments", expression = "java(filterParentComments(post.getComments()))"),
             @Mapping(target = "time", source = "post.modifiedAt")
     })
-    PostDTO.Response toPostDto(Post post, List<FileResponse> files);
+    PostDTO.Response toPostDto(Post post, List<FileResponse> fileUrls);
 
     default List<CommentDTO.Response> filterParentComments(List<Comment> comments) {
         if (comments == null || comments.isEmpty()) {

--- a/src/main/java/leets/weeth/domain/board/application/mapper/PostMapper.java
+++ b/src/main/java/leets/weeth/domain/board/application/mapper/PostMapper.java
@@ -5,6 +5,7 @@ import leets.weeth.domain.board.domain.entity.Post;
 import leets.weeth.domain.comment.application.dto.CommentDTO;
 import leets.weeth.domain.comment.application.mapper.CommentMapper;
 import leets.weeth.domain.comment.domain.entity.Comment;
+import leets.weeth.domain.file.application.dto.response.FileResponse;
 import leets.weeth.domain.user.domain.entity.User;
 import org.mapstruct.*;
 
@@ -28,11 +29,11 @@ public interface PostMapper {
     PostDTO.ResponseAll toAll(Post post);
 
     @Mappings({
-            @Mapping(target = "name", source = "user.name"),
+            @Mapping(target = "name", source = "post.user.name"),
             @Mapping(target = "comments", expression = "java(filterParentComments(post.getComments()))"),
-            @Mapping(target = "time", source = "modifiedAt")
+            @Mapping(target = "time", source = "post.modifiedAt")
     })
-    PostDTO.Response toPostDto(Post post);
+    PostDTO.Response toPostDto(Post post, List<FileResponse> files);
 
     default List<CommentDTO.Response> filterParentComments(List<Comment> comments) {
         if (comments == null || comments.isEmpty()) {

--- a/src/main/java/leets/weeth/domain/board/application/mapper/PostMapper.java
+++ b/src/main/java/leets/weeth/domain/board/application/mapper/PostMapper.java
@@ -19,7 +19,7 @@ public interface PostMapper {
             @Mapping(target = "id", ignore = true),
             @Mapping(target = "user", source = "user")
     })
-    Post fromPostDto(PostDTO.Save dto, List<String> fileUrls, User user);
+    Post fromPostDto(PostDTO.Save dto, User user);
 
     @Mappings({
             @Mapping(target = "name", source = "user.name"),

--- a/src/main/java/leets/weeth/domain/board/application/usecase/NoticeUsecase.java
+++ b/src/main/java/leets/weeth/domain/board/application/usecase/NoticeUsecase.java
@@ -8,13 +8,13 @@ import java.util.List;
 
 public interface NoticeUsecase {
 
-    void save(NoticeDTO.Save dto, List<MultipartFile> files, Long userId);
+    void save(NoticeDTO.Save dto, Long userId);
 
     NoticeDTO.Response findNotice(Long noticeId);
 
     List<NoticeDTO.ResponseAll> findNotices(Long noticeId, Integer count);
 
-    void update(Long noticeId, NoticeDTO.Update dto, List<MultipartFile> files, Long userId) throws UserNotMatchException;
+    void update(Long noticeId, NoticeDTO.Update dto, Long userId) throws UserNotMatchException;
 
     void delete(Long noticeId, Long userId) throws UserNotMatchException;
 

--- a/src/main/java/leets/weeth/domain/board/application/usecase/NoticeUsecaseImpl.java
+++ b/src/main/java/leets/weeth/domain/board/application/usecase/NoticeUsecaseImpl.java
@@ -11,6 +11,7 @@ import leets.weeth.domain.board.domain.service.NoticeUpdateService;
 import leets.weeth.domain.file.application.dto.response.FileResponse;
 import leets.weeth.domain.file.application.mapper.FileMapper;
 import leets.weeth.domain.file.domain.entity.File;
+import leets.weeth.domain.file.domain.service.FileDeleteService;
 import leets.weeth.domain.file.domain.service.FileGetService;
 import leets.weeth.domain.file.domain.service.FileSaveService;
 import leets.weeth.domain.file.domain.service.FileUpdateService;
@@ -35,9 +36,11 @@ public class NoticeUsecaseImpl implements NoticeUsecase {
     private final NoticeDeleteService noticeDeleteService;
 
     private final UserGetService userGetService;
+
     private final FileSaveService fileSaveService;
     private final FileGetService fileGetService;
     private final FileUpdateService fileUpdateService;
+    private final FileDeleteService fileDeleteService;
 
     private final NoticeMapper mapper;
     private final FileMapper fileMapper;
@@ -61,7 +64,7 @@ public class NoticeUsecaseImpl implements NoticeUsecase {
     public NoticeDTO.Response findNotice(Long noticeId) {
         Notice notice = noticeFindService.find(noticeId);
 
-        List<FileResponse> response = fileGetService.findAllByNotice(noticeId).stream()
+        List<FileResponse> response = getFiles(noticeId).stream()
                 .map(fileMapper::toFileResponse)
                 .toList();
 
@@ -97,7 +100,7 @@ public class NoticeUsecaseImpl implements NoticeUsecase {
     public void update(Long noticeId, NoticeDTO.Update dto, Long userId) throws UserNotMatchException {
         Notice notice = validateOwner(noticeId, userId);
 
-        List<File> fileList = fileGetService.findAllByNotice(noticeId);
+        List<File> fileList = getFiles(noticeId);
 
         fileUpdateService.updateFiles(fileList, dto.files());
 
@@ -108,7 +111,15 @@ public class NoticeUsecaseImpl implements NoticeUsecase {
     @Transactional
     public void delete(Long noticeId, Long userId) throws UserNotMatchException {
         validateOwner(noticeId, userId);
+
+        List<File> fileList = getFiles(noticeId);
+        fileDeleteService.delete(fileList);
+
         noticeDeleteService.delete(noticeId);
+    }
+
+    private List<File> getFiles(Long noticeId) {
+        return fileGetService.findAllByNotice(noticeId);
     }
 
     private Notice validateOwner(Long noticeId, Long userId) throws UserNotMatchException {

--- a/src/main/java/leets/weeth/domain/board/application/usecase/NoticeUsecaseImpl.java
+++ b/src/main/java/leets/weeth/domain/board/application/usecase/NoticeUsecaseImpl.java
@@ -53,10 +53,7 @@ public class NoticeUsecaseImpl implements NoticeUsecase {
         Notice notice = mapper.fromNoticeDto(request, user);
         noticeSaveService.save(notice);
 
-        List<File> files = request.files().stream()
-                .map(fileSaveRequest -> fileMapper.toFile(fileSaveRequest.fileName(), fileSaveRequest.fileUrl(), notice))
-                .toList();
-
+        List<File> files = fileMapper.toFileList(request.files(), notice);
         fileSaveService.save(files);
     }
 

--- a/src/main/java/leets/weeth/domain/board/application/usecase/NoticeUsecaseImpl.java
+++ b/src/main/java/leets/weeth/domain/board/application/usecase/NoticeUsecaseImpl.java
@@ -97,7 +97,7 @@ public class NoticeUsecaseImpl implements NoticeUsecase {
 
     @Override
     @Transactional
-    public void update(Long noticeId, NoticeDTO.Update dto, Long userId) throws UserNotMatchException {
+    public void update(Long noticeId, NoticeDTO.Update dto, Long userId) {
         Notice notice = validateOwner(noticeId, userId);
 
         List<File> fileList = getFiles(noticeId);
@@ -109,7 +109,7 @@ public class NoticeUsecaseImpl implements NoticeUsecase {
 
     @Override
     @Transactional
-    public void delete(Long noticeId, Long userId) throws UserNotMatchException {
+    public void delete(Long noticeId, Long userId) {
         validateOwner(noticeId, userId);
 
         List<File> fileList = getFiles(noticeId);
@@ -122,7 +122,7 @@ public class NoticeUsecaseImpl implements NoticeUsecase {
         return fileGetService.findAllByNotice(noticeId);
     }
 
-    private Notice validateOwner(Long noticeId, Long userId) throws UserNotMatchException {
+    private Notice validateOwner(Long noticeId, Long userId) {
         Notice notice = noticeFindService.find(noticeId);
         if (!notice.getUser().getId().equals(userId)) {
             throw new UserNotMatchException();

--- a/src/main/java/leets/weeth/domain/board/application/usecase/NoticeUsecaseImpl.java
+++ b/src/main/java/leets/weeth/domain/board/application/usecase/NoticeUsecaseImpl.java
@@ -98,8 +98,10 @@ public class NoticeUsecaseImpl implements NoticeUsecase {
         Notice notice = validateOwner(noticeId, userId);
 
         List<File> fileList = getFiles(noticeId);
+        fileDeleteService.delete(fileList);
 
-        fileUpdateService.updateFiles(fileList, dto.files());
+        List<File> files = fileMapper.toFileList(dto.files(), notice);
+        fileSaveService.save(files);
 
         noticeUpdateService.update(notice, dto);
     }

--- a/src/main/java/leets/weeth/domain/board/application/usecase/NoticeUsecaseImpl.java
+++ b/src/main/java/leets/weeth/domain/board/application/usecase/NoticeUsecaseImpl.java
@@ -8,6 +8,7 @@ import leets.weeth.domain.board.domain.service.NoticeDeleteService;
 import leets.weeth.domain.board.domain.service.NoticeFindService;
 import leets.weeth.domain.board.domain.service.NoticeSaveService;
 import leets.weeth.domain.board.domain.service.NoticeUpdateService;
+import leets.weeth.domain.file.application.dto.response.FileResponse;
 import leets.weeth.domain.file.application.mapper.FileMapper;
 import leets.weeth.domain.file.domain.entity.File;
 import leets.weeth.domain.file.domain.service.FileGetService;
@@ -59,7 +60,12 @@ public class NoticeUsecaseImpl implements NoticeUsecase {
     @Override
     public NoticeDTO.Response findNotice(Long noticeId) {
         Notice notice = noticeFindService.find(noticeId);
-        return mapper.toNoticeDto(notice);
+
+        List<FileResponse> response = fileGetService.findAllByNotice(noticeId).stream()
+                .map(fileMapper::toFileResponse)
+                .toList();
+
+        return mapper.toNoticeDto(notice, response);
     }
 
     @Override

--- a/src/main/java/leets/weeth/domain/board/application/usecase/PostUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/board/application/usecase/PostUseCaseImpl.java
@@ -53,10 +53,7 @@ public class PostUseCaseImpl implements PostUsecase {
         Post post = mapper.fromPostDto(request, user);
         postSaveService.save(post);
 
-        List<File> files = request.files().stream()
-                .map(fileSaveRequest -> fileMapper.toFile(fileSaveRequest.fileName(), fileSaveRequest.fileUrl(), post))
-                .toList();
-
+        List<File> files = fileMapper.toFileList(request.files(), post);
         fileSaveService.save(files);
     }
 

--- a/src/main/java/leets/weeth/domain/board/application/usecase/PostUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/board/application/usecase/PostUseCaseImpl.java
@@ -8,10 +8,10 @@ import leets.weeth.domain.board.domain.service.PostDeleteService;
 import leets.weeth.domain.board.domain.service.PostFindService;
 import leets.weeth.domain.board.domain.service.PostSaveService;
 import leets.weeth.domain.board.domain.service.PostUpdateService;
-import leets.weeth.domain.file.application.dto.request.FileUpdateRequest;
 import leets.weeth.domain.file.application.dto.response.FileResponse;
 import leets.weeth.domain.file.application.mapper.FileMapper;
 import leets.weeth.domain.file.domain.entity.File;
+import leets.weeth.domain.file.domain.service.FileDeleteService;
 import leets.weeth.domain.file.domain.service.FileGetService;
 import leets.weeth.domain.file.domain.service.FileSaveService;
 import leets.weeth.domain.file.domain.service.FileUpdateService;
@@ -36,9 +36,11 @@ public class PostUseCaseImpl implements PostUsecase {
     private final PostDeleteService postDeleteService;
 
     private final UserGetService userGetService;
+
     private final FileSaveService fileSaveService;
     private final FileGetService fileGetService;
     private final FileUpdateService fileUpdateService;
+    private final FileDeleteService fileDeleteService;
 
     private final PostMapper mapper;
     private final FileMapper fileMapper;
@@ -62,7 +64,7 @@ public class PostUseCaseImpl implements PostUsecase {
     public PostDTO.Response findPost(Long postId) {
         Post post = postFindService.find(postId);
 
-        List<FileResponse> response = fileGetService.findAllByPost(postId).stream()
+        List<FileResponse> response = getFiles(postId).stream()
                 .map(fileMapper::toFileResponse)
                 .toList();
 
@@ -98,7 +100,7 @@ public class PostUseCaseImpl implements PostUsecase {
     public void update(Long postId, PostDTO.Update dto, Long userId) {
         Post post = validateOwner(postId, userId);
 
-        List<File> fileList = fileGetService.findAllByPost(postId);
+        List<File> fileList = getFiles(postId);
 
         fileUpdateService.updateFiles(fileList, dto.files());
 
@@ -109,7 +111,15 @@ public class PostUseCaseImpl implements PostUsecase {
     @Transactional
     public void delete(Long postId, Long userId) {
         validateOwner(postId, userId);
+
+        List<File> fileList = getFiles(postId);
+        fileDeleteService.delete(fileList);
+
         postDeleteService.delete(postId);
+    }
+
+    private List<File> getFiles(Long postId) {
+        return fileGetService.findAllByPost(postId);
     }
 
     private Post validateOwner(Long postId, Long userId) {

--- a/src/main/java/leets/weeth/domain/board/application/usecase/PostUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/board/application/usecase/PostUseCaseImpl.java
@@ -1,22 +1,27 @@
 package leets.weeth.domain.board.application.usecase;
 
 import leets.weeth.domain.board.application.dto.PostDTO;
+import leets.weeth.domain.board.application.exception.PostNotFoundException;
 import leets.weeth.domain.board.application.mapper.PostMapper;
 import leets.weeth.domain.board.domain.entity.Post;
 import leets.weeth.domain.board.domain.service.PostDeleteService;
 import leets.weeth.domain.board.domain.service.PostFindService;
 import leets.weeth.domain.board.domain.service.PostSaveService;
 import leets.weeth.domain.board.domain.service.PostUpdateService;
-import leets.weeth.domain.file.service.S3Service;
+import leets.weeth.domain.file.application.dto.request.FileUpdateRequest;
+import leets.weeth.domain.file.application.mapper.FileMapper;
+import leets.weeth.domain.file.domain.entity.File;
+import leets.weeth.domain.file.domain.service.FileGetService;
+import leets.weeth.domain.file.domain.service.FileSaveService;
+import leets.weeth.domain.file.domain.service.FileUpdateService;
+import leets.weeth.domain.user.application.exception.UserNotMatchException;
 import leets.weeth.domain.user.domain.entity.User;
 import leets.weeth.domain.user.domain.service.UserGetService;
-import leets.weeth.domain.board.application.exception.PostNotFoundException;
-import leets.weeth.domain.user.application.exception.UserNotMatchException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
-import org.springframework.web.multipart.MultipartFile;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -30,17 +35,26 @@ public class PostUseCaseImpl implements PostUsecase {
     private final PostDeleteService postDeleteService;
 
     private final UserGetService userGetService;
-    private final S3Service s3Service;
+    private final FileSaveService fileSaveService;
+    private final FileGetService fileGetService;
+    private final FileUpdateService fileUpdateService;
 
     private final PostMapper mapper;
+    private final FileMapper fileMapper;
 
     @Override
-    public void save(PostDTO.Save request, List<MultipartFile> files, Long userId) {
+    @Transactional
+    public void save(PostDTO.Save request, Long userId) {
         User user = userGetService.find(userId);
 
-        List<String> fileUrls;
-        fileUrls = s3Service.uploadFiles(files);
-        postSaveService.save(mapper.fromPostDto(request, fileUrls, user));
+        Post post = mapper.fromPostDto(request, user);
+        postSaveService.save(post);
+
+        List<File> files = request.files().stream()
+                .map(fileSaveRequest -> fileMapper.toFile(fileSaveRequest.fileName(), fileSaveRequest.fileUrl(), post))
+                .toList();
+
+        fileSaveService.save(files);
     }
 
     @Override
@@ -55,12 +69,12 @@ public class PostUseCaseImpl implements PostUsecase {
         Long finalPostId = postFindService.findFinalPostId();
 
         // 첫번째 요청인 경우
-        if(postId==null){
+        if (postId == null) {
             postId = finalPostId + 1;
         }
 
         // postId가 1 이하이거나 최대값보다 클경우
-        if(postId < 1 || postId > finalPostId + 1){
+        if (postId < 1 || postId > finalPostId + 1) {
             throw new PostNotFoundException();
         }
 
@@ -74,27 +88,37 @@ public class PostUseCaseImpl implements PostUsecase {
     }
 
     @Override
-    public void update(Long postId, PostDTO.Update dto, List<MultipartFile> files, Long userId) throws UserNotMatchException {
+    @Transactional
+    public void update(Long postId, PostDTO.Update dto, Long userId) throws UserNotMatchException {
         Post post = validateOwner(postId, userId);
 
-        List<String> fileUrls = post.getFileUrls();
-        List<String> uploadedFileUrls = s3Service.uploadFiles(files);
+        List<File> fileList = fileGetService.findAllByPost(postId);
 
-        fileUrls.addAll(uploadedFileUrls);
+        updateFiles(fileList, dto.files());
 
-        postUpdateService.update(post, dto, fileUrls);
+        postUpdateService.update(post, dto);
     }
 
     @Override
+    @Transactional
     public void delete(Long postId, Long userId) throws UserNotMatchException {
         validateOwner(postId, userId);
         postDeleteService.delete(postId);
     }
 
+    private void updateFiles(List<File> fileList, List<FileUpdateRequest> dto) {
+        for (File file : fileList) {
+            dto.stream()
+                    .filter(updateRequest -> updateRequest.fileId().equals(file.getId()))
+                    .findFirst()
+                    .ifPresent(updateRequest -> fileUpdateService.update(file, updateRequest));
+        }
+    }
+
     private Post validateOwner(Long postId, Long userId) throws UserNotMatchException {
         Post post = postFindService.find(postId);
 
-        if (!post.getUser().getId().equals(userId)) {
+        if (post.getUser().getId().equals(userId)) {
             throw new UserNotMatchException();
         }
         return post;

--- a/src/main/java/leets/weeth/domain/board/application/usecase/PostUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/board/application/usecase/PostUseCaseImpl.java
@@ -89,7 +89,7 @@ public class PostUseCaseImpl implements PostUsecase {
 
     @Override
     @Transactional
-    public void update(Long postId, PostDTO.Update dto, Long userId) throws UserNotMatchException {
+    public void update(Long postId, PostDTO.Update dto, Long userId) {
         Post post = validateOwner(postId, userId);
 
         List<File> fileList = fileGetService.findAllByPost(postId);
@@ -101,12 +101,12 @@ public class PostUseCaseImpl implements PostUsecase {
 
     @Override
     @Transactional
-    public void delete(Long postId, Long userId) throws UserNotMatchException {
+    public void delete(Long postId, Long userId) {
         validateOwner(postId, userId);
         postDeleteService.delete(postId);
     }
 
-    private Post validateOwner(Long postId, Long userId) throws UserNotMatchException {
+    private Post validateOwner(Long postId, Long userId) {
         Post post = postFindService.find(postId);
 
         if (post.getUser().getId().equals(userId)) {

--- a/src/main/java/leets/weeth/domain/board/application/usecase/PostUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/board/application/usecase/PostUseCaseImpl.java
@@ -109,7 +109,7 @@ public class PostUseCaseImpl implements PostUsecase {
     private Post validateOwner(Long postId, Long userId) {
         Post post = postFindService.find(postId);
 
-        if (post.getUser().getId().equals(userId)) {
+        if (!post.getUser().getId().equals(userId)) {
             throw new UserNotMatchException();
         }
         return post;

--- a/src/main/java/leets/weeth/domain/board/application/usecase/PostUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/board/application/usecase/PostUseCaseImpl.java
@@ -98,8 +98,10 @@ public class PostUseCaseImpl implements PostUsecase {
         Post post = validateOwner(postId, userId);
 
         List<File> fileList = getFiles(postId);
+        fileDeleteService.delete(fileList);
 
-        fileUpdateService.updateFiles(fileList, dto.files());
+        List<File> files = fileMapper.toFileList(dto.files(), post);
+        fileSaveService.save(files);
 
         postUpdateService.update(post, dto);
     }

--- a/src/main/java/leets/weeth/domain/board/application/usecase/PostUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/board/application/usecase/PostUseCaseImpl.java
@@ -94,7 +94,7 @@ public class PostUseCaseImpl implements PostUsecase {
 
         List<File> fileList = fileGetService.findAllByPost(postId);
 
-        updateFiles(fileList, dto.files());
+        fileUpdateService.updateFiles(fileList, dto.files());
 
         postUpdateService.update(post, dto);
     }
@@ -104,15 +104,6 @@ public class PostUseCaseImpl implements PostUsecase {
     public void delete(Long postId, Long userId) throws UserNotMatchException {
         validateOwner(postId, userId);
         postDeleteService.delete(postId);
-    }
-
-    private void updateFiles(List<File> fileList, List<FileUpdateRequest> dto) {
-        for (File file : fileList) {
-            dto.stream()
-                    .filter(updateRequest -> updateRequest.fileId().equals(file.getId()))
-                    .findFirst()
-                    .ifPresent(updateRequest -> fileUpdateService.update(file, updateRequest));
-        }
     }
 
     private Post validateOwner(Long postId, Long userId) throws UserNotMatchException {

--- a/src/main/java/leets/weeth/domain/board/application/usecase/PostUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/board/application/usecase/PostUseCaseImpl.java
@@ -9,6 +9,7 @@ import leets.weeth.domain.board.domain.service.PostFindService;
 import leets.weeth.domain.board.domain.service.PostSaveService;
 import leets.weeth.domain.board.domain.service.PostUpdateService;
 import leets.weeth.domain.file.application.dto.request.FileUpdateRequest;
+import leets.weeth.domain.file.application.dto.response.FileResponse;
 import leets.weeth.domain.file.application.mapper.FileMapper;
 import leets.weeth.domain.file.domain.entity.File;
 import leets.weeth.domain.file.domain.service.FileGetService;
@@ -60,7 +61,12 @@ public class PostUseCaseImpl implements PostUsecase {
     @Override
     public PostDTO.Response findPost(Long postId) {
         Post post = postFindService.find(postId);
-        return mapper.toPostDto(post);
+
+        List<FileResponse> response = fileGetService.findAllByPost(postId).stream()
+                .map(fileMapper::toFileResponse)
+                .toList();
+
+        return mapper.toPostDto(post, response);
     }
 
     @Override

--- a/src/main/java/leets/weeth/domain/board/application/usecase/PostUsecase.java
+++ b/src/main/java/leets/weeth/domain/board/application/usecase/PostUsecase.java
@@ -8,13 +8,13 @@ import java.util.List;
 
 public interface PostUsecase {
 
-    void save(PostDTO.Save request, List<MultipartFile> files, Long userId);
+    void save(PostDTO.Save request, Long userId);
 
     PostDTO.Response findPost(Long postId);
 
     List<PostDTO.ResponseAll> findPosts(Long postId, Integer count);
 
-    void update(Long postId, PostDTO.Update dto, List<MultipartFile> files, Long userId) throws UserNotMatchException;
+    void update(Long postId, PostDTO.Update dto, Long userId) throws UserNotMatchException;
 
     void delete(Long postId, Long userId) throws UserNotMatchException;
 

--- a/src/main/java/leets/weeth/domain/board/domain/entity/Board.java
+++ b/src/main/java/leets/weeth/domain/board/domain/entity/Board.java
@@ -38,9 +38,6 @@ public class Board extends BaseEntity {
     @JoinColumn(name = "user_id")
     private User user;
 
-    @Convert(converter = FileListConverter.class)
-    private List<String> fileUrls = new ArrayList<>();
-
     private Integer commentCount;
 
     @PrePersist
@@ -64,16 +61,14 @@ public class Board extends BaseEntity {
                 .count();
     }
 
-    public void updateUpperClass(NoticeDTO.Update dto, List<String> fileUrls) {
+    public void updateUpperClass(NoticeDTO.Update dto) {
         this.title = dto.title();
         this.content = dto.content();
-        this.fileUrls = fileUrls;
     }
 
-    public void updateUpperClass(PostDTO.Update dto, List<String> fileUrls) {
+    public void updateUpperClass(PostDTO.Update dto) {
         this.title = dto.title();
         this.content = dto.content();
-        this.fileUrls = fileUrls;
     }
 
 }

--- a/src/main/java/leets/weeth/domain/board/domain/entity/Notice.java
+++ b/src/main/java/leets/weeth/domain/board/domain/entity/Notice.java
@@ -30,8 +30,8 @@ public class Notice extends Board {
         comments.add(comment);
     }
 
-    public void update(NoticeDTO.Update dto, List<String> fileUrls){
-        this.updateUpperClass(dto, fileUrls);
+    public void update(NoticeDTO.Update dto){
+        this.updateUpperClass(dto);
     }
 
 }

--- a/src/main/java/leets/weeth/domain/board/domain/entity/Post.java
+++ b/src/main/java/leets/weeth/domain/board/domain/entity/Post.java
@@ -30,8 +30,8 @@ public class Post extends Board {
         comments.add(comment);
     }
 
-    public void update(PostDTO.Update dto, List<String> fileUrls) {
-        this.updateUpperClass(dto, fileUrls);
+    public void update(PostDTO.Update dto) {
+        this.updateUpperClass(dto);
     }
 
 }

--- a/src/main/java/leets/weeth/domain/board/domain/service/NoticeSaveService.java
+++ b/src/main/java/leets/weeth/domain/board/domain/service/NoticeSaveService.java
@@ -12,7 +12,6 @@ public class NoticeSaveService {
 
     private final NoticeRepository noticeRepository;
 
-    @Transactional
     public void save(Notice notice){
         noticeRepository.save(notice);
     }

--- a/src/main/java/leets/weeth/domain/board/domain/service/NoticeUpdateService.java
+++ b/src/main/java/leets/weeth/domain/board/domain/service/NoticeUpdateService.java
@@ -12,9 +12,8 @@ import java.util.List;
 @RequiredArgsConstructor
 public class NoticeUpdateService {
 
-    @Transactional
-    public void update(Notice notice, NoticeDTO.Update dto, List<String> fileUrls){
-        notice.update(dto, fileUrls);
+    public void update(Notice notice, NoticeDTO.Update dto){
+        notice.update(dto);
     }
 
 }

--- a/src/main/java/leets/weeth/domain/board/domain/service/PostDeleteService.java
+++ b/src/main/java/leets/weeth/domain/board/domain/service/PostDeleteService.java
@@ -11,7 +11,6 @@ public class PostDeleteService {
 
     private final PostRepository postRepository;
 
-    @Transactional
     public void delete(Long postId) {
         postRepository.deleteById(postId);
     }

--- a/src/main/java/leets/weeth/domain/board/domain/service/PostSaveService.java
+++ b/src/main/java/leets/weeth/domain/board/domain/service/PostSaveService.java
@@ -12,7 +12,6 @@ public class PostSaveService {
 
     private final PostRepository postRepository;
 
-    @Transactional
     public void save(Post post) {
         postRepository.save(post);
     }

--- a/src/main/java/leets/weeth/domain/board/domain/service/PostUpdateService.java
+++ b/src/main/java/leets/weeth/domain/board/domain/service/PostUpdateService.java
@@ -15,9 +15,8 @@ import java.util.List;
 @RequiredArgsConstructor
 public class PostUpdateService {
 
-    @Transactional
-    public void update(Post post, PostDTO.Update dto, List<String> fileUrls){
-        post.update(dto, fileUrls);
+    public void update(Post post, PostDTO.Update dto){
+        post.update(dto);
     }
 
 }

--- a/src/main/java/leets/weeth/domain/board/presentation/NoticeAdminController.java
+++ b/src/main/java/leets/weeth/domain/board/presentation/NoticeAdminController.java
@@ -26,22 +26,20 @@ public class NoticeAdminController {
 
     private final NoticeUsecase noticeUsecase;
 
-    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PostMapping
     @Operation(summary="공지사항 생성")
-    public CommonResponse<String> save(@RequestPart @Valid NoticeDTO.Save dto,
-                                       @RequestPart(value = "files", required = false) List<MultipartFile> files,
+    public CommonResponse<String> save(@RequestBody @Valid NoticeDTO.Save dto,
                                        @Parameter(hidden = true) @CurrentUser Long userId) {
-        noticeUsecase.save(dto, files, userId);
+        noticeUsecase.save(dto, userId);
         return CommonResponse.createSuccess(NOTICE_CREATED_SUCCESS.getMessage());
     }
 
-    @PatchMapping(value = "/{noticeId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PatchMapping(value = "/{noticeId}")
     @Operation(summary="특정 공지사항 수정")
     public CommonResponse<String> update(@PathVariable Long noticeId,
-                                         @RequestPart @Valid NoticeDTO.Update dto,
-                                         @RequestPart(value = "files", required = false) List<MultipartFile> files,
+                                         @RequestBody @Valid NoticeDTO.Update dto,
                                          @Parameter(hidden = true) @CurrentUser Long userId) throws UserNotMatchException {
-        noticeUsecase.update(noticeId, dto, files, userId);
+        noticeUsecase.update(noticeId, dto, userId);
         return CommonResponse.createSuccess(NOTICE_UPDATED_SUCCESS.getMessage());
     }
 

--- a/src/main/java/leets/weeth/domain/board/presentation/PostController.java
+++ b/src/main/java/leets/weeth/domain/board/presentation/PostController.java
@@ -26,12 +26,11 @@ public class PostController {
 
     private final PostUsecase postUsecase;
 
-    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PostMapping
     @Operation(summary="게시글 생성")
-    public CommonResponse<String> save(@RequestPart @Valid PostDTO.Save dto,
-                                       @RequestPart(value = "files", required = false) List<MultipartFile> files,
+    public CommonResponse<String> save(@RequestBody @Valid PostDTO.Save dto,
                                        @Parameter(hidden = true) @CurrentUser Long userId) {
-        postUsecase.save(dto, files, userId);
+        postUsecase.save(dto, userId);
         return CommonResponse.createSuccess(POST_CREATED_SUCCESS.getMessage());
     }
 
@@ -47,13 +46,12 @@ public class PostController {
         return CommonResponse.createSuccess(POST_FIND_BY_ID_SUCCESS.getMessage(),postUsecase.findPost(postId));
     }
 
-    @PatchMapping(value = "/{postId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PatchMapping(value = "/{postId}")
     @Operation(summary="특정 게시글 수정")
     public CommonResponse<String> update(@PathVariable Long postId,
-                                         @RequestPart @Valid PostDTO.Update dto,
-                                         @RequestPart(value = "files", required = false) List<MultipartFile> files,
+                                         @RequestBody @Valid PostDTO.Update dto,
                                          @Parameter(hidden = true) @CurrentUser Long userId) throws UserNotMatchException {
-        postUsecase.update(postId, dto, files, userId);
+        postUsecase.update(postId, dto, userId);
         return CommonResponse.createSuccess(POST_UPDATED_SUCCESS.getMessage());
     }
 

--- a/src/main/java/leets/weeth/domain/file/application/dto/request/FileSaveRequest.java
+++ b/src/main/java/leets/weeth/domain/file/application/dto/request/FileSaveRequest.java
@@ -1,7 +1,10 @@
 package leets.weeth.domain.file.application.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
+import org.hibernate.validator.constraints.URL;
+
 public record FileSaveRequest(
-        String fileName,
-        String fileUrl
+        @NotBlank String fileName,
+        @URL String fileUrl
 ) {
 }

--- a/src/main/java/leets/weeth/domain/file/application/dto/request/FileSaveRequest.java
+++ b/src/main/java/leets/weeth/domain/file/application/dto/request/FileSaveRequest.java
@@ -5,6 +5,6 @@ import org.hibernate.validator.constraints.URL;
 
 public record FileSaveRequest(
         @NotBlank String fileName,
-        @URL String fileUrl
+        @NotBlank @URL String fileUrl
 ) {
 }

--- a/src/main/java/leets/weeth/domain/file/application/dto/request/FileUpdateRequest.java
+++ b/src/main/java/leets/weeth/domain/file/application/dto/request/FileUpdateRequest.java
@@ -1,10 +1,11 @@
 package leets.weeth.domain.file.application.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import org.hibernate.validator.constraints.URL;
 
 public record FileUpdateRequest(
         @NotBlank Long fileId,
-        String fileName,
-        String fileUrl
+        @NotBlank String fileName,
+        @URL String fileUrl
 ) {
 }

--- a/src/main/java/leets/weeth/domain/file/application/dto/request/FileUpdateRequest.java
+++ b/src/main/java/leets/weeth/domain/file/application/dto/request/FileUpdateRequest.java
@@ -1,10 +1,11 @@
 package leets.weeth.domain.file.application.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import org.hibernate.validator.constraints.URL;
 
 public record FileUpdateRequest(
-        @NotBlank Long fileId,
+        @NotNull Long fileId,
         @NotBlank String fileName,
         @NotBlank @URL String fileUrl
 ) {

--- a/src/main/java/leets/weeth/domain/file/application/dto/request/FileUpdateRequest.java
+++ b/src/main/java/leets/weeth/domain/file/application/dto/request/FileUpdateRequest.java
@@ -6,6 +6,6 @@ import org.hibernate.validator.constraints.URL;
 public record FileUpdateRequest(
         @NotBlank Long fileId,
         @NotBlank String fileName,
-        @URL String fileUrl
+        @NotBlank @URL String fileUrl
 ) {
 }

--- a/src/main/java/leets/weeth/domain/file/application/mapper/FileMapper.java
+++ b/src/main/java/leets/weeth/domain/file/application/mapper/FileMapper.java
@@ -1,8 +1,10 @@
 package leets.weeth.domain.file.application.mapper;
 
+import leets.weeth.domain.account.domain.entity.Receipt;
 import leets.weeth.domain.board.domain.entity.Notice;
 import leets.weeth.domain.board.domain.entity.Post;
 import leets.weeth.domain.comment.application.mapper.CommentMapper;
+import leets.weeth.domain.file.application.dto.request.FileSaveRequest;
 import leets.weeth.domain.file.application.dto.response.FileResponse;
 import leets.weeth.domain.file.application.dto.response.UrlResponse;
 import leets.weeth.domain.file.domain.entity.File;
@@ -10,6 +12,10 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingConstants;
 import org.mapstruct.ReportingPolicy;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Mapper(componentModel = MappingConstants.ComponentModel.SPRING, uses = CommentMapper.class, unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface FileMapper {
@@ -20,8 +26,42 @@ public interface FileMapper {
     @Mapping(target = "notice", source = "notice")
     File toFile(String fileName, String fileUrl, Notice notice);
 
+    @Mapping(target = "receipt", source = "receipt")
+    File toFile(String fileName, String fileUrl, Receipt receipt);
+
     @Mapping(target = "fileId", source = "file.id")
     FileResponse toFileResponse(File file);
 
     UrlResponse toUrlResponse(String fileName, String putUrl);
+
+    default List<File> toFileList(List<FileSaveRequest> requests, Post post) {
+        List<FileSaveRequest> dto = requests;
+        if (dto == null || dto.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return dto.stream()
+                .map(request -> toFile(request.fileName(), request.fileUrl(), post))
+                .collect(Collectors.toList());
+    }
+
+    default List<File> toFileList(List<FileSaveRequest> requests, Notice notice) {
+        if (requests == null || requests.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return requests.stream()
+                .map(request -> toFile(request.fileName(), request.fileUrl(), notice))
+                .collect(Collectors.toList());
+    }
+
+    default List<File> toFileList(List<FileSaveRequest> requests, Receipt receipt) {
+        if (requests == null || requests.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return requests.stream()
+                .map(request -> toFile(request.fileName(), request.fileUrl(), receipt))
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/leets/weeth/domain/file/application/mapper/FileMapper.java
+++ b/src/main/java/leets/weeth/domain/file/application/mapper/FileMapper.java
@@ -20,6 +20,7 @@ public interface FileMapper {
     @Mapping(target = "notice", source = "notice")
     File toFile(String fileName, String fileUrl, Notice notice);
 
+    @Mapping(target = "fileId", source = "file.id")
     FileResponse toFileResponse(File file);
 
     UrlResponse toUrlResponse(String fileName, String putUrl);

--- a/src/main/java/leets/weeth/domain/file/application/mapper/FileMapper.java
+++ b/src/main/java/leets/weeth/domain/file/application/mapper/FileMapper.java
@@ -20,12 +20,15 @@ import java.util.stream.Collectors;
 @Mapper(componentModel = MappingConstants.ComponentModel.SPRING, uses = CommentMapper.class, unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface FileMapper {
 
+    @Mapping(target = "id", ignore = true)
     @Mapping(target = "post", source = "post")
     File toFile(String fileName, String fileUrl, Post post);
 
+    @Mapping(target = "id", ignore = true)
     @Mapping(target = "notice", source = "notice")
     File toFile(String fileName, String fileUrl, Notice notice);
 
+    @Mapping(target = "id", ignore = true)
     @Mapping(target = "receipt", source = "receipt")
     File toFile(String fileName, String fileUrl, Receipt receipt);
 

--- a/src/main/java/leets/weeth/domain/file/application/mapper/FileMapper.java
+++ b/src/main/java/leets/weeth/domain/file/application/mapper/FileMapper.java
@@ -22,15 +22,15 @@ public interface FileMapper {
 
     @Mapping(target = "id", ignore = true)
     @Mapping(target = "post", source = "post")
-    File toFile(String fileName, String fileUrl, Post post);
+    File toFileWithPost(String fileName, String fileUrl, Post post);
 
     @Mapping(target = "id", ignore = true)
     @Mapping(target = "notice", source = "notice")
-    File toFile(String fileName, String fileUrl, Notice notice);
+    File toFileWithNotice(String fileName, String fileUrl, Notice notice);
 
     @Mapping(target = "id", ignore = true)
     @Mapping(target = "receipt", source = "receipt")
-    File toFile(String fileName, String fileUrl, Receipt receipt);
+    File toFileWithReceipt(String fileName, String fileUrl, Receipt receipt);
 
     @Mapping(target = "fileId", source = "file.id")
     FileResponse toFileResponse(File file);
@@ -44,7 +44,7 @@ public interface FileMapper {
         }
 
         return dto.stream()
-                .map(request -> toFile(request.fileName(), request.fileUrl(), post))
+                .map(request -> toFileWithPost(request.fileName(), request.fileUrl(), post))
                 .collect(Collectors.toList());
     }
 
@@ -54,7 +54,7 @@ public interface FileMapper {
         }
 
         return requests.stream()
-                .map(request -> toFile(request.fileName(), request.fileUrl(), notice))
+                .map(request -> toFileWithNotice(request.fileName(), request.fileUrl(), notice))
                 .collect(Collectors.toList());
     }
 
@@ -64,7 +64,7 @@ public interface FileMapper {
         }
 
         return requests.stream()
-                .map(request -> toFile(request.fileName(), request.fileUrl(), receipt))
+                .map(request -> toFileWithReceipt(request.fileName(), request.fileUrl(), receipt))
                 .collect(Collectors.toList());
     }
 }

--- a/src/main/java/leets/weeth/domain/file/domain/entity/File.java
+++ b/src/main/java/leets/weeth/domain/file/domain/entity/File.java
@@ -1,6 +1,7 @@
 package leets.weeth.domain.file.domain.entity;
 
 import jakarta.persistence.*;
+import leets.weeth.domain.account.domain.entity.Receipt;
 import leets.weeth.domain.board.domain.entity.Notice;
 import leets.weeth.domain.board.domain.entity.Post;
 import lombok.*;
@@ -14,7 +15,7 @@ public class File {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    public Long id;
+    private Long id;
 
     private String fileName;
 
@@ -27,6 +28,10 @@ public class File {
     @ManyToOne
     @JoinColumn(name = "notice_id")
     private Notice notice;
+
+    @ManyToOne
+    @JoinColumn(name = "receipt_id")
+    private Receipt receipt;
 
     public void update(String fileName, String fileUrl) {
         this.fileName = fileName;

--- a/src/main/java/leets/weeth/domain/file/domain/repository/FileRepository.java
+++ b/src/main/java/leets/weeth/domain/file/domain/repository/FileRepository.java
@@ -10,4 +10,6 @@ public interface FileRepository extends JpaRepository<File, Long> {
     List<File> findAllByPostId(Long postId);
 
     List<File> findAllByNoticeId(Long noticeId);
+
+    List<File> findAllByReceiptId(Long receiptId);
 }

--- a/src/main/java/leets/weeth/domain/file/domain/service/FileDeleteService.java
+++ b/src/main/java/leets/weeth/domain/file/domain/service/FileDeleteService.java
@@ -1,0 +1,23 @@
+package leets.weeth.domain.file.domain.service;
+
+import leets.weeth.domain.file.domain.entity.File;
+import leets.weeth.domain.file.domain.repository.FileRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class FileDeleteService {
+
+    private final FileRepository fileRepository;
+
+    public void delete(File file) {
+        fileRepository.delete(file);
+    }
+
+    public void delete(List<File> files) {
+        fileRepository.deleteAll(files);
+    }
+}

--- a/src/main/java/leets/weeth/domain/file/domain/service/FileGetService.java
+++ b/src/main/java/leets/weeth/domain/file/domain/service/FileGetService.java
@@ -20,4 +20,8 @@ public class FileGetService {
     public List<File> findAllByNotice(Long noticeId) {
         return fileRepository.findAllByNoticeId(noticeId);
     }
+
+    public List<File> findAllByReceipt(Long receiptId) {
+        return fileRepository.findAllByReceiptId(receiptId);
+    }
 }

--- a/src/main/java/leets/weeth/domain/file/domain/service/FileGetService.java
+++ b/src/main/java/leets/weeth/domain/file/domain/service/FileGetService.java
@@ -18,6 +18,6 @@ public class FileGetService {
     }
 
     public List<File> findAllByNotice(Long noticeId) {
-        return fileRepository.findAllByPostId(noticeId);
+        return fileRepository.findAllByNoticeId(noticeId);
     }
 }

--- a/src/main/java/leets/weeth/domain/file/domain/service/FileUpdateService.java
+++ b/src/main/java/leets/weeth/domain/file/domain/service/FileUpdateService.java
@@ -5,11 +5,22 @@ import leets.weeth.domain.file.domain.entity.File;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class FileUpdateService {
 
     public void update(File file, FileUpdateRequest dto) {
         file.update(dto.fileName(), dto.fileUrl());
+    }
+
+    public void updateFiles(List<File> fileList, List<FileUpdateRequest> dto) {
+        for (File file : fileList) {
+            dto.stream()
+                    .filter(updateRequest -> updateRequest.fileId().equals(file.getId()))
+                    .findFirst()
+                    .ifPresent(updateRequest -> file.update(updateRequest.fileName(), updateRequest.fileUrl()));
+        }
     }
 }

--- a/src/main/java/leets/weeth/global/auth/jwt/exception/AnonymousAuthenticationException.java
+++ b/src/main/java/leets/weeth/global/auth/jwt/exception/AnonymousAuthenticationException.java
@@ -1,0 +1,9 @@
+package leets.weeth.global.auth.jwt.exception;
+
+import leets.weeth.global.common.exception.BusinessLogicException;
+
+public class AnonymousAuthenticationException extends BusinessLogicException {
+    public AnonymousAuthenticationException() {
+        super(401, "인증정보가 존재하지 않습니다.");
+    }
+}

--- a/src/main/java/leets/weeth/global/auth/resolver/CurrentUserArgumentResolver.java
+++ b/src/main/java/leets/weeth/global/auth/resolver/CurrentUserArgumentResolver.java
@@ -1,6 +1,7 @@
 package leets.weeth.global.auth.resolver;
 
 import leets.weeth.global.auth.annotation.CurrentUser;
+import leets.weeth.global.auth.jwt.exception.AnonymousAuthenticationException;
 import leets.weeth.global.auth.jwt.service.JwtService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.MethodParameter;
@@ -31,7 +32,7 @@ public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolve
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();     // 인증 객체 가져오기
 
         if (authentication instanceof AnonymousAuthenticationToken) {   // 익명 인증 토큰의 인스턴스라면 0 반환
-            return 0;
+            throw new AnonymousAuthenticationException();
         }
 
         String token = Optional.ofNullable(webRequest.getHeader("Authorization"))

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,6 +15,7 @@ springdoc:
   swagger-ui:
     operations-sorter: method
     tags-sorter: alpha
+    display-request-duration: true
 
 auth:
   kakao:


### PR DESCRIPTION
## PR 내용
- 기존 MultipartFile로 파일을 입력 받아 서버에서 S3로 파일 업로드를 하던 것을 presigned url을 이용해 프론트와 비동기적으로 하도록 수정했습니다
- 해당작업은 파일이 들어가는 Post, Notice, Receipt 3개의 도메인에 대해 작업을 했습니다.
<br>

## PR 세부사항
- 프론트는 사용자가 파일을 첨부하면 presigned url을 서버로 요청합니다. 서버는 바로 url을 반환하고, 파일이 첨부된 게시글, 공지 등이 저장이 되면 s3 객체 url을 서버로 보내고, put 요청으로 이미지를 업로드 합니다
- 따라서 서버가 파일을 업로드 할 때 발생하는 네트워크 지연과, 속도 지연을 감소할 수 있습니다.
- 파일 업로드는 필수가 아니기 때문에 files를 [], 즉 빈 리스트로 보낼 수 있습니다. 또는 생략할 수 있습니다. 하지만 null이 오게되면 내부에서 nullPointException이 발생하기 때문에 유효성 검증을 했습니다.
<br>

## 관련 스크린샷
<img width="605" alt="image" src="https://github.com/user-attachments/assets/388c108c-acd0-4eaa-80f5-1082cdb01c6e">
<img width="876" alt="image" src="https://github.com/user-attachments/assets/3225becb-9024-4eea-b640-01592d00c914">
<img width="613" alt="image" src="https://github.com/user-attachments/assets/3a5c6af7-9c19-4fe7-8d57-a19b5dba5a90">

<br>

## 주의사항
- 최대한 모든 케이스에 대한 dto 유효성 검사를 추가했고 확인해봤는데 이상은 찾지 못했으나, 파일이 없는 경우, null인 경우, 빈 리스트인  경우, fileName이 없는 경우, fileUrl이 없는 경우 등 케이스가 너무 많아서 체크가 안된 부분이 있을 수 있습니다. 관련 부분 봐주시면 감사하겠습니다
- 작업 중에 jwt filter에 오류가 있어 예외를 던지는 방식으로 수정했습니다. 자잘한 오류가 발견되어 차후에 작업할 계획입니다.
- 스웨거에서도 api 응답 속도를 볼 수 있는 설정을 추가했습니다
<br>

## 체크 리스트

- [x] 리뷰어 설정
- [x] Assignee 설정
- [x] Label 설정
- [x] 제목 양식 맞췄나요? (ex. #0 Feat: 기능 추가)
- [x] 변경 사항에 대한 테스트