### PR TITLE
Refactor#82 slice를 이용한 무한 스크롤

### DIFF
--- a/src/main/java/leets/weeth/domain/board/application/exception/PageNotFoundException.java
+++ b/src/main/java/leets/weeth/domain/board/application/exception/PageNotFoundException.java
@@ -1,0 +1,10 @@
+package leets.weeth.domain.board.application.exception;
+
+import leets.weeth.global.common.exception.BusinessLogicException;
+
+public class PageNotFoundException extends BusinessLogicException {
+    public PageNotFoundException() {
+        super(404, "존재하지 않는 페이지입니다.");
+
+    }
+}

--- a/src/main/java/leets/weeth/domain/board/application/usecase/NoticeUsecase.java
+++ b/src/main/java/leets/weeth/domain/board/application/usecase/NoticeUsecase.java
@@ -2,9 +2,8 @@ package leets.weeth.domain.board.application.usecase;
 
 import leets.weeth.domain.board.application.dto.NoticeDTO;
 import leets.weeth.domain.user.application.exception.UserNotMatchException;
-import org.springframework.web.multipart.MultipartFile;
+import org.springframework.data.domain.Slice;
 
-import java.util.List;
 
 public interface NoticeUsecase {
 
@@ -12,7 +11,7 @@ public interface NoticeUsecase {
 
     NoticeDTO.Response findNotice(Long noticeId);
 
-    List<NoticeDTO.ResponseAll> findNotices(Long noticeId, Integer count);
+    Slice<NoticeDTO.ResponseAll> findNotices(Integer pageNumber, Integer pageSize);
 
     void update(Long noticeId, NoticeDTO.Update dto, Long userId) throws UserNotMatchException;
 

--- a/src/main/java/leets/weeth/domain/board/application/usecase/NoticeUsecase.java
+++ b/src/main/java/leets/weeth/domain/board/application/usecase/NoticeUsecase.java
@@ -11,7 +11,7 @@ public interface NoticeUsecase {
 
     NoticeDTO.Response findNotice(Long noticeId);
 
-    Slice<NoticeDTO.ResponseAll> findNotices(Integer pageNumber, Integer pageSize);
+    Slice<NoticeDTO.ResponseAll> findNotices(int pageNumber, int pageSize);
 
     void update(Long noticeId, NoticeDTO.Update dto, Long userId) throws UserNotMatchException;
 

--- a/src/main/java/leets/weeth/domain/board/application/usecase/NoticeUsecaseImpl.java
+++ b/src/main/java/leets/weeth/domain/board/application/usecase/NoticeUsecaseImpl.java
@@ -1,6 +1,7 @@
 package leets.weeth.domain.board.application.usecase;
 
 import leets.weeth.domain.board.application.dto.NoticeDTO;
+import leets.weeth.domain.board.application.exception.PageNotFoundException;
 import leets.weeth.domain.board.application.mapper.NoticeMapper;
 import leets.weeth.domain.board.domain.entity.Notice;
 import leets.weeth.domain.board.domain.service.NoticeDeleteService;
@@ -71,7 +72,9 @@ public class NoticeUsecaseImpl implements NoticeUsecase {
 
     @Override
     public Slice<NoticeDTO.ResponseAll> findNotices(Integer pageNumber, Integer pageSize) {
-
+        if (pageNumber < 0) {
+            throw new PageNotFoundException();
+        }
         Pageable pageable = PageRequest.of(pageNumber, pageSize, Sort.by(Sort.Direction.DESC, "id")); // id를 기준으로 내림차순
         Slice<Notice> notices = noticeFindService.findRecentNotices(pageable);
 

--- a/src/main/java/leets/weeth/domain/board/application/usecase/NoticeUsecaseImpl.java
+++ b/src/main/java/leets/weeth/domain/board/application/usecase/NoticeUsecaseImpl.java
@@ -71,7 +71,7 @@ public class NoticeUsecaseImpl implements NoticeUsecase {
     }
 
     @Override
-    public Slice<NoticeDTO.ResponseAll> findNotices(Integer pageNumber, Integer pageSize) {
+    public Slice<NoticeDTO.ResponseAll> findNotices(int pageNumber, int pageSize) {
         if (pageNumber < 0) {
             throw new PageNotFoundException();
         }

--- a/src/main/java/leets/weeth/domain/board/application/usecase/NoticeUsecaseImpl.java
+++ b/src/main/java/leets/weeth/domain/board/application/usecase/NoticeUsecaseImpl.java
@@ -1,7 +1,6 @@
 package leets.weeth.domain.board.application.usecase;
 
 import leets.weeth.domain.board.application.dto.NoticeDTO;
-import leets.weeth.domain.board.application.exception.NoticeNotFoundException;
 import leets.weeth.domain.board.application.mapper.NoticeMapper;
 import leets.weeth.domain.board.domain.entity.Notice;
 import leets.weeth.domain.board.domain.service.NoticeDeleteService;
@@ -21,6 +20,8 @@ import leets.weeth.domain.user.domain.service.UserGetService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -69,27 +70,12 @@ public class NoticeUsecaseImpl implements NoticeUsecase {
     }
 
     @Override
-    public List<NoticeDTO.ResponseAll> findNotices(Long noticeId, Integer count) {
+    public Slice<NoticeDTO.ResponseAll> findNotices(Integer pageNumber, Integer pageSize) {
 
-        Long finalNoticeId = noticeFindService.findFinalNoticeId();
+        Pageable pageable = PageRequest.of(pageNumber, pageSize, Sort.by(Sort.Direction.DESC, "id")); // id를 기준으로 내림차순
+        Slice<Notice> notices = noticeFindService.findRecentNotices(pageable);
 
-        // 첫번째 요청인 경우
-        if (noticeId == null) {
-            noticeId = finalNoticeId + 1;
-        }
-
-        // postId가 1 이하이거나 최대값보다 클경우
-        if (noticeId < 1 || noticeId > finalNoticeId + 1) {
-            throw new NoticeNotFoundException();
-        }
-
-        Pageable pageable = PageRequest.of(0, count); // 첫 페이지, 페이지당 15개 게시글
-
-        List<Notice> notices = noticeFindService.findRecentNotices(noticeId, pageable);
-
-        return notices.stream()
-                .map(mapper::toAll)
-                .toList();
+        return notices.map(mapper::toAll);
     }
 
     @Override

--- a/src/main/java/leets/weeth/domain/board/application/usecase/PostUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/board/application/usecase/PostUseCaseImpl.java
@@ -1,7 +1,7 @@
 package leets.weeth.domain.board.application.usecase;
 
 import leets.weeth.domain.board.application.dto.PostDTO;
-import leets.weeth.domain.board.application.exception.PostNotFoundException;
+import leets.weeth.domain.board.application.exception.PageNotFoundException;
 import leets.weeth.domain.board.application.mapper.PostMapper;
 import leets.weeth.domain.board.domain.entity.Post;
 import leets.weeth.domain.board.domain.service.PostDeleteService;
@@ -69,7 +69,9 @@ public class PostUseCaseImpl implements PostUsecase {
 
     @Override
     public Slice<PostDTO.ResponseAll> findPosts(Integer pageNumber, Integer pageSize) {
-
+        if (pageNumber < 0) {
+            throw new PageNotFoundException();
+        }
         Pageable pageable = PageRequest.of(pageNumber, pageSize, Sort.by(Sort.Direction.DESC, "id"));
         Slice<Post> recentPosts = postFindService.findRecentPosts(pageable);
 

--- a/src/main/java/leets/weeth/domain/board/application/usecase/PostUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/board/application/usecase/PostUseCaseImpl.java
@@ -19,8 +19,7 @@ import leets.weeth.domain.user.application.exception.UserNotMatchException;
 import leets.weeth.domain.user.domain.entity.User;
 import leets.weeth.domain.user.domain.service.UserGetService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -69,27 +68,12 @@ public class PostUseCaseImpl implements PostUsecase {
     }
 
     @Override
-    public List<PostDTO.ResponseAll> findPosts(Long postId, Integer count) {
+    public Slice<PostDTO.ResponseAll> findPosts(Integer pageNumber, Integer pageSize) {
 
-        Long finalPostId = postFindService.findFinalPostId();
+        Pageable pageable = PageRequest.of(pageNumber, pageSize, Sort.by(Sort.Direction.DESC, "id"));
+        Slice<Post> recentPosts = postFindService.findRecentPosts(pageable);
 
-        // 첫번째 요청인 경우
-        if (postId == null) {
-            postId = finalPostId + 1;
-        }
-
-        // postId가 1 이하이거나 최대값보다 클경우
-        if (postId < 1 || postId > finalPostId + 1) {
-            throw new PostNotFoundException();
-        }
-
-        Pageable pageable = PageRequest.of(0, count); // 첫 페이지, 페이지당 15개 게시글
-
-        List<Post> posts = postFindService.findRecentPosts(postId, pageable);
-
-        return posts.stream()
-                .map(mapper::toAll)
-                .toList();
+        return recentPosts.map(post -> mapper.toAll(post));
     }
 
     @Override

--- a/src/main/java/leets/weeth/domain/board/application/usecase/PostUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/board/application/usecase/PostUseCaseImpl.java
@@ -68,7 +68,7 @@ public class PostUseCaseImpl implements PostUsecase {
     }
 
     @Override
-    public Slice<PostDTO.ResponseAll> findPosts(Integer pageNumber, Integer pageSize) {
+    public Slice<PostDTO.ResponseAll> findPosts(int pageNumber, int pageSize) {
         if (pageNumber < 0) {
             throw new PageNotFoundException();
         }

--- a/src/main/java/leets/weeth/domain/board/application/usecase/PostUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/board/application/usecase/PostUseCaseImpl.java
@@ -73,7 +73,7 @@ public class PostUseCaseImpl implements PostUsecase {
         Pageable pageable = PageRequest.of(pageNumber, pageSize, Sort.by(Sort.Direction.DESC, "id"));
         Slice<Post> recentPosts = postFindService.findRecentPosts(pageable);
 
-        return recentPosts.map(post -> mapper.toAll(post));
+        return recentPosts.map(mapper::toAll);
     }
 
     @Override

--- a/src/main/java/leets/weeth/domain/board/application/usecase/PostUsecase.java
+++ b/src/main/java/leets/weeth/domain/board/application/usecase/PostUsecase.java
@@ -2,9 +2,8 @@ package leets.weeth.domain.board.application.usecase;
 
 import leets.weeth.domain.board.application.dto.PostDTO;
 import leets.weeth.domain.user.application.exception.UserNotMatchException;
-import org.springframework.web.multipart.MultipartFile;
+import org.springframework.data.domain.Slice;
 
-import java.util.List;
 
 public interface PostUsecase {
 
@@ -12,7 +11,7 @@ public interface PostUsecase {
 
     PostDTO.Response findPost(Long postId);
 
-    List<PostDTO.ResponseAll> findPosts(Long postId, Integer count);
+    Slice<PostDTO.ResponseAll> findPosts(Integer pageNumber, Integer pageSize);
 
     void update(Long postId, PostDTO.Update dto, Long userId) throws UserNotMatchException;
 

--- a/src/main/java/leets/weeth/domain/board/application/usecase/PostUsecase.java
+++ b/src/main/java/leets/weeth/domain/board/application/usecase/PostUsecase.java
@@ -11,7 +11,7 @@ public interface PostUsecase {
 
     PostDTO.Response findPost(Long postId);
 
-    Slice<PostDTO.ResponseAll> findPosts(Integer pageNumber, Integer pageSize);
+    Slice<PostDTO.ResponseAll> findPosts(int pageNumber, int pageSize);
 
     void update(Long postId, PostDTO.Update dto, Long userId) throws UserNotMatchException;
 

--- a/src/main/java/leets/weeth/domain/board/domain/repository/NoticeRepository.java
+++ b/src/main/java/leets/weeth/domain/board/domain/repository/NoticeRepository.java
@@ -1,21 +1,13 @@
 package leets.weeth.domain.board.domain.repository;
 
 import leets.weeth.domain.board.domain.entity.Notice;
-import leets.weeth.domain.board.domain.entity.Post;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
-import java.util.List;
-import java.util.Optional;
 
 public interface NoticeRepository extends JpaRepository<Notice, Long> {
 
-    @Query("SELECT MAX(n.id) FROM Notice n")
-    Optional<Long>  findLastId();
-
-    @Query("SELECT n FROM Notice n WHERE n.id < :maxNoticeId ORDER BY n.id DESC")
-    List<Notice> findRecentNotices(@Param("maxNoticeId") Long maxNoticeId, Pageable pageable);
+    Slice<Notice> findPageBy(Pageable page);
 
 }

--- a/src/main/java/leets/weeth/domain/board/domain/repository/PostRepository.java
+++ b/src/main/java/leets/weeth/domain/board/domain/repository/PostRepository.java
@@ -1,20 +1,12 @@
 package leets.weeth.domain.board.domain.repository;
 
-import leets.weeth.domain.board.domain.entity.Notice;
 import leets.weeth.domain.board.domain.entity.Post;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
-import java.util.List;
-import java.util.Optional;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
 
-    @Query("SELECT MAX(p.id) FROM Post p")
-    Optional<Long> findLastId();
-
-    @Query("SELECT p FROM Post p WHERE p.id < :maxPostId ORDER BY p.id DESC")
-    List<Post> findRecentPosts(@Param("maxPostId") Long maxPostId, Pageable pageable);
+    Slice<Post> findPageBy(Pageable page);
 }

--- a/src/main/java/leets/weeth/domain/board/domain/service/NoticeFindService.java
+++ b/src/main/java/leets/weeth/domain/board/domain/service/NoticeFindService.java
@@ -5,6 +5,7 @@ import leets.weeth.domain.board.domain.repository.NoticeRepository;
 import leets.weeth.domain.board.application.exception.NoticeNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -24,13 +25,9 @@ public class NoticeFindService {
         return noticeRepository.findAll();
     }
 
-    public Long findFinalNoticeId(){
-        return noticeRepository.findLastId()
-                .orElseThrow(NoticeNotFoundException::new);
-    }
 
-    public List<Notice> findRecentNotices(Long postId, Pageable pageable) {
-        return noticeRepository.findRecentNotices(postId, pageable);
+    public Slice<Notice> findRecentNotices(Pageable pageable) {
+        return noticeRepository.findPageBy(pageable);
     }
 
 }

--- a/src/main/java/leets/weeth/domain/board/domain/service/PostFindService.java
+++ b/src/main/java/leets/weeth/domain/board/domain/service/PostFindService.java
@@ -5,6 +5,7 @@ import leets.weeth.domain.board.domain.repository.PostRepository;
 import leets.weeth.domain.board.application.exception.PostNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -24,13 +25,8 @@ public class PostFindService {
         return postRepository.findAll();
     }
 
-    public Long findFinalPostId() {
-        return postRepository.findLastId()
-                .orElseThrow(PostNotFoundException::new);
-    }
-
-    public List<Post> findRecentPosts(Long postId, Pageable pageable) {
-        return postRepository.findRecentPosts(postId, pageable);
+    public Slice<Post> findRecentPosts(Pageable pageable) {
+        return postRepository.findPageBy(pageable);
     }
 
 }

--- a/src/main/java/leets/weeth/domain/board/presentation/NoticeController.java
+++ b/src/main/java/leets/weeth/domain/board/presentation/NoticeController.java
@@ -24,8 +24,8 @@ public class NoticeController {
 
     @GetMapping
     @Operation(summary="최근 공지사항 조회 및 입력된 개수 만큼 조회")
-    public CommonResponse<Slice<NoticeDTO.ResponseAll>> findNotices(@RequestParam("pageNumber") Integer pageNumber,
-                                                                   @RequestParam("pageSize") Integer pageSize) {
+    public CommonResponse<Slice<NoticeDTO.ResponseAll>> findNotices(@RequestParam("pageNumber") int pageNumber,
+                                                                   @RequestParam("pageSize") int pageSize) {
         return CommonResponse.createSuccess(NOTICE_FIND_ALL_SUCCESS.getMessage(), noticeUsecase.findNotices(pageNumber, pageSize));
     }
 

--- a/src/main/java/leets/weeth/domain/board/presentation/NoticeController.java
+++ b/src/main/java/leets/weeth/domain/board/presentation/NoticeController.java
@@ -10,9 +10,9 @@ import leets.weeth.domain.board.application.dto.NoticeDTO;
 import leets.weeth.domain.board.application.usecase.NoticeUsecase;
 import leets.weeth.global.common.response.CommonResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Slice;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
 
 @Tag(name = "NoticeController", description = "공지사항 관련 컨트롤러")
 @RestController
@@ -24,8 +24,9 @@ public class NoticeController {
 
     @GetMapping
     @Operation(summary="최근 공지사항 조회 및 입력된 개수 만큼 조회")
-    public CommonResponse<List<NoticeDTO.ResponseAll>> findNotices(@RequestParam(required = false) Long noticeId, @RequestParam Integer count) {
-        return CommonResponse.createSuccess(NOTICE_FIND_ALL_SUCCESS.getMessage(), noticeUsecase.findNotices(noticeId, count));
+    public CommonResponse<Slice<NoticeDTO.ResponseAll>> findNotices(@RequestParam("pageNumber") Integer pageNumber,
+                                                                   @RequestParam("pageSize") Integer pageSize) {
+        return CommonResponse.createSuccess(NOTICE_FIND_ALL_SUCCESS.getMessage(), noticeUsecase.findNotices(pageNumber, pageSize));
     }
 
     @GetMapping("/{noticeId}")

--- a/src/main/java/leets/weeth/domain/board/presentation/PostController.java
+++ b/src/main/java/leets/weeth/domain/board/presentation/PostController.java
@@ -10,11 +10,9 @@ import leets.weeth.global.auth.annotation.CurrentUser;
 import leets.weeth.domain.user.application.exception.UserNotMatchException;
 import leets.weeth.global.common.response.CommonResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.MediaType;
+import org.springframework.data.domain.Slice;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
 
-import java.util.List;
 
 import static leets.weeth.domain.board.presentation.ResponseMessage.*;
 
@@ -36,8 +34,9 @@ public class PostController {
 
     @GetMapping
     @Operation(summary="최근 게시글 조회 및 입력된 개수 만큼 조회")
-    public CommonResponse<List<PostDTO.ResponseAll>> findPosts(@RequestParam(required = false) Long postId, @RequestParam Integer count) {
-        return CommonResponse.createSuccess(POST_FIND_ALL_SUCCESS.getMessage(), postUsecase.findPosts(postId, count));
+    public CommonResponse<Slice<PostDTO.ResponseAll>> findPosts(@RequestParam("pageNumber") Integer pageNumber,
+                                                                      @RequestParam("pageSize") Integer pageSize) {
+        return CommonResponse.createSuccess(POST_FIND_ALL_SUCCESS.getMessage(), postUsecase.findPosts(pageNumber, pageSize));
     }
 
     @GetMapping("/{postId}")

--- a/src/main/java/leets/weeth/domain/board/presentation/PostController.java
+++ b/src/main/java/leets/weeth/domain/board/presentation/PostController.java
@@ -34,8 +34,8 @@ public class PostController {
 
     @GetMapping
     @Operation(summary="최근 게시글 조회 및 입력된 개수 만큼 조회")
-    public CommonResponse<Slice<PostDTO.ResponseAll>> findPosts(@RequestParam("pageNumber") Integer pageNumber,
-                                                                      @RequestParam("pageSize") Integer pageSize) {
+    public CommonResponse<Slice<PostDTO.ResponseAll>> findPosts(@RequestParam("pageNumber") int pageNumber,
+                                                                      @RequestParam("pageSize") int pageSize) {
         return CommonResponse.createSuccess(POST_FIND_ALL_SUCCESS.getMessage(), postUsecase.findPosts(pageNumber, pageSize));
     }
 


### PR DESCRIPTION
## PR 내용
- slice를 이용한 무한 스크롤 구현
<br>

## PR 세부사항
- Integer pageNumber, Integer pageSize을 param으로 받아와 slice를 이용해 구현했습니다
- 첫번째 글, 마지막 글이 포함되어 있는지도 확인 가능합니다
- 첫 글부터 n개의 글을 보려면 pageNumber = 0, pageSize = n의 값이 들어가게 됩니다
<br>

## 관련 스크린샷
중간 게시물을 조회한 경우
![image](https://github.com/user-attachments/assets/b1b974d8-1936-40ff-8964-04763920eb3b)
마지막 게시물까지 조회한 경우
last = true
![image](https://github.com/user-attachments/assets/5897308f-1fe4-4061-98fe-618423d544af)


<br>

## 주의사항
- pageNumber과 pageSize을 Integer을 사용할지 Long을 사용할지 고민입니다
=> 원시 타입인 int로 변경했습니다!

<br>

## 체크 리스트

- [x] 리뷰어 설정
- [x] Assignee 설정
- [x] Label 설정
- [x] 제목 양식 맞췄나요? (ex. #0 Feat: 기능 추가)
- [x] 변경 사항에 대한 테스트