### PR TITLE
Feat #84 소셜 로그인 후 회원가입 정보 입력 api 구현

### DIFF
--- a/src/main/java/leets/weeth/domain/user/application/dto/request/UserRequestDto.java
+++ b/src/main/java/leets/weeth/domain/user/application/dto/request/UserRequestDto.java
@@ -20,6 +20,14 @@ public class UserRequestDto {
             @NotNull         String department,
             @NotNull         Integer cardinal
     ) {}
+    public record Register (
+            @NotBlank String name,
+            @NotBlank        String studentId,
+            @NotNull         String department,
+            @NotBlank        String tel,
+            @NotNull         Integer cardinal,
+            @NotNull String position
+            ) {}
 
     public record Update (
             @NotBlank        String name,

--- a/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCase.java
+++ b/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCase.java
@@ -15,6 +15,8 @@ public interface UserUseCase {
 
     void apply(SignUp dto);
 
+    void register(Register dto, Long userId);
+
     Response find(Long userId);
 
     Map<Integer, List<Response>> findAll();

--- a/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCaseImpl.java
@@ -96,6 +96,14 @@ public class UserUseCaseImpl implements UserUseCase {
     }
 
     @Override
+    @Transactional
+    public void register(Register dto, Long userId) {
+        validate(dto, userId);
+        User user = userGetService.find(userId);
+        userUpdateService.update(user, dto);
+    }
+
+    @Override
     public Map<Integer, List<Response>> findAll() {
         return userGetService.findAllByStatus(ACTIVE).stream()
                 .flatMap(user -> Stream.concat(
@@ -209,5 +217,13 @@ public class UserUseCaseImpl implements UserUseCase {
             throw new StudentIdExistsException();
         if (userGetService.validateTel(dto.tel(), userId))
             throw new TelExistsException();
+    }
+    private void validate(Register dto, Long userId) {
+        if (userGetService.validateStudentId(dto.studentId(), userId)) {
+            throw new StudentIdExistsException();
+        }
+        if (userGetService.validateTel(dto.tel(), userId)) {
+            throw new TelExistsException();
+        }
     }
 }

--- a/src/main/java/leets/weeth/domain/user/domain/entity/User.java
+++ b/src/main/java/leets/weeth/domain/user/domain/entity/User.java
@@ -111,7 +111,14 @@ public class User extends BaseEntity {
         this.tel = dto.tel();
         this.department = Department.to(dto.department());
     }
-
+    public void update(Register dto) {
+        this.name = dto.name();
+        this.studentId = dto.studentId();
+        this.tel = dto.tel();
+        this.department = Department.to(dto.department());
+        this.cardinals = List.of(dto.cardinal());
+        this.position = Position.valueOf(dto.position());
+    }
     public void accept() {
         this.status = Status.ACTIVE;
     }

--- a/src/main/java/leets/weeth/domain/user/domain/service/UserUpdateService.java
+++ b/src/main/java/leets/weeth/domain/user/domain/service/UserUpdateService.java
@@ -18,7 +18,9 @@ public class UserUpdateService {
     public void update(User user, Update dto, PasswordEncoder passwordEncoder) {
         user.update(dto, passwordEncoder);
     }
-
+    public void update(User user, Register dto) {
+        user.update(dto);
+    }
     public void accept(User user) {
         user.accept();
     }

--- a/src/main/java/leets/weeth/domain/user/presentation/UserController.java
+++ b/src/main/java/leets/weeth/domain/user/presentation/UserController.java
@@ -52,6 +52,15 @@ public class UserController {
         return CommonResponse.createSuccess(USER_APPLY_SUCCESS.getMessage());
     }
 
+    @PatchMapping("/register")
+    @Operation(summary = "소셜 로그인 후 정보입력")
+    public CommonResponse<Void> register(
+            @RequestBody @Valid Register dto,
+            @Parameter(hidden = true) @CurrentUser Long userId) {
+        userUseCase.register(dto, userId);
+        return CommonResponse.createSuccess(USER_APPLY_SUCCESS.getMessage());
+    }
+
     @GetMapping("/email")
     @Operation(summary="이메일 중복 확인")
     public CommonResponse<Boolean> checkEmail(@RequestParam String email) {


### PR DESCRIPTION
## PR 내용
소셜 로그인 후 사용자 정보를 입력받아 유저 엔티티를 업데이트하는 로직을 구현하였습니다. 새롭게 축소된 Register DTO를 기반으로 서비스 및 유스케이스 계층에서 업데이트 기능을 추가하였습니다
<br>

## PR 세부사항
Register DTO는 소셜 로그인 후 입력받는 최소한의 유저 정보(name, studentId, department, tel, cardinal, position)를 담도록 했습니다
@CurrentUser를 통해 현재 인증된 유저의 ID를 가져와 로직에 전달해주는 플로우로 구현했습니다
register 메서드를 통해 유효성 검증, 유저 조회, 유저 정보 업데이트 등의 로직을 구현했으며, 
동일한 studentId로 입력 시 중복 에러 발생과 동일한 tel로 입력 시 중복 예외 처리 확인 후, 유효한 데이터로만 유저 정보가 업데이트 되는 것을 테스트하였습니다
<br>

## 관련 스크린샷
![image](https://github.com/user-attachments/assets/9efa801c-2d4d-47f4-8da1-2ba014c7cdc9)

<br>

## 주의사항

<br>

## 체크 리스트

- [x] 리뷰어 설정
- [x] Assignee 설정
- [x] Label 설정
- [x] 제목 양식 맞췄나요? (ex. #0 Feat: 기능 추가)
- [x] 변경 사항에 대한 테스트