### PR TITLE
Feat#86  다수 게시물 조회 시 파일 첨부 여부 표시 기능 추가

### DIFF
--- a/src/main/java/leets/weeth/domain/board/application/dto/NoticeDTO.java
+++ b/src/main/java/leets/weeth/domain/board/application/dto/NoticeDTO.java
@@ -4,7 +4,6 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import leets.weeth.domain.comment.application.dto.CommentDTO;
 import leets.weeth.domain.file.application.dto.request.FileSaveRequest;
-import leets.weeth.domain.file.application.dto.request.FileUpdateRequest;
 import leets.weeth.domain.file.application.dto.response.FileResponse;
 import lombok.Builder;
 
@@ -49,7 +48,8 @@ public class NoticeDTO {
             String title,
             String content,
             LocalDateTime time,//modifiedAt
-            Integer commentCount
+            Integer commentCount,
+            boolean hasFile
     ) {
     }
 

--- a/src/main/java/leets/weeth/domain/board/application/dto/PostDTO.java
+++ b/src/main/java/leets/weeth/domain/board/application/dto/PostDTO.java
@@ -46,7 +46,8 @@ public class PostDTO {
             String title,
             String content,
             LocalDateTime time,//modifiedAt
-            Integer commentCount
+            Integer commentCount,
+            boolean hasFile
     ){}
 
 }

--- a/src/main/java/leets/weeth/domain/board/application/mapper/NoticeMapper.java
+++ b/src/main/java/leets/weeth/domain/board/application/mapper/NoticeMapper.java
@@ -26,15 +26,9 @@ public interface NoticeMapper {
     @Mappings({
             @Mapping(target = "name", source = "notice.user.name"),
             @Mapping(target = "time", source = "notice.modifiedAt"),
-            @Mapping(target = "hasFile", expression = "java(checkHasFile(notice, fileGetService))")
+            @Mapping(target = "hasFile", expression = "java(fileExists)")
     })
-    NoticeDTO.ResponseAll toAll(Notice notice, FileGetService fileGetService);
-
-    default boolean checkHasFile(@MappingTarget Notice notice, FileGetService fileGetService) {
-        // 게시글에 파일이 존재하는지 확인
-        return fileGetService.checkFileExistsByNotice(notice.id);
-    }
-
+    NoticeDTO.ResponseAll toAll(Notice notice, boolean fileExists);
 
     @Mappings({
             @Mapping(target = "name", source = "notice.user.name"),

--- a/src/main/java/leets/weeth/domain/board/application/mapper/NoticeMapper.java
+++ b/src/main/java/leets/weeth/domain/board/application/mapper/NoticeMapper.java
@@ -6,7 +6,7 @@ import leets.weeth.domain.comment.application.dto.CommentDTO;
 import leets.weeth.domain.comment.application.mapper.CommentMapper;
 import leets.weeth.domain.comment.domain.entity.Comment;
 import leets.weeth.domain.file.application.dto.response.FileResponse;
-import leets.weeth.domain.file.domain.entity.File;
+import leets.weeth.domain.file.domain.service.FileGetService;
 import leets.weeth.domain.user.domain.entity.User;
 import org.mapstruct.*;
 
@@ -24,10 +24,17 @@ public interface NoticeMapper {
     Notice fromNoticeDto(NoticeDTO.Save dto, User user);
 
     @Mappings({
-            @Mapping(target = "name", source = "user.name"),
-            @Mapping(target = "time", source = "modifiedAt")
+            @Mapping(target = "name", source = "notice.user.name"),
+            @Mapping(target = "time", source = "notice.modifiedAt"),
+            @Mapping(target = "hasFile", expression = "java(checkHasFile(notice, fileGetService))")
     })
-    NoticeDTO.ResponseAll toAll(Notice notice);
+    NoticeDTO.ResponseAll toAll(Notice notice, FileGetService fileGetService);
+
+    default boolean checkHasFile(@MappingTarget Notice notice, FileGetService fileGetService) {
+        // 게시글에 파일이 존재하는지 확인
+        return fileGetService.checkFileExists(notice);
+    }
+
 
     @Mappings({
             @Mapping(target = "name", source = "notice.user.name"),

--- a/src/main/java/leets/weeth/domain/board/application/mapper/NoticeMapper.java
+++ b/src/main/java/leets/weeth/domain/board/application/mapper/NoticeMapper.java
@@ -32,7 +32,7 @@ public interface NoticeMapper {
 
     default boolean checkHasFile(@MappingTarget Notice notice, FileGetService fileGetService) {
         // 게시글에 파일이 존재하는지 확인
-        return fileGetService.checkFileExists(notice);
+        return fileGetService.checkFileExistsByNotice(notice.id);
     }
 
 

--- a/src/main/java/leets/weeth/domain/board/application/mapper/PostMapper.java
+++ b/src/main/java/leets/weeth/domain/board/application/mapper/PostMapper.java
@@ -26,14 +26,10 @@ public interface PostMapper {
     @Mappings({
             @Mapping(target = "name", source = "post.user.name"),
             @Mapping(target = "time", source = "post.modifiedAt"),
-            @Mapping(target = "hasFile", expression = "java(checkHasFile(post, fileGetService))")
+            @Mapping(target = "hasFile", expression = "java(fileExists)")
     })
-    PostDTO.ResponseAll toAll(Post post, FileGetService fileGetService);
+    PostDTO.ResponseAll toAll(Post post, boolean fileExists);
 
-    default boolean checkHasFile(@MappingTarget Post post, FileGetService fileGetService) {
-        // 게시글에 파일이 존재하는지 확인
-        return fileGetService.checkFileExistsByPost(post.id);
-    }
 
     @Mappings({
             @Mapping(target = "name", source = "post.user.name"),

--- a/src/main/java/leets/weeth/domain/board/application/mapper/PostMapper.java
+++ b/src/main/java/leets/weeth/domain/board/application/mapper/PostMapper.java
@@ -6,6 +6,7 @@ import leets.weeth.domain.comment.application.dto.CommentDTO;
 import leets.weeth.domain.comment.application.mapper.CommentMapper;
 import leets.weeth.domain.comment.domain.entity.Comment;
 import leets.weeth.domain.file.application.dto.response.FileResponse;
+import leets.weeth.domain.file.domain.service.FileGetService;
 import leets.weeth.domain.user.domain.entity.User;
 import org.mapstruct.*;
 
@@ -23,10 +24,16 @@ public interface PostMapper {
     Post fromPostDto(PostDTO.Save dto, User user);
 
     @Mappings({
-            @Mapping(target = "name", source = "user.name"),
-            @Mapping(target = "time", source = "modifiedAt")
+            @Mapping(target = "name", source = "post.user.name"),
+            @Mapping(target = "time", source = "post.modifiedAt"),
+            @Mapping(target = "hasFile", expression = "java(checkHasFile(post, fileGetService))")
     })
-    PostDTO.ResponseAll toAll(Post post);
+    PostDTO.ResponseAll toAll(Post post, FileGetService fileGetService);
+
+    default boolean checkHasFile(@MappingTarget Post post, FileGetService fileGetService) {
+        // 게시글에 파일이 존재하는지 확인
+        return fileGetService.checkFileExistsByPost(post.id);
+    }
 
     @Mappings({
             @Mapping(target = "name", source = "post.user.name"),

--- a/src/main/java/leets/weeth/domain/board/application/usecase/NoticeUsecaseImpl.java
+++ b/src/main/java/leets/weeth/domain/board/application/usecase/NoticeUsecaseImpl.java
@@ -78,7 +78,7 @@ public class NoticeUsecaseImpl implements NoticeUsecase {
         Pageable pageable = PageRequest.of(pageNumber, pageSize, Sort.by(Sort.Direction.DESC, "id")); // id를 기준으로 내림차순
         Slice<Notice> notices = noticeFindService.findRecentNotices(pageable);
 
-        return notices.map(mapper::toAll);
+        return notices.map(notice->mapper.toAll(notice, fileGetService));
     }
 
     @Override

--- a/src/main/java/leets/weeth/domain/board/application/usecase/NoticeUsecaseImpl.java
+++ b/src/main/java/leets/weeth/domain/board/application/usecase/NoticeUsecaseImpl.java
@@ -77,8 +77,7 @@ public class NoticeUsecaseImpl implements NoticeUsecase {
         }
         Pageable pageable = PageRequest.of(pageNumber, pageSize, Sort.by(Sort.Direction.DESC, "id")); // id를 기준으로 내림차순
         Slice<Notice> notices = noticeFindService.findRecentNotices(pageable);
-
-        return notices.map(notice->mapper.toAll(notice, fileGetService));
+        return notices.map(notice->mapper.toAll(notice, checkFileExistsByNotice(notice.id)));
     }
 
     @Override
@@ -116,6 +115,10 @@ public class NoticeUsecaseImpl implements NoticeUsecase {
             throw new UserNotMatchException();
         }
         return notice;
+    }
+
+    public boolean checkFileExistsByNotice(Long noticeId){
+        return !fileGetService.findAllByNotice(noticeId).isEmpty();
     }
 
 }

--- a/src/main/java/leets/weeth/domain/board/application/usecase/PostUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/board/application/usecase/PostUseCaseImpl.java
@@ -75,7 +75,7 @@ public class PostUseCaseImpl implements PostUsecase {
         Pageable pageable = PageRequest.of(pageNumber, pageSize, Sort.by(Sort.Direction.DESC, "id"));
         Slice<Post> posts = postFindService.findRecentPosts(pageable);
 
-        return posts.map(post->mapper.toAll(post, fileGetService));
+        return posts.map(post->mapper.toAll(post, checkFileExistsByPost(post.id)));
     }
 
     @Override
@@ -114,6 +114,10 @@ public class PostUseCaseImpl implements PostUsecase {
             throw new UserNotMatchException();
         }
         return post;
+    }
+
+    public boolean checkFileExistsByPost(Long postId){
+        return !fileGetService.findAllByPost(postId).isEmpty();
     }
 
 }

--- a/src/main/java/leets/weeth/domain/board/application/usecase/PostUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/board/application/usecase/PostUseCaseImpl.java
@@ -73,9 +73,9 @@ public class PostUseCaseImpl implements PostUsecase {
             throw new PageNotFoundException();
         }
         Pageable pageable = PageRequest.of(pageNumber, pageSize, Sort.by(Sort.Direction.DESC, "id"));
-        Slice<Post> recentPosts = postFindService.findRecentPosts(pageable);
+        Slice<Post> posts = postFindService.findRecentPosts(pageable);
 
-        return recentPosts.map(mapper::toAll);
+        return posts.map(post->mapper.toAll(post, fileGetService));
     }
 
     @Override

--- a/src/main/java/leets/weeth/domain/file/domain/service/FileGetService.java
+++ b/src/main/java/leets/weeth/domain/file/domain/service/FileGetService.java
@@ -1,5 +1,6 @@
 package leets.weeth.domain.file.domain.service;
 
+import leets.weeth.domain.board.domain.entity.Notice;
 import leets.weeth.domain.file.domain.entity.File;
 import leets.weeth.domain.file.domain.repository.FileRepository;
 import lombok.RequiredArgsConstructor;
@@ -23,5 +24,9 @@ public class FileGetService {
 
     public List<File> findAllByReceipt(Long receiptId) {
         return fileRepository.findAllByReceiptId(receiptId);
+    }
+
+    public boolean checkFileExists(Notice notice){
+        return !findAllByNotice(notice.getId()).isEmpty();
     }
 }

--- a/src/main/java/leets/weeth/domain/file/domain/service/FileGetService.java
+++ b/src/main/java/leets/weeth/domain/file/domain/service/FileGetService.java
@@ -26,10 +26,6 @@ public class FileGetService {
         return fileRepository.findAllByReceiptId(receiptId);
     }
 
-    public boolean checkFileExistsByNotice(Long noticeId){
-        return !findAllByNotice(noticeId).isEmpty();
-    }
-
     public boolean checkFileExistsByPost(Long postId){
         return !findAllByPost(postId).isEmpty();
     }

--- a/src/main/java/leets/weeth/domain/file/domain/service/FileGetService.java
+++ b/src/main/java/leets/weeth/domain/file/domain/service/FileGetService.java
@@ -29,4 +29,8 @@ public class FileGetService {
     public boolean checkFileExists(Notice notice){
         return !findAllByNotice(notice.getId()).isEmpty();
     }
+
+    public boolean checkFileExistsByPost(Long postId){
+        return !findAllByPost(postId).isEmpty();
+    }
 }

--- a/src/main/java/leets/weeth/domain/file/domain/service/FileGetService.java
+++ b/src/main/java/leets/weeth/domain/file/domain/service/FileGetService.java
@@ -26,7 +26,4 @@ public class FileGetService {
         return fileRepository.findAllByReceiptId(receiptId);
     }
 
-    public boolean checkFileExistsByPost(Long postId){
-        return !findAllByPost(postId).isEmpty();
-    }
 }

--- a/src/main/java/leets/weeth/domain/file/domain/service/FileGetService.java
+++ b/src/main/java/leets/weeth/domain/file/domain/service/FileGetService.java
@@ -26,8 +26,8 @@ public class FileGetService {
         return fileRepository.findAllByReceiptId(receiptId);
     }
 
-    public boolean checkFileExists(Notice notice){
-        return !findAllByNotice(notice.getId()).isEmpty();
+    public boolean checkFileExistsByNotice(Long noticeId){
+        return !findAllByNotice(noticeId).isEmpty();
     }
 
     public boolean checkFileExistsByPost(Long postId){


### PR DESCRIPTION
## PR 내용
- 다수 게시물(공지사항, 일반게시물) 조회 시 파일 첨부 여부 표시 기능 추가
<br>

## PR 세부사항
- 반환하는 dto에 boolean hasFile을 추가했습니다
- hasFile의 값이 true인 경우, 파일이 1개 이상 첨부되어있습니다
- hasFile의 값이 false인 경우 파일이 첨부되어 있지 않습니다

<br>

## 관련 스크린샷
hasFile이 true인 경우와 false인 경우입니다
![image](https://github.com/user-attachments/assets/4a58a258-cbac-4a9f-ab3e-ca6a41261d8a)

<br>

## 주의사항
- checkFileExistsByNotice와 checkFileExistsByPost이 현재 FileGetService에 구현되어 있는데 알맞은 위치인지 궁금합니다

<br>

## 체크 리스트

- [x] 리뷰어 설정
- [x] Assignee 설정
- [x] Label 설정
- [x] 제목 양식 맞췄나요? (ex. #0 Feat: 기능 추가)
- [x] 변경 사항에 대한 테스트