### PR TITLE
Refactor #76 소셜 로그인을 위한 더미 패스워드 도입

### DIFF
--- a/src/main/java/leets/weeth/global/auth/jwt/filter/JwtAuthenticationProcessingFilter.java
+++ b/src/main/java/leets/weeth/global/auth/jwt/filter/JwtAuthenticationProcessingFilter.java
@@ -19,13 +19,13 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
-import java.util.TooManyListenersException;
 
 @RequiredArgsConstructor
 @Slf4j
 public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
 
     private static final String NO_CHECK_URL = "/api/v1/login";
+    private final String DUMMY = "DUMMY_PASSWORD";
 
     private final JwtProvider jwtProvider;
     private final JwtService jwtService;
@@ -55,11 +55,10 @@ public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
     }
 
     public void saveAuthentication(User myUser) {
-        String password = myUser.getPassword();
 
         UserDetails userDetailsUser = org.springframework.security.core.userdetails.User.builder()
                 .username(myUser.getEmail())
-                .password(password)
+                .password(DUMMY)
                 .roles(myUser.getRole().name())
                 .build();
 


### PR DESCRIPTION
## PR 내용
- 기존 로그인을 사용하지 않기로 했으며, 소셜 로그인을 통한 인증시 password가 없다면 인증 오류가 발생하기 때문에 임시로 더미 패스워드 조치를 했습니다
<br>

## PR 세부사항
- 인증 객체 생성을 위한 userDetails 객체 생성시 password에 더미 패스워드를 전달하는 방식으로 임시 조치
- 기존 로그인이 폐기됐지 때문에, JWT 필터를 소셜 로그인에 맞는, 즉 JWT에 의존하는 방식으로 수정할 예정
- 로그인시, 그리고 매 요청시 userRepository에서 user를 조회해 role을 가져오고 있기 때문에, 이 방식은 지연이 크다고 생각해 차후 작업에서 수정할 계획입니다
- -> role을 jwt에 담아서 확인하도록 하겠습니다
<br>

## 관련 스크린샷
X
<br>

## 주의사항
- 현재 kakao social login redirect uri가 노션-정보-환경변수에 작성되어 구현되어 있으니, 서버 개발자 분들은 로그인 테스트 시 참고 바랍니다!
<br>

## 체크 리스트

- [x] 리뷰어 설정
- [x] Assignee 설정
- [x] Label 설정
- [x] 제목 양식 맞췄나요? (ex. #0 Feat: 기능 추가)
- [x] 변경 사항에 대한 테스트