### PR TITLE
Refactor #89 UserUseCase 분리 및 리프레시 토큰 수정

### DIFF
--- a/src/main/java/leets/weeth/domain/user/application/usecase/UserManageUseCase.java
+++ b/src/main/java/leets/weeth/domain/user/application/usecase/UserManageUseCase.java
@@ -1,10 +1,38 @@
 package leets.weeth.domain.user.application.usecase;
 
 import jakarta.servlet.http.HttpServletRequest;
+import leets.weeth.domain.user.application.dto.request.UserRequestDto;
+import leets.weeth.domain.user.application.dto.response.UserResponseDto;
 import leets.weeth.global.auth.jwt.application.dto.JwtDto;
+
+import java.util.List;
+import java.util.Map;
 
 import static leets.weeth.domain.user.application.dto.request.UserRequestDto.refreshRequest;
 
 public interface UserManageUseCase {
-    JwtDto refresh(HttpServletRequest request);
+
+    UserResponseDto.Response find(Long userId);
+
+    Map<Integer, List<UserResponseDto.Response>> findAll();
+
+    Map<Integer, List<UserResponseDto.SummaryResponse>> findAllUser();
+
+    List<UserResponseDto.AdminResponse> findAllByAdmin();
+
+    UserResponseDto.UserResponse findUserDetails(Long userId);
+
+    void update(UserRequestDto.Update dto, Long userId);
+
+    void accept(Long userId);
+
+    void update(Long userId, String role);
+
+    void leave(Long userId);
+
+    void ban(Long userId);
+
+    void applyOB(Long userId, Integer cardinal);
+
+    void reset(Long userId);
 }

--- a/src/main/java/leets/weeth/domain/user/application/usecase/UserManageUseCase.java
+++ b/src/main/java/leets/weeth/domain/user/application/usecase/UserManageUseCase.java
@@ -1,28 +1,16 @@
 package leets.weeth.domain.user.application.usecase;
 
-import jakarta.servlet.http.HttpServletRequest;
 import leets.weeth.domain.user.application.dto.request.UserRequestDto;
 import leets.weeth.domain.user.application.dto.response.UserResponseDto;
-import leets.weeth.global.auth.jwt.application.dto.JwtDto;
 
 import java.util.List;
 import java.util.Map;
 
-import static leets.weeth.domain.user.application.dto.request.UserRequestDto.refreshRequest;
-
 public interface UserManageUseCase {
 
-    UserResponseDto.Response find(Long userId);
 
-    Map<Integer, List<UserResponseDto.Response>> findAll();
-
-    Map<Integer, List<UserResponseDto.SummaryResponse>> findAllUser();
 
     List<UserResponseDto.AdminResponse> findAllByAdmin();
-
-    UserResponseDto.UserResponse findUserDetails(Long userId);
-
-    void update(UserRequestDto.Update dto, Long userId);
 
     void accept(Long userId);
 

--- a/src/main/java/leets/weeth/domain/user/application/usecase/UserManageUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/user/application/usecase/UserManageUseCaseImpl.java
@@ -1,29 +1,166 @@
 package leets.weeth.domain.user.application.usecase;
 
-import jakarta.servlet.http.HttpServletRequest;
+import jakarta.transaction.Transactional;
+import leets.weeth.domain.attendance.domain.service.AttendanceSaveService;
+import leets.weeth.domain.schedule.domain.entity.Meeting;
+import leets.weeth.domain.schedule.domain.service.MeetingGetService;
+import leets.weeth.domain.user.application.exception.StudentIdExistsException;
+import leets.weeth.domain.user.application.exception.TelExistsException;
+import leets.weeth.domain.user.application.mapper.UserMapper;
+import leets.weeth.domain.user.domain.entity.User;
+import leets.weeth.domain.user.domain.service.UserDeleteService;
+import leets.weeth.domain.user.domain.service.UserGetService;
+import leets.weeth.domain.user.domain.service.UserSaveService;
+import leets.weeth.domain.user.domain.service.UserUpdateService;
 import leets.weeth.global.auth.jwt.application.dto.JwtDto;
 import leets.weeth.global.auth.jwt.application.usecase.JwtManageUseCase;
+import leets.weeth.global.auth.jwt.service.JwtRedisService;
+import leets.weeth.global.auth.kakao.KakaoAuthService;
+import leets.weeth.global.auth.kakao.dto.KakaoTokenResponse;
+import leets.weeth.global.auth.kakao.dto.KakaoUserInfoResponse;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-import static leets.weeth.domain.user.application.dto.request.UserRequestDto.refreshRequest;
+import java.util.AbstractMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
-@Slf4j
+import static leets.weeth.domain.user.application.dto.request.UserRequestDto.*;
+import static leets.weeth.domain.user.application.dto.response.UserResponseDto.*;
+import static leets.weeth.domain.user.domain.entity.enums.LoginStatus.LOGIN;
+import static leets.weeth.domain.user.domain.entity.enums.LoginStatus.REGISTER;
+import static leets.weeth.domain.user.domain.entity.enums.Status.ACTIVE;
+
 @Service
 @RequiredArgsConstructor
 public class UserManageUseCaseImpl implements UserManageUseCase {
-    private final JwtManageUseCase jwtManageUseCase;
+
+    private final UserGetService userGetService;
+    private final UserUpdateService userUpdateService;
+    private final UserDeleteService userDeleteService;
+
+    private final AttendanceSaveService attendanceSaveService;
+    private final MeetingGetService meetingGetService;
+    private final JwtRedisService jwtRedisService;
+
+    private final UserMapper mapper;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public Map<Integer, List<Response>> findAll() {
+        return userGetService.findAllByStatus(ACTIVE).stream()
+                .flatMap(user -> Stream.concat(
+                        user.getCardinals().stream()
+                                .map(cardinal -> new AbstractMap.SimpleEntry<>(cardinal, mapper.to(user))), // 기수별 Map
+                        Stream.of(new AbstractMap.SimpleEntry<>(0, mapper.to(user)))    // 모든 기수는 cardinal 0에 저장
+                ))
+                .collect(Collectors.groupingBy(Map.Entry::getKey,   // key = 기수, value = 유저 정보
+                        Collectors.mapping(Map.Entry::getValue, Collectors.toList())));
+    }
+
+    @Override
+    public Map<Integer, List<SummaryResponse>> findAllUser() {
+        return userGetService.findAllByStatus(ACTIVE).stream()
+                .map(user -> new AbstractMap.SimpleEntry<>(user.getCardinals(), mapper.toSummaryResponse(user)))
+                .flatMap(entry -> Stream.concat(
+                        entry.getKey().stream().map(cardinal -> new AbstractMap.SimpleEntry<>(cardinal, entry.getValue())), // 기수별 Map
+                        Stream.of(new AbstractMap.SimpleEntry<>(0, entry.getValue())) // 모든 기수는 cardinal 0에 저장
+                ))
+                .collect(Collectors.groupingBy(
+                        Map.Entry::getKey, // key = 기수
+                        Collectors.mapping(Map.Entry::getValue, Collectors.toList()) // value = 요약 정보 리스트
+                ));
+    }
+
+    @Override
+    public List<AdminResponse> findAllByAdmin() {
+        return userGetService.findAll().stream()
+                .map(mapper::toAdminResponse)
+                .toList();
+    }
+
+    @Override
+    public UserResponse findUserDetails(Long userId) {
+        User user = userGetService.find(userId);
+        return mapper.toUserResponse(user);
+    }
+
+    @Override
+    public Response find(Long userId) {
+        return mapper.to(userGetService.find(userId));
+    }
+
+    @Override
+    public void update(Update dto, Long userId) {
+        validate(dto, userId);
+        User user = userGetService.find(userId);
+        userUpdateService.update(user, dto, passwordEncoder);
+    }
 
     @Override
     @Transactional
-    public JwtDto refresh(HttpServletRequest request) {
+    public void accept(Long userId) {
+        User user = userGetService.find(userId);
 
-        JwtDto token = jwtManageUseCase.reIssueToken(request);
+        if (user.isInactive()) {
+            userUpdateService.accept(user);
+            List<Meeting> meetings = meetingGetService.find(user.getCardinals().get(0));
+            attendanceSaveService.save(user, meetings);
+        }
+    }
 
-        log.info("RefreshToken 발급 완료: {}", token);
-        return new JwtDto(token.accessToken(), token.refreshToken());
+    @Override
+    public void update(Long userId, String role) {
+        User user = userGetService.find(userId);
+        userUpdateService.update(user, role);
+        jwtRedisService.updateRole(user.getId(), role);
+    }
+
+    @Override
+    public void leave(Long userId) {
+        User user = userGetService.find(userId);
+        // 탈퇴하는 경우 리프레시 토큰 삭제
+        jwtRedisService.delete(user.getId());
+        userDeleteService.leave(user);
+    }
+
+    @Override
+    public void ban(Long userId) {
+        User user = userGetService.find(userId);
+        jwtRedisService.delete(user.getId());
+        userDeleteService.ban(user);
+    }
+
+    @Override
+    @Transactional
+    public void applyOB(Long userId, Integer cardinal) {
+        User user = userGetService.find(userId);
+
+        if (user.notContains(cardinal)) {
+            if (user.isCurrent(cardinal)) {
+                user.initAttendance();
+                List<Meeting> meetings = meetingGetService.find(cardinal);
+                attendanceSaveService.save(user, meetings);
+            }
+
+            userUpdateService.applyOB(user, cardinal);
+        }
+    }
+
+    @Override
+    public void reset(Long userId) {
+        User user = userGetService.find(userId);
+        userUpdateService.reset(user, passwordEncoder);
+    }
+
+    private void validate(Update dto, Long userId) {
+        if (userGetService.validateStudentId(dto.studentId(), userId))
+            throw new StudentIdExistsException();
+        if (userGetService.validateTel(dto.tel(), userId))
+            throw new TelExistsException();
     }
 
 }

--- a/src/main/java/leets/weeth/domain/user/application/usecase/UserManageUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/user/application/usecase/UserManageUseCaseImpl.java
@@ -50,54 +50,10 @@ public class UserManageUseCaseImpl implements UserManageUseCase {
     private final PasswordEncoder passwordEncoder;
 
     @Override
-    public Map<Integer, List<Response>> findAll() {
-        return userGetService.findAllByStatus(ACTIVE).stream()
-                .flatMap(user -> Stream.concat(
-                        user.getCardinals().stream()
-                                .map(cardinal -> new AbstractMap.SimpleEntry<>(cardinal, mapper.to(user))), // 기수별 Map
-                        Stream.of(new AbstractMap.SimpleEntry<>(0, mapper.to(user)))    // 모든 기수는 cardinal 0에 저장
-                ))
-                .collect(Collectors.groupingBy(Map.Entry::getKey,   // key = 기수, value = 유저 정보
-                        Collectors.mapping(Map.Entry::getValue, Collectors.toList())));
-    }
-
-    @Override
-    public Map<Integer, List<SummaryResponse>> findAllUser() {
-        return userGetService.findAllByStatus(ACTIVE).stream()
-                .map(user -> new AbstractMap.SimpleEntry<>(user.getCardinals(), mapper.toSummaryResponse(user)))
-                .flatMap(entry -> Stream.concat(
-                        entry.getKey().stream().map(cardinal -> new AbstractMap.SimpleEntry<>(cardinal, entry.getValue())), // 기수별 Map
-                        Stream.of(new AbstractMap.SimpleEntry<>(0, entry.getValue())) // 모든 기수는 cardinal 0에 저장
-                ))
-                .collect(Collectors.groupingBy(
-                        Map.Entry::getKey, // key = 기수
-                        Collectors.mapping(Map.Entry::getValue, Collectors.toList()) // value = 요약 정보 리스트
-                ));
-    }
-
-    @Override
     public List<AdminResponse> findAllByAdmin() {
         return userGetService.findAll().stream()
                 .map(mapper::toAdminResponse)
                 .toList();
-    }
-
-    @Override
-    public UserResponse findUserDetails(Long userId) {
-        User user = userGetService.find(userId);
-        return mapper.toUserResponse(user);
-    }
-
-    @Override
-    public Response find(Long userId) {
-        return mapper.to(userGetService.find(userId));
-    }
-
-    @Override
-    public void update(Update dto, Long userId) {
-        validate(dto, userId);
-        User user = userGetService.find(userId);
-        userUpdateService.update(user, dto, passwordEncoder);
     }
 
     @Override
@@ -154,13 +110,6 @@ public class UserManageUseCaseImpl implements UserManageUseCase {
     public void reset(Long userId) {
         User user = userGetService.find(userId);
         userUpdateService.reset(user, passwordEncoder);
-    }
-
-    private void validate(Update dto, Long userId) {
-        if (userGetService.validateStudentId(dto.studentId(), userId))
-            throw new StudentIdExistsException();
-        if (userGetService.validateTel(dto.tel(), userId))
-            throw new TelExistsException();
     }
 
 }

--- a/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCase.java
+++ b/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCase.java
@@ -1,19 +1,30 @@
 package leets.weeth.domain.user.application.usecase;
 
-import jakarta.servlet.http.HttpServletRequest;
 import leets.weeth.domain.user.application.dto.request.UserRequestDto;
+import leets.weeth.domain.user.application.dto.response.UserResponseDto;
 import leets.weeth.global.auth.jwt.application.dto.JwtDto;
 
 import java.util.List;
 import java.util.Map;
 
-import static leets.weeth.domain.user.application.dto.request.UserRequestDto.*;
-import static leets.weeth.domain.user.application.dto.response.UserResponseDto.*;
+import static leets.weeth.domain.user.application.dto.request.UserRequestDto.Register;
+import static leets.weeth.domain.user.application.dto.request.UserRequestDto.SignUp;
+import static leets.weeth.domain.user.application.dto.response.UserResponseDto.SocialLoginResponse;
 
 
 public interface UserUseCase {
 
     SocialLoginResponse login(UserRequestDto.login dto);
+
+    UserResponseDto.Response find(Long userId);
+
+    Map<Integer, List<UserResponseDto.Response>> findAll();
+
+    Map<Integer, List<UserResponseDto.SummaryResponse>> findAllUser();
+
+    UserResponseDto.UserResponse findUserDetails(Long userId);
+
+    void update(UserRequestDto.Update dto, Long userId);
 
     void apply(SignUp dto);
 

--- a/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCase.java
+++ b/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCase.java
@@ -19,6 +19,6 @@ public interface UserUseCase {
 
     void register(Register dto, Long userId);
 
-    JwtDto refresh(HttpServletRequest request);
+    JwtDto refresh(String refreshToken);
 
 }

--- a/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCase.java
+++ b/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCase.java
@@ -1,6 +1,8 @@
 package leets.weeth.domain.user.application.usecase;
 
+import jakarta.servlet.http.HttpServletRequest;
 import leets.weeth.domain.user.application.dto.request.UserRequestDto;
+import leets.weeth.global.auth.jwt.application.dto.JwtDto;
 
 import java.util.List;
 import java.util.Map;
@@ -17,27 +19,6 @@ public interface UserUseCase {
 
     void register(Register dto, Long userId);
 
-    Response find(Long userId);
+    JwtDto refresh(HttpServletRequest request);
 
-    Map<Integer, List<Response>> findAll();
-
-    Map<Integer, List<SummaryResponse>> findAllUser();
-
-    List<AdminResponse> findAllByAdmin();
-
-    UserResponse findUserDetails(Long userId);
-
-    void update(Update dto, Long userId);
-
-    void accept(Long userId);
-
-    void update(Long userId, String role);
-
-    void leave(Long userId);
-
-    void ban(Long userId);
-
-    void applyOB(Long userId, Integer cardinal);
-
-    void reset(Long userId);
 }

--- a/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCaseImpl.java
@@ -1,6 +1,5 @@
 package leets.weeth.domain.user.application.usecase;
 
-import jakarta.servlet.http.HttpServletRequest;
 import leets.weeth.domain.user.application.dto.request.UserRequestDto;
 import leets.weeth.domain.user.application.dto.response.UserResponseDto;
 import leets.weeth.domain.user.application.exception.StudentIdExistsException;
@@ -21,23 +20,28 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.AbstractMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import static leets.weeth.domain.user.domain.entity.enums.LoginStatus.LOGIN;
 import static leets.weeth.domain.user.domain.entity.enums.LoginStatus.REGISTER;
+import static leets.weeth.domain.user.domain.entity.enums.Status.ACTIVE;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class UserUseCaseImpl implements UserUseCase {
+    private static final String BEARER = "Bearer ";
     private final JwtManageUseCase jwtManageUseCase;
     private final UserSaveService userSaveService;
     private final UserGetService userGetService;
     private final UserUpdateService userUpdateService;
     private final KakaoAuthService kakaoAuthService;
-
     private final UserMapper mapper;
     private final PasswordEncoder passwordEncoder;
-
-    private static final String BEARER = "Bearer ";
 
     @Override
     @Transactional
@@ -77,6 +81,50 @@ public class UserUseCaseImpl implements UserUseCase {
     }
 
     @Override
+    public Map<Integer, List<UserResponseDto.Response>> findAll() {
+        return userGetService.findAllByStatus(ACTIVE).stream()
+                .flatMap(user -> Stream.concat(
+                        user.getCardinals().stream()
+                                .map(cardinal -> new AbstractMap.SimpleEntry<>(cardinal, mapper.to(user))), // 기수별 Map
+                        Stream.of(new AbstractMap.SimpleEntry<>(0, mapper.to(user)))    // 모든 기수는 cardinal 0에 저장
+                ))
+                .collect(Collectors.groupingBy(Map.Entry::getKey,   // key = 기수, value = 유저 정보
+                        Collectors.mapping(Map.Entry::getValue, Collectors.toList())));
+    }
+
+    @Override
+    public Map<Integer, List<UserResponseDto.SummaryResponse>> findAllUser() {
+        return userGetService.findAllByStatus(ACTIVE).stream()
+                .map(user -> new AbstractMap.SimpleEntry<>(user.getCardinals(), mapper.toSummaryResponse(user)))
+                .flatMap(entry -> Stream.concat(
+                        entry.getKey().stream().map(cardinal -> new AbstractMap.SimpleEntry<>(cardinal, entry.getValue())), // 기수별 Map
+                        Stream.of(new AbstractMap.SimpleEntry<>(0, entry.getValue())) // 모든 기수는 cardinal 0에 저장
+                ))
+                .collect(Collectors.groupingBy(
+                        Map.Entry::getKey, // key = 기수
+                        Collectors.mapping(Map.Entry::getValue, Collectors.toList()) // value = 요약 정보 리스트
+                ));
+    }
+
+    @Override
+    public UserResponseDto.UserResponse findUserDetails(Long userId) {
+        User user = userGetService.find(userId);
+        return mapper.toUserResponse(user);
+    }
+
+    @Override
+    public UserResponseDto.Response find(Long userId) {
+        return mapper.to(userGetService.find(userId));
+    }
+
+    @Override
+    public void update(UserRequestDto.Update dto, Long userId) {
+        validate(dto, userId);
+        User user = userGetService.find(userId);
+        userUpdateService.update(user, dto, passwordEncoder);
+    }
+
+    @Override
     public void apply(UserRequestDto.SignUp dto) {
         validate(dto);
         userSaveService.save(mapper.from(dto, passwordEncoder));
@@ -100,6 +148,14 @@ public class UserUseCaseImpl implements UserUseCase {
 
         log.info("RefreshToken 발급 완료: {}", token);
         return new JwtDto(token.accessToken(), token.refreshToken());
+    }
+
+
+    private void validate(UserRequestDto.Update dto, Long userId) {
+        if (userGetService.validateStudentId(dto.studentId(), userId))
+            throw new StudentIdExistsException();
+        if (userGetService.validateTel(dto.tel(), userId))
+            throw new TelExistsException();
     }
 
     private void validate(UserRequestDto.SignUp dto) {

--- a/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCaseImpl.java
@@ -37,6 +37,8 @@ public class UserUseCaseImpl implements UserUseCase {
     private final UserMapper mapper;
     private final PasswordEncoder passwordEncoder;
 
+    private static final String BEARER = "Bearer ";
+
     @Override
     @Transactional
     public UserResponseDto.SocialLoginResponse login(UserRequestDto.login dto) {
@@ -90,9 +92,11 @@ public class UserUseCaseImpl implements UserUseCase {
 
     @Override
     @Transactional
-    public JwtDto refresh(HttpServletRequest request) {
+    public JwtDto refresh(String refreshToken) {
 
-        JwtDto token = jwtManageUseCase.reIssueToken(request);
+        String requestToken = refreshToken.replace(BEARER, "");
+
+        JwtDto token = jwtManageUseCase.reIssueToken(requestToken);
 
         log.info("RefreshToken 발급 완료: {}", token);
         return new JwtDto(token.accessToken(), token.refreshToken());

--- a/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCaseImpl.java
@@ -1,60 +1,45 @@
 package leets.weeth.domain.user.application.usecase;
 
-import jakarta.transaction.Transactional;
-import leets.weeth.domain.attendance.domain.service.AttendanceSaveService;
-import leets.weeth.domain.schedule.domain.entity.Meeting;
-import leets.weeth.domain.schedule.domain.service.MeetingGetService;
+import jakarta.servlet.http.HttpServletRequest;
+import leets.weeth.domain.user.application.dto.request.UserRequestDto;
+import leets.weeth.domain.user.application.dto.response.UserResponseDto;
 import leets.weeth.domain.user.application.exception.StudentIdExistsException;
 import leets.weeth.domain.user.application.exception.TelExistsException;
 import leets.weeth.domain.user.application.mapper.UserMapper;
 import leets.weeth.domain.user.domain.entity.User;
-import leets.weeth.domain.user.domain.service.UserDeleteService;
 import leets.weeth.domain.user.domain.service.UserGetService;
 import leets.weeth.domain.user.domain.service.UserSaveService;
 import leets.weeth.domain.user.domain.service.UserUpdateService;
 import leets.weeth.global.auth.jwt.application.dto.JwtDto;
 import leets.weeth.global.auth.jwt.application.usecase.JwtManageUseCase;
-import leets.weeth.global.auth.jwt.service.JwtRedisService;
 import leets.weeth.global.auth.kakao.KakaoAuthService;
 import leets.weeth.global.auth.kakao.dto.KakaoTokenResponse;
 import leets.weeth.global.auth.kakao.dto.KakaoUserInfoResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-import java.util.AbstractMap;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import static leets.weeth.domain.user.application.dto.request.UserRequestDto.*;
-import static leets.weeth.domain.user.application.dto.response.UserResponseDto.*;
 import static leets.weeth.domain.user.domain.entity.enums.LoginStatus.LOGIN;
 import static leets.weeth.domain.user.domain.entity.enums.LoginStatus.REGISTER;
-import static leets.weeth.domain.user.domain.entity.enums.Status.ACTIVE;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class UserUseCaseImpl implements UserUseCase {
-
+    private final JwtManageUseCase jwtManageUseCase;
     private final UserSaveService userSaveService;
     private final UserGetService userGetService;
     private final UserUpdateService userUpdateService;
-    private final UserDeleteService userDeleteService;
+    private final KakaoAuthService kakaoAuthService;
+
     private final UserMapper mapper;
     private final PasswordEncoder passwordEncoder;
-    private final AttendanceSaveService attendanceSaveService;
-    private final MeetingGetService meetingGetService;
-
-    private final JwtRedisService jwtRedisService;
-    private final JwtManageUseCase jwtManageUseCase;
-
-    private final KakaoAuthService kakaoAuthService;
 
     @Override
     @Transactional
-    public SocialLoginResponse login(login dto) {
+    public UserResponseDto.SocialLoginResponse login(UserRequestDto.login dto) {
         KakaoTokenResponse tokenResponse = kakaoAuthService.getKakaoToken(dto.authCode());
         KakaoUserInfoResponse userInfo = kakaoAuthService.getUserInfo(tokenResponse.access_token());
 
@@ -70,7 +55,7 @@ public class UserUseCaseImpl implements UserUseCase {
         return !userGetService.check(email);
     }
 
-    private SocialLoginResponse registerUser(String email) {
+    private UserResponseDto.SocialLoginResponse registerUser(String email) {
         User user = User.builder()
                 .email(email)
                 .build();
@@ -78,148 +63,49 @@ public class UserUseCaseImpl implements UserUseCase {
 
         JwtDto dto = jwtManageUseCase.create(user.getId(), email, user.getRole());
 
-        return new SocialLoginResponse(user.getId(), REGISTER, dto.accessToken(), dto.refreshToken());
+        return new UserResponseDto.SocialLoginResponse(user.getId(), REGISTER, dto.accessToken(), dto.refreshToken());
     }
 
-    private SocialLoginResponse login(String email) {
+    private UserResponseDto.SocialLoginResponse login(String email) {
         User user = userGetService.find(email);
 
         JwtDto dto = jwtManageUseCase.create(user.getId(), email, user.getRole());
 
-        return new SocialLoginResponse(user.getId(), LOGIN, dto.accessToken(), dto.refreshToken());
+        return new UserResponseDto.SocialLoginResponse(user.getId(), LOGIN, dto.accessToken(), dto.refreshToken());
     }
 
     @Override
-    public void apply(SignUp dto) {
+    public void apply(UserRequestDto.SignUp dto) {
         validate(dto);
         userSaveService.save(mapper.from(dto, passwordEncoder));
     }
 
     @Override
     @Transactional
-    public void register(Register dto, Long userId) {
+    public void register(UserRequestDto.Register dto, Long userId) {
         validate(dto, userId);
         User user = userGetService.find(userId);
         userUpdateService.update(user, dto);
     }
 
     @Override
-    public Map<Integer, List<Response>> findAll() {
-        return userGetService.findAllByStatus(ACTIVE).stream()
-                .flatMap(user -> Stream.concat(
-                        user.getCardinals().stream()
-                                .map(cardinal -> new AbstractMap.SimpleEntry<>(cardinal, mapper.to(user))), // 기수별 Map
-                        Stream.of(new AbstractMap.SimpleEntry<>(0, mapper.to(user)))    // 모든 기수는 cardinal 0에 저장
-                ))
-                .collect(Collectors.groupingBy(Map.Entry::getKey,   // key = 기수, value = 유저 정보
-                        Collectors.mapping(Map.Entry::getValue, Collectors.toList())));
-    }
-    @Override
-    public Map<Integer, List<SummaryResponse>> findAllUser() {
-        return userGetService.findAllByStatus(ACTIVE).stream()
-                .map(user -> new AbstractMap.SimpleEntry<>(user.getCardinals(), mapper.toSummaryResponse(user)))
-                .flatMap(entry -> Stream.concat(
-                        entry.getKey().stream().map(cardinal -> new AbstractMap.SimpleEntry<>(cardinal, entry.getValue())), // 기수별 Map
-                        Stream.of(new AbstractMap.SimpleEntry<>(0, entry.getValue())) // 모든 기수는 cardinal 0에 저장
-                ))
-                .collect(Collectors.groupingBy(
-                        Map.Entry::getKey, // key = 기수
-                        Collectors.mapping(Map.Entry::getValue, Collectors.toList()) // value = 요약 정보 리스트
-                ));
-    }
-    @Override
-    public List<AdminResponse> findAllByAdmin() {
-        return userGetService.findAll().stream()
-                .map(mapper::toAdminResponse)
-                .toList();
-    }
-    @Override
-    public UserResponse findUserDetails(Long userId) {
-        User user = userGetService.find(userId);
-        return mapper.toUserResponse(user);
-    }
-    @Override
-    public Response find(Long userId) {
-        return mapper.to(userGetService.find(userId));
-    }
-
-    @Override
-    public void update(Update dto, Long userId) {
-        validate(dto, userId);
-        User user = userGetService.find(userId);
-        userUpdateService.update(user, dto, passwordEncoder);
-    }
-
-    @Override
     @Transactional
-    public void accept(Long userId) {
-        User user = userGetService.find(userId);
+    public JwtDto refresh(HttpServletRequest request) {
 
-        if (user.isInactive()) {
-            userUpdateService.accept(user);
-            List<Meeting> meetings = meetingGetService.find(user.getCardinals().get(0));
-            attendanceSaveService.save(user, meetings);
-        }
+        JwtDto token = jwtManageUseCase.reIssueToken(request);
+
+        log.info("RefreshToken 발급 완료: {}", token);
+        return new JwtDto(token.accessToken(), token.refreshToken());
     }
 
-    @Override
-    public void update(Long userId, String role) {
-        User user = userGetService.find(userId);
-        userUpdateService.update(user, role);
-        jwtRedisService.updateRole(user.getId(), role);
-    }
-
-    @Override
-    public void leave(Long userId) {
-        User user = userGetService.find(userId);
-        // 탈퇴하는 경우 리프레시 토큰 삭제
-        jwtRedisService.delete(user.getId());
-        userDeleteService.leave(user);
-    }
-
-    @Override
-    public void ban(Long userId) {
-        User user = userGetService.find(userId);
-        jwtRedisService.delete(user.getId());
-        userDeleteService.ban(user);
-    }
-
-    @Override
-    @Transactional
-    public void applyOB(Long userId, Integer cardinal) {
-        User user = userGetService.find(userId);
-
-        if (user.notContains(cardinal)) {
-            if (user.isCurrent(cardinal)) {
-                user.initAttendance();
-                List<Meeting> meetings = meetingGetService.find(cardinal);
-                attendanceSaveService.save(user, meetings);
-            }
-
-            userUpdateService.applyOB(user, cardinal);
-        }
-    }
-
-    @Override
-    public void reset(Long userId) {
-        User user = userGetService.find(userId);
-        userUpdateService.reset(user, passwordEncoder);
-    }
-
-    private void validate(SignUp dto) {
+    private void validate(UserRequestDto.SignUp dto) {
         if (userGetService.validateStudentId(dto.studentId()))
             throw new StudentIdExistsException();
         if (userGetService.validateTel(dto.tel()))
             throw new TelExistsException();
     }
 
-    private void validate(Update dto, Long userId) {
-        if (userGetService.validateStudentId(dto.studentId(), userId))
-            throw new StudentIdExistsException();
-        if (userGetService.validateTel(dto.tel(), userId))
-            throw new TelExistsException();
-    }
-    private void validate(Register dto, Long userId) {
+    private void validate(UserRequestDto.Register dto, Long userId) {
         if (userGetService.validateStudentId(dto.studentId(), userId)) {
             throw new StudentIdExistsException();
         }
@@ -227,4 +113,5 @@ public class UserUseCaseImpl implements UserUseCase {
             throw new TelExistsException();
         }
     }
+
 }

--- a/src/main/java/leets/weeth/domain/user/presentation/UserAdminController.java
+++ b/src/main/java/leets/weeth/domain/user/presentation/UserAdminController.java
@@ -2,6 +2,7 @@ package leets.weeth.domain.user.presentation;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import leets.weeth.domain.user.application.usecase.UserManageUseCase;
 import leets.weeth.domain.user.application.usecase.UserUseCase;
 import leets.weeth.global.common.response.CommonResponse;
 import lombok.RequiredArgsConstructor;
@@ -18,46 +19,46 @@ import static leets.weeth.domain.user.presentation.ResponseMessage.*;
 @RequestMapping("/api/v1/admin/users")
 public class UserAdminController {
 
-    private final UserUseCase userUseCase;
+    private final UserManageUseCase userManageUseCase;
 
     @GetMapping("/all")
     @Operation(summary="어드민용 회원 조회")
     public CommonResponse<List<AdminResponse>> findAll() {
-        return CommonResponse.createSuccess(USER_FIND_ALL_SUCCESS.getMessage(), userUseCase.findAllByAdmin());
+        return CommonResponse.createSuccess(USER_FIND_ALL_SUCCESS.getMessage(), userManageUseCase.findAllByAdmin());
     }
 
     @PatchMapping
     @Operation(summary="가입 신청 승인")
     public CommonResponse<Void> accept(@RequestParam Long userId) {
-        userUseCase.accept(userId);
+        userManageUseCase.accept(userId);
         return CommonResponse.createSuccess(USER_ACCEPT_SUCCESS.getMessage());
     }
 
     @DeleteMapping
     @Operation(summary="유저 추방")
     public CommonResponse<Void> ban(@RequestParam Long userId) {
-        userUseCase.ban(userId);
+        userManageUseCase.ban(userId);
         return CommonResponse.createSuccess(USER_BAN_SUCCESS.getMessage());
     }
 
     @PatchMapping("/role")
     @Operation(summary="관리자로 승격/강등")
     public CommonResponse<Void> update(@RequestParam Long userId, @RequestParam String role) {
-        userUseCase.update(userId, role);
+        userManageUseCase.update(userId, role);
         return CommonResponse.createSuccess(USER_ROLE_UPDATE_SUCCESS.getMessage());
     }
 
     @PatchMapping("/apply")
     @Operation(summary="다음 기수도 이어서 진행")
     public CommonResponse<Void> applyOB(@RequestParam Long userId, @RequestParam Integer cardinal) {
-        userUseCase.applyOB(userId, cardinal);
+        userManageUseCase.applyOB(userId, cardinal);
         return CommonResponse.createSuccess(USER_APPLY_OB_SUCCESS.getMessage());
     }
 
     @PatchMapping("/reset")
     @Operation(summary="회원 비밀번호 초기화")
     public CommonResponse<Void> resetPassword(@RequestParam Long userId) {
-        userUseCase.reset(userId);
+        userManageUseCase.reset(userId);
         return CommonResponse.createSuccess(USER_PASSWORD_RESET_SUCCESS.getMessage());
     }
 }

--- a/src/main/java/leets/weeth/domain/user/presentation/UserController.java
+++ b/src/main/java/leets/weeth/domain/user/presentation/UserController.java
@@ -70,25 +70,25 @@ public class UserController {
     @GetMapping("/all")
     @Operation(summary="동아리 멤버 전체 조회(전체/기수별)")
     public CommonResponse<Map<Integer, List<SummaryResponse>>> findAllUser() {
-        return CommonResponse.createSuccess(USER_FIND_ALL_SUCCESS.getMessage(), userManageUseCase.findAllUser());
+        return CommonResponse.createSuccess(USER_FIND_ALL_SUCCESS.getMessage(), userUseCase.findAllUser());
     }
     @GetMapping("/details")
     @Operation(summary = "특정 멤버 상세 조회")
     public CommonResponse<UserResponse> findUser(@RequestParam Long userId) {
         return CommonResponse.createSuccess(
-                USER_DETAILS_SUCCESS.getMessage(), userManageUseCase.findUserDetails(userId)
+                USER_DETAILS_SUCCESS.getMessage(), userUseCase.findUserDetails(userId)
         );
     }
     @GetMapping
     @Operation(summary="내 정보 조회")
     public CommonResponse<Response> find(@Parameter(hidden = true) @CurrentUser Long userId) {
-        return CommonResponse.createSuccess(USER_FIND_BY_ID_SUCCESS.getMessage(), userManageUseCase.find(userId));
+        return CommonResponse.createSuccess(USER_FIND_BY_ID_SUCCESS.getMessage(), userUseCase.find(userId));
     }
 
     @PatchMapping
     @Operation(summary="내 정보 수정")
     public CommonResponse<Void> update(@RequestBody @Valid Update dto, @Parameter(hidden = true) @CurrentUser Long userId) {
-        userManageUseCase.update(dto, userId);
+        userUseCase.update(dto, userId);
         return CommonResponse.createSuccess(USER_UPDATE_SUCCESS.getMessage());
     }
 

--- a/src/main/java/leets/weeth/domain/user/presentation/UserController.java
+++ b/src/main/java/leets/weeth/domain/user/presentation/UserController.java
@@ -70,38 +70,38 @@ public class UserController {
     @GetMapping("/all")
     @Operation(summary="동아리 멤버 전체 조회(전체/기수별)")
     public CommonResponse<Map<Integer, List<SummaryResponse>>> findAllUser() {
-        return CommonResponse.createSuccess(USER_FIND_ALL_SUCCESS.getMessage(), userUseCase.findAllUser());
+        return CommonResponse.createSuccess(USER_FIND_ALL_SUCCESS.getMessage(), userManageUseCase.findAllUser());
     }
     @GetMapping("/details")
     @Operation(summary = "특정 멤버 상세 조회")
     public CommonResponse<UserResponse> findUser(@RequestParam Long userId) {
         return CommonResponse.createSuccess(
-                USER_DETAILS_SUCCESS.getMessage(), userUseCase.findUserDetails(userId)
+                USER_DETAILS_SUCCESS.getMessage(), userManageUseCase.findUserDetails(userId)
         );
     }
     @GetMapping
     @Operation(summary="내 정보 조회")
     public CommonResponse<Response> find(@Parameter(hidden = true) @CurrentUser Long userId) {
-        return CommonResponse.createSuccess(USER_FIND_BY_ID_SUCCESS.getMessage(), userUseCase.find(userId));
+        return CommonResponse.createSuccess(USER_FIND_BY_ID_SUCCESS.getMessage(), userManageUseCase.find(userId));
     }
 
     @PatchMapping
     @Operation(summary="내 정보 수정")
     public CommonResponse<Void> update(@RequestBody @Valid Update dto, @Parameter(hidden = true) @CurrentUser Long userId) {
-        userUseCase.update(dto, userId);
+        userManageUseCase.update(dto, userId);
         return CommonResponse.createSuccess(USER_UPDATE_SUCCESS.getMessage());
     }
 
     @DeleteMapping
     @Operation(summary="동아리 탈퇴")
     public CommonResponse<Void> leave(@Parameter(hidden = true) @CurrentUser Long userId) {
-        userUseCase.leave(userId);
+        userManageUseCase.leave(userId);
         return CommonResponse.createSuccess(USER_LEAVE_SUCCESS.getMessage());
     }
 
     @PostMapping("/refresh")
     @Operation(summary = "JWT 토큰 재발급 API")
     public CommonResponse<JwtDto> refresh(HttpServletRequest request) {
-        return CommonResponse.createSuccess(JWT_REFRESH_SUCCESS.getMessage(), userManageUseCase.refresh(request));
+        return CommonResponse.createSuccess(JWT_REFRESH_SUCCESS.getMessage(), userUseCase.refresh(request));
     }
 }

--- a/src/main/java/leets/weeth/domain/user/presentation/UserController.java
+++ b/src/main/java/leets/weeth/domain/user/presentation/UserController.java
@@ -101,7 +101,7 @@ public class UserController {
 
     @PostMapping("/refresh")
     @Operation(summary = "JWT 토큰 재발급 API")
-    public CommonResponse<JwtDto> refresh(HttpServletRequest request) {
-        return CommonResponse.createSuccess(JWT_REFRESH_SUCCESS.getMessage(), userUseCase.refresh(request));
+    public CommonResponse<JwtDto> refresh(@Parameter(hidden = true) @RequestHeader("Authorization_refresh") String refreshToken) {
+        return CommonResponse.createSuccess(JWT_REFRESH_SUCCESS.getMessage(), userUseCase.refresh(refreshToken));
     }
 }

--- a/src/main/java/leets/weeth/global/auth/jwt/application/usecase/JwtManageUseCase.java
+++ b/src/main/java/leets/weeth/global/auth/jwt/application/usecase/JwtManageUseCase.java
@@ -36,8 +36,7 @@ public class JwtManageUseCase {
     }
 
     // 토큰 재발급
-    public JwtDto reIssueToken(HttpServletRequest request){
-        String requestToken = jwtService.extractRefreshToken(request);
+    public JwtDto reIssueToken(String requestToken){
         jwtProvider.validate(requestToken);
 
         Long userId = jwtService.extractId(requestToken).get();


### PR DESCRIPTION
## PR 내용
- 관리 용이성을 위해 너무 많은 메서드가 작성된 UserUseCase를 UserManageUseCase로 분리 했습니다
- 기존 HttpServletRequest를 받아와서 refreshToken을 추출하던 부분을 @RequestHeader를 사용해 가져오도록 수정했습니다
<br>

## PR 세부사항
- 분리한 기준은 로그인+지원 / 그외 메서드로 분리했습니다.
- 어드민 기준으로 나눌까도 고민을 했는데, 이렇게 분리하는게 관리가 용이할 것 같아서 해당 방식으로 분리했습니다
- User 관련해서 별도의 로직을 추가하진 않았습니다
- 토큰을 헤더에서 가져오는 방식만 수정했습니다
<br>

## 관련 스크린샷

<br>

## 주의사항
X
<br>

## 체크 리스트

- [x] 리뷰어 설정
- [x] Assignee 설정
- [x] Label 설정
- [x] 제목 양식 맞췄나요? (ex. #0 Feat: 기능 추가)
- [x] 변경 사항에 대한 테스트