### PR TITLE
Refactor #80 user entity에서 refreshToken 제거

### DIFF
--- a/src/main/java/leets/weeth/domain/user/domain/entity/User.java
+++ b/src/main/java/leets/weeth/domain/user/domain/entity/User.java
@@ -61,8 +61,6 @@ public class User extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private Role role;
 
-    private String refreshToken;
-
     private Integer attendanceCount;
 
     private Integer absenceCount;
@@ -85,10 +83,6 @@ public class User extends BaseEntity {
         absenceCount = 0;
         attendanceRate = 0;
         penaltyCount = 0;
-    }
-
-    public void updateRefreshToken(String updatedToken) {
-        this.refreshToken = updatedToken;
     }
 
     public void leave() {

--- a/src/main/java/leets/weeth/domain/user/domain/repository/UserRepository.java
+++ b/src/main/java/leets/weeth/domain/user/domain/repository/UserRepository.java
@@ -19,6 +19,4 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByTelAndIdIsNot(String tel, Long id);
 
     List<User> findAllByStatusOrderByName(Status status);
-
-    Optional<User> findByRefreshToken(String refreshToken);
 }


### PR DESCRIPTION
## PR 내용
-  refreshToken의 관리를 레디스로 이전함에 따라 User entity에서 해당 컬럼을 제거했습니다
<br>

## PR 세부사항
- 이하동문
<br>

## 관련 스크린샷
x
<br>

## 주의사항
- 작업 중이신 로컬 DB와의 동기화를 해주세요
<br>

## 체크 리스트

- [x] 리뷰어 설정
- [x] Assignee 설정
- [x] Label 설정
- [x] 제목 양식 맞췄나요? (ex. #0 Feat: 기능 추가)
- [x] 변경 사항에 대한 테스트