### PR TITLE
Feat #75 멤버 리스트 반환 수정 및 멤버 상세 조회 추가

### DIFF
--- a/src/main/java/leets/weeth/domain/user/application/dto/response/UserResponseDto.java
+++ b/src/main/java/leets/weeth/domain/user/application/dto/response/UserResponseDto.java
@@ -30,7 +30,12 @@ public class UserResponseDto {
             Role role
     ) {
     }
-
+    public record SummaryResponse(
+            Integer id,
+            String name,
+            List<Integer> cardinals,
+            String department
+    ) {}
     public record AdminResponse(
             Integer id,
             String name,
@@ -50,10 +55,4 @@ public class UserResponseDto {
             LocalDateTime modifiedAt
     ) {
     }
-    public record AdminSummaryResponse(
-            Integer id,
-            String name,
-            List<Integer> cardinals,
-            String department
-    ) {}
 }

--- a/src/main/java/leets/weeth/domain/user/application/dto/response/UserResponseDto.java
+++ b/src/main/java/leets/weeth/domain/user/application/dto/response/UserResponseDto.java
@@ -50,5 +50,10 @@ public class UserResponseDto {
             LocalDateTime modifiedAt
     ) {
     }
-
+    public record AdminSummaryResponse(
+            Integer id,
+            String name,
+            List<Integer> cardinals,
+            String department
+    ) {}
 }

--- a/src/main/java/leets/weeth/domain/user/application/dto/response/UserResponseDto.java
+++ b/src/main/java/leets/weeth/domain/user/application/dto/response/UserResponseDto.java
@@ -55,4 +55,14 @@ public class UserResponseDto {
             LocalDateTime modifiedAt
     ) {
     }
+    public record UserResponse(
+            Integer id,
+            String name,
+            String email,
+            String studentId,
+            String department,
+            List<Integer> cardinals,
+            Position position
+    ) {
+    }
 }

--- a/src/main/java/leets/weeth/domain/user/application/mapper/UserMapper.java
+++ b/src/main/java/leets/weeth/domain/user/application/mapper/UserMapper.java
@@ -1,13 +1,12 @@
 package leets.weeth.domain.user.application.mapper;
 
-import leets.weeth.domain.user.application.dto.response.UserResponseDto.AdminResponse;
-import leets.weeth.domain.user.application.dto.response.UserResponseDto.AdminSummaryResponse;
 import leets.weeth.domain.user.domain.entity.User;
 import leets.weeth.domain.user.domain.entity.enums.Department;
 import org.mapstruct.*;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import static leets.weeth.domain.user.application.dto.request.UserRequestDto.SignUp;
+import static leets.weeth.domain.user.application.dto.response.UserResponseDto.AdminResponse;
 import static leets.weeth.domain.user.application.dto.response.UserResponseDto.Response;
 
 @Mapper(componentModel = MappingConstants.ComponentModel.SPRING, unmappedTargetPolicy = ReportingPolicy.IGNORE)
@@ -22,15 +21,12 @@ public interface UserMapper {
 
     @Mapping(target = "department", expression = "java( toString(user.getDepartment()) )")
     Response to(User user);
-    @Mappings({
-            @Mapping(target = "cardinals", source = "cardinals"),
-            @Mapping(target = "department", expression = "java(user.getDepartment().getValue())")
-    })
-    AdminSummaryResponse toSummary(User user);
+
     @Mappings({
             // 수정: 출석률, 출석 횟수, 결석 횟수 매핑 추후 추가 예정
     })
     AdminResponse toAdminResponse(User user);
+
     default String toString(Department department) {
         return department.getValue();
     }

--- a/src/main/java/leets/weeth/domain/user/application/mapper/UserMapper.java
+++ b/src/main/java/leets/weeth/domain/user/application/mapper/UserMapper.java
@@ -1,5 +1,6 @@
 package leets.weeth.domain.user.application.mapper;
 
+import leets.weeth.domain.user.application.dto.response.UserResponseDto.SummaryResponse;
 import leets.weeth.domain.user.domain.entity.User;
 import leets.weeth.domain.user.domain.entity.enums.Department;
 import org.mapstruct.*;
@@ -26,7 +27,15 @@ public interface UserMapper {
             // 수정: 출석률, 출석 횟수, 결석 횟수 매핑 추후 추가 예정
     })
     AdminResponse toAdminResponse(User user);
+    @Mappings({
+            @Mapping(target = "department", expression = "java( toString(user.getDepartment()) )")
+    })
+    SummaryResponse toSummaryResponse(User user);
 
+    @Mappings({
+            // 상세 데이터 매핑
+    })
+    Response toResponse(User user);
     default String toString(Department department) {
         return department.getValue();
     }

--- a/src/main/java/leets/weeth/domain/user/application/mapper/UserMapper.java
+++ b/src/main/java/leets/weeth/domain/user/application/mapper/UserMapper.java
@@ -1,5 +1,6 @@
 package leets.weeth.domain.user.application.mapper;
 
+import leets.weeth.domain.user.application.dto.response.UserResponseDto.AdminResponse;
 import leets.weeth.domain.user.application.dto.response.UserResponseDto.AdminSummaryResponse;
 import leets.weeth.domain.user.domain.entity.User;
 import leets.weeth.domain.user.domain.entity.enums.Department;
@@ -24,9 +25,12 @@ public interface UserMapper {
     @Mappings({
             @Mapping(target = "cardinals", source = "cardinals"),
             @Mapping(target = "department", expression = "java(user.getDepartment().getValue())")
-            // 수정: 출석률, 출석 횟수, 결석 횟수 매핑 추후 추가 예정
     })
     AdminSummaryResponse toSummary(User user);
+    @Mappings({
+            // 수정: 출석률, 출석 횟수, 결석 횟수 매핑 추후 추가 예정
+    })
+    AdminResponse toAdminResponse(User user);
     default String toString(Department department) {
         return department.getValue();
     }

--- a/src/main/java/leets/weeth/domain/user/application/mapper/UserMapper.java
+++ b/src/main/java/leets/weeth/domain/user/application/mapper/UserMapper.java
@@ -1,6 +1,7 @@
 package leets.weeth.domain.user.application.mapper;
 
 import leets.weeth.domain.user.application.dto.response.UserResponseDto.SummaryResponse;
+import leets.weeth.domain.user.application.dto.response.UserResponseDto.UserResponse;
 import leets.weeth.domain.user.domain.entity.User;
 import leets.weeth.domain.user.domain.entity.enums.Department;
 import org.mapstruct.*;
@@ -35,7 +36,7 @@ public interface UserMapper {
     @Mappings({
             // 상세 데이터 매핑
     })
-    Response toResponse(User user);
+    UserResponse toUserResponse(User user);
     default String toString(Department department) {
         return department.getValue();
     }

--- a/src/main/java/leets/weeth/domain/user/application/mapper/UserMapper.java
+++ b/src/main/java/leets/weeth/domain/user/application/mapper/UserMapper.java
@@ -1,5 +1,6 @@
 package leets.weeth.domain.user.application.mapper;
 
+import leets.weeth.domain.user.application.dto.response.UserResponseDto.AdminSummaryResponse;
 import leets.weeth.domain.user.domain.entity.User;
 import leets.weeth.domain.user.domain.entity.enums.Department;
 import org.mapstruct.*;
@@ -26,7 +27,11 @@ public interface UserMapper {
             // 수정: 출석률, 출석 횟수, 결석 횟수 매핑 추후 추가 예정
     })
     AdminResponse toAdminResponse(User user);
-
+    @Mappings({
+            @Mapping(target = "cardinals", source = "cardinals"),
+            @Mapping(target = "department", expression = "java(user.getDepartment().getValue())")
+    })
+    AdminSummaryResponse toSummary(User user);
     default String toString(Department department) {
         return department.getValue();
     }

--- a/src/main/java/leets/weeth/domain/user/application/mapper/UserMapper.java
+++ b/src/main/java/leets/weeth/domain/user/application/mapper/UserMapper.java
@@ -7,7 +7,6 @@ import org.mapstruct.*;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import static leets.weeth.domain.user.application.dto.request.UserRequestDto.SignUp;
-import static leets.weeth.domain.user.application.dto.response.UserResponseDto.AdminResponse;
 import static leets.weeth.domain.user.application.dto.response.UserResponseDto.Response;
 
 @Mapper(componentModel = MappingConstants.ComponentModel.SPRING, unmappedTargetPolicy = ReportingPolicy.IGNORE)
@@ -22,14 +21,10 @@ public interface UserMapper {
 
     @Mapping(target = "department", expression = "java( toString(user.getDepartment()) )")
     Response to(User user);
-
-    @Mappings({
-            // 수정: 출석률, 출석 횟수, 결석 횟수 매핑 추후 추가 예정
-    })
-    AdminResponse toAdminResponse(User user);
     @Mappings({
             @Mapping(target = "cardinals", source = "cardinals"),
             @Mapping(target = "department", expression = "java(user.getDepartment().getValue())")
+            // 수정: 출석률, 출석 횟수, 결석 횟수 매핑 추후 추가 예정
     })
     AdminSummaryResponse toSummary(User user);
     default String toString(Department department) {

--- a/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCase.java
+++ b/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCase.java
@@ -19,7 +19,11 @@ public interface UserUseCase {
 
     Map<Integer, List<Response>> findAll();
 
+    Map<Integer, List<SummaryResponse>> findAllUser();
+
     List<AdminResponse> findAllByAdmin();
+
+    Response findUserDetails(Long userId);
 
     void update(Update dto, Long userId);
 

--- a/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCase.java
+++ b/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCase.java
@@ -23,7 +23,7 @@ public interface UserUseCase {
 
     List<AdminResponse> findAllByAdmin();
 
-    Response findUserDetails(Long userId);
+    UserResponse findUserDetails(Long userId);
 
     void update(Update dto, Long userId);
 

--- a/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCase.java
+++ b/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCase.java
@@ -21,6 +21,8 @@ public interface UserUseCase {
 
     List<AdminSummaryResponse> findAllByAdmin();
 
+    AdminResponse findUserDetails(Long userId);
+
     void update(Update dto, Long userId);
 
     void accept(Long userId);

--- a/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCase.java
+++ b/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCase.java
@@ -19,7 +19,7 @@ public interface UserUseCase {
 
     Map<Integer, List<Response>> findAll();
 
-    List<AdminResponse> findAllByAdmin();
+    List<AdminSummaryResponse> findAllByAdmin();
 
     void update(Update dto, Long userId);
 

--- a/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCase.java
+++ b/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCase.java
@@ -19,9 +19,7 @@ public interface UserUseCase {
 
     Map<Integer, List<Response>> findAll();
 
-    List<AdminSummaryResponse> findAllByAdmin();
-
-    AdminResponse findUserDetails(Long userId);
+    List<AdminResponse> findAllByAdmin();
 
     void update(Update dto, Long userId);
 

--- a/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCaseImpl.java
@@ -98,6 +98,7 @@ public class UserUseCaseImpl implements UserUseCase {
     @Override
     public Map<Integer, List<Response>> findAll() {
         return userGetService.findAllByStatus(ACTIVE).stream()
+                .filter(user -> !"admin".equals(user.getName()))
                 .flatMap(user -> Stream.concat(
                         user.getCardinals().stream()
                                 .map(cardinal -> new AbstractMap.SimpleEntry<>(cardinal, mapper.to(user))), // 기수별 Map
@@ -108,9 +109,9 @@ public class UserUseCaseImpl implements UserUseCase {
     }
 
     @Override
-    public List<AdminResponse> findAllByAdmin() {
+    public List<AdminSummaryResponse> findAllByAdmin() {
         return userGetService.findAll().stream()
-                .map(mapper::toAdminResponse)
+                .map(mapper::toSummary)
                 .toList();
     }
 

--- a/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCaseImpl.java
@@ -6,7 +6,6 @@ import leets.weeth.domain.schedule.domain.entity.Meeting;
 import leets.weeth.domain.schedule.domain.service.MeetingGetService;
 import leets.weeth.domain.user.application.exception.StudentIdExistsException;
 import leets.weeth.domain.user.application.exception.TelExistsException;
-import leets.weeth.domain.user.application.exception.UserNotFoundException;
 import leets.weeth.domain.user.application.mapper.UserMapper;
 import leets.weeth.domain.user.domain.entity.User;
 import leets.weeth.domain.user.domain.service.UserDeleteService;
@@ -34,6 +33,7 @@ import static leets.weeth.domain.user.application.dto.response.UserResponseDto.*
 import static leets.weeth.domain.user.domain.entity.enums.LoginStatus.LOGIN;
 import static leets.weeth.domain.user.domain.entity.enums.LoginStatus.REGISTER;
 import static leets.weeth.domain.user.domain.entity.enums.Status.ACTIVE;
+
 @Service
 @RequiredArgsConstructor
 public class UserUseCaseImpl implements UserUseCase {
@@ -98,7 +98,6 @@ public class UserUseCaseImpl implements UserUseCase {
     @Override
     public Map<Integer, List<Response>> findAll() {
         return userGetService.findAllByStatus(ACTIVE).stream()
-                .filter(user -> !"admin".equals(user.getName()))
                 .flatMap(user -> Stream.concat(
                         user.getCardinals().stream()
                                 .map(cardinal -> new AbstractMap.SimpleEntry<>(cardinal, mapper.to(user))), // 기수별 Map
@@ -109,19 +108,12 @@ public class UserUseCaseImpl implements UserUseCase {
     }
 
     @Override
-    public List<AdminSummaryResponse> findAllByAdmin() {
+    public List<AdminResponse> findAllByAdmin() {
         return userGetService.findAll().stream()
-                .map(mapper::toSummary)
+                .map(mapper::toAdminResponse)
                 .toList();
     }
-    @Override
-    public AdminResponse findUserDetails(Long userId) {
-        User user = userGetService.find(userId);
-        if (user == null) {
-            throw new UserNotFoundException();
-        }
-        return mapper.toAdminResponse(user);
-    }
+
     @Override
     public Response find(Long userId) {
         return mapper.to(userGetService.find(userId));

--- a/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCaseImpl.java
@@ -6,6 +6,7 @@ import leets.weeth.domain.schedule.domain.entity.Meeting;
 import leets.weeth.domain.schedule.domain.service.MeetingGetService;
 import leets.weeth.domain.user.application.exception.StudentIdExistsException;
 import leets.weeth.domain.user.application.exception.TelExistsException;
+import leets.weeth.domain.user.application.exception.UserNotFoundException;
 import leets.weeth.domain.user.application.mapper.UserMapper;
 import leets.weeth.domain.user.domain.entity.User;
 import leets.weeth.domain.user.domain.service.UserDeleteService;
@@ -33,7 +34,6 @@ import static leets.weeth.domain.user.application.dto.response.UserResponseDto.*
 import static leets.weeth.domain.user.domain.entity.enums.LoginStatus.LOGIN;
 import static leets.weeth.domain.user.domain.entity.enums.LoginStatus.REGISTER;
 import static leets.weeth.domain.user.domain.entity.enums.Status.ACTIVE;
-
 @Service
 @RequiredArgsConstructor
 public class UserUseCaseImpl implements UserUseCase {
@@ -114,7 +114,14 @@ public class UserUseCaseImpl implements UserUseCase {
                 .map(mapper::toSummary)
                 .toList();
     }
-
+    @Override
+    public AdminResponse findUserDetails(Long userId) {
+        User user = userGetService.find(userId);
+        if (user == null) {
+            throw new UserNotFoundException();
+        }
+        return mapper.toAdminResponse(user);
+    }
     @Override
     public Response find(Long userId) {
         return mapper.to(userGetService.find(userId));

--- a/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCaseImpl.java
@@ -6,7 +6,6 @@ import leets.weeth.domain.schedule.domain.entity.Meeting;
 import leets.weeth.domain.schedule.domain.service.MeetingGetService;
 import leets.weeth.domain.user.application.exception.StudentIdExistsException;
 import leets.weeth.domain.user.application.exception.TelExistsException;
-import leets.weeth.domain.user.application.exception.UserNotFoundException;
 import leets.weeth.domain.user.application.mapper.UserMapper;
 import leets.weeth.domain.user.domain.entity.User;
 import leets.weeth.domain.user.domain.service.UserDeleteService;
@@ -129,9 +128,6 @@ public class UserUseCaseImpl implements UserUseCase {
     @Override
     public Response findUserDetails(Long userId) {
         User user = userGetService.find(userId);
-        if (user == null) {
-            throw new UserNotFoundException();
-        }
         return mapper.toResponse(user);
     }
     @Override

--- a/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCaseImpl.java
@@ -109,10 +109,10 @@ public class UserUseCaseImpl implements UserUseCase {
     @Override
     public Map<Integer, List<SummaryResponse>> findAllUser() {
         return userGetService.findAllByStatus(ACTIVE).stream()
-                .flatMap(user -> Stream.concat(
-                        user.getCardinals().stream()
-                                .map(cardinal -> new AbstractMap.SimpleEntry<>(cardinal, mapper.toSummaryResponse(user))), // 기수별 Map
-                        Stream.of(new AbstractMap.SimpleEntry<>(0, mapper.toSummaryResponse(user))) // 모든 기수는 cardinal 0에 저장
+                .map(user -> new AbstractMap.SimpleEntry<>(user.getCardinals(), mapper.toSummaryResponse(user)))
+                .flatMap(entry -> Stream.concat(
+                        entry.getKey().stream().map(cardinal -> new AbstractMap.SimpleEntry<>(cardinal, entry.getValue())), // 기수별 Map
+                        Stream.of(new AbstractMap.SimpleEntry<>(0, entry.getValue())) // 모든 기수는 cardinal 0에 저장
                 ))
                 .collect(Collectors.groupingBy(
                         Map.Entry::getKey, // key = 기수

--- a/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCaseImpl.java
@@ -126,9 +126,9 @@ public class UserUseCaseImpl implements UserUseCase {
                 .toList();
     }
     @Override
-    public Response findUserDetails(Long userId) {
+    public UserResponse findUserDetails(Long userId) {
         User user = userGetService.find(userId);
-        return mapper.toResponse(user);
+        return mapper.toUserResponse(user);
     }
     @Override
     public Response find(Long userId) {

--- a/src/main/java/leets/weeth/domain/user/presentation/ResponseMessage.java
+++ b/src/main/java/leets/weeth/domain/user/presentation/ResponseMessage.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 public enum ResponseMessage {
     // UserAdminController 관련
     USER_FIND_ALL_SUCCESS("관리자가 모든 회원 정보를 성공적으로 조회했습니다."),
+    USER_DETAILS_SUCCESS("특정 회원의 상세 정보를 성공적으로 조회했습니다."),
     USER_ACCEPT_SUCCESS("회원 가입 승인이 성공적으로 처리되었습니다."),
     USER_BAN_SUCCESS("회원이 성공적으로 차단되었습니다."),
     USER_ROLE_UPDATE_SUCCESS("회원의 역할이 성공적으로 수정되었습니다."),

--- a/src/main/java/leets/weeth/domain/user/presentation/UserAdminController.java
+++ b/src/main/java/leets/weeth/domain/user/presentation/UserAdminController.java
@@ -2,6 +2,7 @@ package leets.weeth.domain.user.presentation;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import leets.weeth.domain.user.application.dto.response.UserResponseDto.AdminResponse;
 import leets.weeth.domain.user.application.dto.response.UserResponseDto.AdminSummaryResponse;
 import leets.weeth.domain.user.application.usecase.UserUseCase;
 import leets.weeth.global.common.response.CommonResponse;
@@ -25,7 +26,14 @@ public class UserAdminController {
     public CommonResponse<List<AdminSummaryResponse>> findAll() {
         return CommonResponse.createSuccess(USER_FIND_ALL_SUCCESS.getMessage(), userUseCase.findAllByAdmin());
     }
-
+    @GetMapping("/details")
+    @Operation(summary = "어드민용 특정 멤버 상세 조회")
+    public CommonResponse<AdminResponse> findUserDetails(@RequestParam Long userId) {
+        return CommonResponse.createSuccess(
+                USER_DETAILS_SUCCESS.getMessage(),
+                userUseCase.findUserDetails(userId)
+        );
+    }
     @PatchMapping
     @Operation(summary="가입 신청 승인")
     public CommonResponse<Void> accept(@RequestParam Long userId) {

--- a/src/main/java/leets/weeth/domain/user/presentation/UserAdminController.java
+++ b/src/main/java/leets/weeth/domain/user/presentation/UserAdminController.java
@@ -10,7 +10,6 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-import static leets.weeth.domain.user.application.dto.response.UserResponseDto.AdminResponse;
 import static leets.weeth.domain.user.presentation.ResponseMessage.*;
 
 @Tag(name = "UserAdminController", description = "유저 관련 어드민 컨트롤러")

--- a/src/main/java/leets/weeth/domain/user/presentation/UserAdminController.java
+++ b/src/main/java/leets/weeth/domain/user/presentation/UserAdminController.java
@@ -2,8 +2,6 @@ package leets.weeth.domain.user.presentation;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import leets.weeth.domain.user.application.dto.response.UserResponseDto.AdminResponse;
-import leets.weeth.domain.user.application.dto.response.UserResponseDto.AdminSummaryResponse;
 import leets.weeth.domain.user.application.usecase.UserUseCase;
 import leets.weeth.global.common.response.CommonResponse;
 import lombok.RequiredArgsConstructor;
@@ -11,6 +9,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+import static leets.weeth.domain.user.application.dto.response.UserResponseDto.AdminResponse;
 import static leets.weeth.domain.user.presentation.ResponseMessage.*;
 
 @Tag(name = "UserAdminController", description = "유저 관련 어드민 컨트롤러")
@@ -23,17 +22,10 @@ public class UserAdminController {
 
     @GetMapping("/all")
     @Operation(summary="어드민용 회원 조회")
-    public CommonResponse<List<AdminSummaryResponse>> findAll() {
+    public CommonResponse<List<AdminResponse>> findAll() {
         return CommonResponse.createSuccess(USER_FIND_ALL_SUCCESS.getMessage(), userUseCase.findAllByAdmin());
     }
-    @GetMapping("/details")
-    @Operation(summary = "어드민용 특정 멤버 상세 조회")
-    public CommonResponse<AdminResponse> findUserDetails(@RequestParam Long userId) {
-        return CommonResponse.createSuccess(
-                USER_DETAILS_SUCCESS.getMessage(),
-                userUseCase.findUserDetails(userId)
-        );
-    }
+
     @PatchMapping
     @Operation(summary="가입 신청 승인")
     public CommonResponse<Void> accept(@RequestParam Long userId) {

--- a/src/main/java/leets/weeth/domain/user/presentation/UserAdminController.java
+++ b/src/main/java/leets/weeth/domain/user/presentation/UserAdminController.java
@@ -2,6 +2,7 @@ package leets.weeth.domain.user.presentation;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import leets.weeth.domain.user.application.dto.response.UserResponseDto.AdminSummaryResponse;
 import leets.weeth.domain.user.application.usecase.UserUseCase;
 import leets.weeth.global.common.response.CommonResponse;
 import lombok.RequiredArgsConstructor;
@@ -22,7 +23,7 @@ public class UserAdminController {
 
     @GetMapping("/all")
     @Operation(summary="어드민용 회원 조회")
-    public CommonResponse<List<AdminResponse>> findAll() {
+    public CommonResponse<List<AdminSummaryResponse>> findAll() {
         return CommonResponse.createSuccess(USER_FIND_ALL_SUCCESS.getMessage(), userUseCase.findAllByAdmin());
     }
 

--- a/src/main/java/leets/weeth/domain/user/presentation/UserController.java
+++ b/src/main/java/leets/weeth/domain/user/presentation/UserController.java
@@ -66,8 +66,7 @@ public class UserController {
     @Operation(summary = "특정 멤버 상세 조회")
     public CommonResponse<Response> findUser(@RequestParam Long userId) {
         return CommonResponse.createSuccess(
-                USER_DETAILS_SUCCESS.getMessage(),
-                userUseCase.findUserDetails(userId)
+                USER_DETAILS_SUCCESS.getMessage(), userUseCase.findUserDetails(userId)
         );
     }
     @GetMapping

--- a/src/main/java/leets/weeth/domain/user/presentation/UserController.java
+++ b/src/main/java/leets/weeth/domain/user/presentation/UserController.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import leets.weeth.domain.user.application.dto.response.UserResponseDto.SummaryResponse;
+import leets.weeth.domain.user.application.dto.response.UserResponseDto.UserResponse;
 import leets.weeth.domain.user.application.usecase.UserManageUseCase;
 import leets.weeth.domain.user.application.usecase.UserUseCase;
 import leets.weeth.domain.user.domain.service.UserGetService;
@@ -64,7 +65,7 @@ public class UserController {
     }
     @GetMapping("/details")
     @Operation(summary = "특정 멤버 상세 조회")
-    public CommonResponse<Response> findUser(@RequestParam Long userId) {
+    public CommonResponse<UserResponse> findUser(@RequestParam Long userId) {
         return CommonResponse.createSuccess(
                 USER_DETAILS_SUCCESS.getMessage(), userUseCase.findUserDetails(userId)
         );

--- a/src/main/java/leets/weeth/domain/user/presentation/UserController.java
+++ b/src/main/java/leets/weeth/domain/user/presentation/UserController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
+import leets.weeth.domain.user.application.dto.response.UserResponseDto.SummaryResponse;
 import leets.weeth.domain.user.application.usecase.UserManageUseCase;
 import leets.weeth.domain.user.application.usecase.UserUseCase;
 import leets.weeth.domain.user.domain.service.UserGetService;
@@ -58,10 +59,17 @@ public class UserController {
 
     @GetMapping("/all")
     @Operation(summary="동아리 멤버 전체 조회(전체/기수별)")
-    public CommonResponse<Map<Integer, List<Response>>> findAll() {
-        return CommonResponse.createSuccess(USER_FIND_ALL_SUCCESS.getMessage(), userUseCase.findAll());
+    public CommonResponse<Map<Integer, List<SummaryResponse>>> findAllUser() {
+        return CommonResponse.createSuccess(USER_FIND_ALL_SUCCESS.getMessage(), userUseCase.findAllUser());
     }
-
+    @GetMapping("/details")
+    @Operation(summary = "특정 멤버 상세 조회")
+    public CommonResponse<Response> findUser(@RequestParam Long userId) {
+        return CommonResponse.createSuccess(
+                USER_DETAILS_SUCCESS.getMessage(),
+                userUseCase.findUserDetails(userId)
+        );
+    }
     @GetMapping
     @Operation(summary="내 정보 조회")
     public CommonResponse<Response> find(@Parameter(hidden = true) @CurrentUser Long userId) {


### PR DESCRIPTION
## PR 내용
멤버 리스트 조회 API
멤버 상세 조회 API
<br>

## PR 세부사항
기존 API를 수정하여 멤버 리스트를 반환할 때 데이터 양을 축소하였습니다
SummaryResponse를 통해 userId, name, cardinals, department 만 반환하도록 수정했습니다
GET으로 축소된 멤버 리스트 반환하는 내용 구현하였고, 
멤버 상세 조회 API 내용도 구현하였습니다
기존 dto에 있는 Response 내용을 참조하기 보다는
새로운 UserResponse를 생성하여 멤버 상세 조회 API시 반환하도록 하였습니다
<br>

## 관련 스크린샷
<img width="1137" alt="image" src="https://github.com/user-attachments/assets/54c95d24-73b7-4503-9d8a-e3eaa7cccb2a">


<br>

## 주의사항
로직은 이전에 adminResponse 축소할때와 동일하게 진행 하였으나,
UserAdminController 반환 리스트가 아닌 UserController의 동아리 멤버 전체조회(전체/기수별) api를 올바르게 수정했습니다.
기존 findAll메서드와 AdminResponse는 그대로 유지하기 위해서 새로운 findAllUser 메서드를 추가하여 구현했습니다

<br>

## 체크 리스트

- [x] 리뷰어 설정
- [x] Assignee 설정
- [x] Label 설정
- [x] 제목 양식 맞췄나요? (ex. #0 Feat: 기능 추가)
- [x] 변경 사항에 대한 테스트