### PR TITLE
Refactor #91 소셜 로그인 연동 기능 구현 

### DIFF
--- a/src/main/java/leets/weeth/domain/user/application/dto/request/UserRequestDto.java
+++ b/src/main/java/leets/weeth/domain/user/application/dto/request/UserRequestDto.java
@@ -6,40 +6,49 @@ import jakarta.validation.constraints.NotNull;
 
 public class UserRequestDto {
 
-    public record login (
+    public record Login(
             @NotBlank String authCode
-    ){}
+    ) {
+    }
 
-    public record SignUp (
+    public record SignUp(
             @NotBlank String name,
             @Email @NotBlank String email,
-            @NotBlank        String password,
-            @NotBlank        String studentId,
-            @NotBlank        String tel,
+            @NotBlank String password,
+            @NotBlank String studentId,
+            @NotBlank String tel,
             @NotNull String position,
-            @NotNull         String department,
-            @NotNull         Integer cardinal
-    ) {}
-    public record Register (
+            @NotNull String department,
+            @NotNull Integer cardinal
+    ) {
+    }
+
+    public record Register(
+            @NotNull Long kakaoId,
             @NotBlank String name,
-            @NotBlank        String studentId,
-            @NotNull         String department,
-            @NotBlank        String tel,
-            @NotNull         Integer cardinal,
+            @NotBlank String studentId,
+            @NotNull String department,
+            @NotBlank String tel,
+            @NotNull Integer cardinal,
             @NotNull String position
-            ) {}
+    ) {
+    }
 
-    public record Update (
-            @NotBlank        String name,
+    public record Update(
+            @NotBlank String name,
             @Email @NotBlank String email,
-            @NotBlank        String password,
-            @NotBlank        String studentId,
-            @NotBlank        String tel,
-            @NotNull         String department
-    ) {}
+            @NotBlank String password,
+            @NotBlank String studentId,
+            @NotBlank String tel,
+            @NotNull String department
+    ) {
+    }
 
-    public record refreshRequest(
-            @Email String email
-    ){}
+    public record NormalLogin(
+            @NotBlank String email,
+            @NotBlank String passWord,
+            @NotNull Long kakaoId
+    ) {
+    }
 
 }

--- a/src/main/java/leets/weeth/domain/user/application/dto/response/UserResponseDto.java
+++ b/src/main/java/leets/weeth/domain/user/application/dto/response/UserResponseDto.java
@@ -12,6 +12,7 @@ public class UserResponseDto {
 
     public record SocialLoginResponse(
             Long id,
+            Long kakaoId,
             LoginStatus status,
             String accessToken,
             String refreshToken
@@ -30,12 +31,15 @@ public class UserResponseDto {
             Role role
     ) {
     }
+
     public record SummaryResponse(
             Integer id,
             String name,
             List<Integer> cardinals,
             Position position
-    ) {}
+    ) {
+    }
+
     public record AdminResponse(
             Integer id,
             String name,
@@ -55,6 +59,7 @@ public class UserResponseDto {
             LocalDateTime modifiedAt
     ) {
     }
+
     public record UserResponse(
             Integer id,
             String name,
@@ -63,6 +68,11 @@ public class UserResponseDto {
             String department,
             List<Integer> cardinals,
             Position position
+    ) {
+    }
+
+    public record SocialAuthResponse(
+            Long kakaoId
     ) {
     }
 }

--- a/src/main/java/leets/weeth/domain/user/application/exception/PasswordMismatchException.java
+++ b/src/main/java/leets/weeth/domain/user/application/exception/PasswordMismatchException.java
@@ -1,0 +1,9 @@
+package leets.weeth.domain.user.application.exception;
+
+import leets.weeth.global.common.exception.BusinessLogicException;
+
+public class PasswordMismatchException extends BusinessLogicException {
+    public PasswordMismatchException() {
+        super(400, "비밀번호가 일치하지 않습니다.");
+    }
+}

--- a/src/main/java/leets/weeth/domain/user/application/exception/UserInActiveException.java
+++ b/src/main/java/leets/weeth/domain/user/application/exception/UserInActiveException.java
@@ -1,0 +1,9 @@
+package leets.weeth.domain.user.application.exception;
+
+import leets.weeth.global.common.exception.BusinessLogicException;
+
+public class UserInActiveException extends BusinessLogicException {
+    public UserInActiveException() {
+        super(403, "가입 승인이 허가되지 않은 계정입니다.");
+    }
+}

--- a/src/main/java/leets/weeth/domain/user/application/mapper/UserMapper.java
+++ b/src/main/java/leets/weeth/domain/user/application/mapper/UserMapper.java
@@ -1,15 +1,15 @@
 package leets.weeth.domain.user.application.mapper;
 
-import leets.weeth.domain.user.application.dto.response.UserResponseDto.SummaryResponse;
-import leets.weeth.domain.user.application.dto.response.UserResponseDto.UserResponse;
+import leets.weeth.domain.user.application.dto.response.UserResponseDto.*;
 import leets.weeth.domain.user.domain.entity.User;
 import leets.weeth.domain.user.domain.entity.enums.Department;
+import leets.weeth.global.auth.jwt.application.dto.JwtDto;
 import org.mapstruct.*;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import static leets.weeth.domain.user.application.dto.request.UserRequestDto.Register;
 import static leets.weeth.domain.user.application.dto.request.UserRequestDto.SignUp;
-import static leets.weeth.domain.user.application.dto.response.UserResponseDto.AdminResponse;
-import static leets.weeth.domain.user.application.dto.response.UserResponseDto.Response;
+import static leets.weeth.domain.user.application.dto.response.UserResponseDto.*;
 
 @Mapper(componentModel = MappingConstants.ComponentModel.SPRING, unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface UserMapper {
@@ -21,6 +21,12 @@ public interface UserMapper {
     })
     User from(SignUp dto, @Context PasswordEncoder passwordEncoder);
 
+    @Mappings({
+            @Mapping(target = "cardinals", expression = "java( java.util.List.of(dto.cardinal()) )"),
+            @Mapping(target = "department", expression = "java( leets.weeth.domain.user.domain.entity.enums.Department.to(dto.department()) )")
+    })
+    User from(Register dto);
+
     @Mapping(target = "department", expression = "java( toString(user.getDepartment()) )")
     Response to(User user);
 
@@ -31,10 +37,25 @@ public interface UserMapper {
 
     SummaryResponse toSummaryResponse(User user);
 
+    SocialAuthResponse toSocialAuthResponse(Long kakaoId);
+
+    @Mappings({
+            @Mapping(target = "status", expression = "java(LoginStatus.LOGIN)"),
+            @Mapping(target = "id", source = "user.id"),
+            @Mapping(target = "kakaoId", source = "user.kakaoId"),
+    })
+    SocialLoginResponse toLoginResponse(User user, JwtDto dto);
+
+    @Mappings({
+            @Mapping(target = "status", expression = "java(LoginStatus.INTEGRATE)"),
+    })
+    SocialLoginResponse toIntegrateResponse(Long kakaoId);
+
     @Mappings({
             // 상세 데이터 매핑
     })
     UserResponse toUserResponse(User user);
+
     default String toString(Department department) {
         return department.getValue();
     }

--- a/src/main/java/leets/weeth/domain/user/application/usecase/UserManageUseCase.java
+++ b/src/main/java/leets/weeth/domain/user/application/usecase/UserManageUseCase.java
@@ -1,13 +1,10 @@
 package leets.weeth.domain.user.application.usecase;
 
-import leets.weeth.domain.user.application.dto.request.UserRequestDto;
 import leets.weeth.domain.user.application.dto.response.UserResponseDto;
 
 import java.util.List;
-import java.util.Map;
 
 public interface UserManageUseCase {
-
 
 
     List<UserResponseDto.AdminResponse> findAllByAdmin();

--- a/src/main/java/leets/weeth/domain/user/application/usecase/UserManageUseCase.java
+++ b/src/main/java/leets/weeth/domain/user/application/usecase/UserManageUseCase.java
@@ -1,14 +1,10 @@
 package leets.weeth.domain.user.application.usecase;
 
-import jakarta.servlet.http.HttpServletRequest;
 import leets.weeth.domain.user.application.dto.request.UserRequestDto;
 import leets.weeth.domain.user.application.dto.response.UserResponseDto;
-import leets.weeth.global.auth.jwt.application.dto.JwtDto;
 
 import java.util.List;
 import java.util.Map;
-
-import static leets.weeth.domain.user.application.dto.request.UserRequestDto.refreshRequest;
 
 public interface UserManageUseCase {
 

--- a/src/main/java/leets/weeth/domain/user/application/usecase/UserManageUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/user/application/usecase/UserManageUseCaseImpl.java
@@ -4,35 +4,19 @@ import jakarta.transaction.Transactional;
 import leets.weeth.domain.attendance.domain.service.AttendanceSaveService;
 import leets.weeth.domain.schedule.domain.entity.Meeting;
 import leets.weeth.domain.schedule.domain.service.MeetingGetService;
-import leets.weeth.domain.user.application.exception.StudentIdExistsException;
-import leets.weeth.domain.user.application.exception.TelExistsException;
 import leets.weeth.domain.user.application.mapper.UserMapper;
 import leets.weeth.domain.user.domain.entity.User;
 import leets.weeth.domain.user.domain.service.UserDeleteService;
 import leets.weeth.domain.user.domain.service.UserGetService;
-import leets.weeth.domain.user.domain.service.UserSaveService;
 import leets.weeth.domain.user.domain.service.UserUpdateService;
-import leets.weeth.global.auth.jwt.application.dto.JwtDto;
-import leets.weeth.global.auth.jwt.application.usecase.JwtManageUseCase;
 import leets.weeth.global.auth.jwt.service.JwtRedisService;
-import leets.weeth.global.auth.kakao.KakaoAuthService;
-import leets.weeth.global.auth.kakao.dto.KakaoTokenResponse;
-import leets.weeth.global.auth.kakao.dto.KakaoUserInfoResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
-import java.util.AbstractMap;
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
-import static leets.weeth.domain.user.application.dto.request.UserRequestDto.*;
-import static leets.weeth.domain.user.application.dto.response.UserResponseDto.*;
-import static leets.weeth.domain.user.domain.entity.enums.LoginStatus.LOGIN;
-import static leets.weeth.domain.user.domain.entity.enums.LoginStatus.REGISTER;
-import static leets.weeth.domain.user.domain.entity.enums.Status.ACTIVE;
+import static leets.weeth.domain.user.application.dto.response.UserResponseDto.AdminResponse;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCase.java
+++ b/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCase.java
@@ -34,7 +34,7 @@ public interface UserUseCase {
 
     void apply(SignUp dto);
 
-    void register(Register dto, Long userId);
+    void register(Register dto);
 
     JwtDto refresh(String refreshToken);
 

--- a/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCase.java
+++ b/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCase.java
@@ -34,7 +34,7 @@ public interface UserUseCase {
 
     void apply(SignUp dto);
 
-    void register(Register dto);
+    void socialRegister(Register dto);
 
     JwtDto refresh(String refreshToken);
 

--- a/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCase.java
+++ b/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCase.java
@@ -1,11 +1,6 @@
 package leets.weeth.domain.user.application.usecase;
 
-import jakarta.servlet.http.HttpServletRequest;
-import leets.weeth.domain.user.application.dto.request.UserRequestDto;
 import leets.weeth.global.auth.jwt.application.dto.JwtDto;
-
-import java.util.List;
-import java.util.Map;
 
 import static leets.weeth.domain.user.application.dto.request.UserRequestDto.*;
 import static leets.weeth.domain.user.application.dto.response.UserResponseDto.*;
@@ -13,12 +8,15 @@ import static leets.weeth.domain.user.application.dto.response.UserResponseDto.*
 
 public interface UserUseCase {
 
-    SocialLoginResponse login(UserRequestDto.login dto);
+    SocialLoginResponse login(Login dto);
+
+    SocialAuthResponse authenticate(Login dto);
+
+    SocialLoginResponse integrate(NormalLogin dto);
 
     void apply(SignUp dto);
 
-    void register(Register dto, Long userId);
+    void register(Register dto);
 
     JwtDto refresh(String refreshToken);
-
 }

--- a/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCaseImpl.java
@@ -144,7 +144,7 @@ public class UserUseCaseImpl implements UserUseCase {
 
     @Override
     @Transactional
-    public void register(Register dto) {
+    public void socialRegister(Register dto) {
         validate(dto);
         userSaveService.save(mapper.from(dto));
     }

--- a/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCaseImpl.java
@@ -1,10 +1,10 @@
 package leets.weeth.domain.user.application.usecase;
 
-import jakarta.servlet.http.HttpServletRequest;
-import leets.weeth.domain.user.application.dto.request.UserRequestDto;
 import leets.weeth.domain.user.application.dto.response.UserResponseDto;
+import leets.weeth.domain.user.application.exception.PasswordMismatchException;
 import leets.weeth.domain.user.application.exception.StudentIdExistsException;
 import leets.weeth.domain.user.application.exception.TelExistsException;
+import leets.weeth.domain.user.application.exception.UserInActiveException;
 import leets.weeth.domain.user.application.mapper.UserMapper;
 import leets.weeth.domain.user.domain.entity.User;
 import leets.weeth.domain.user.domain.service.UserGetService;
@@ -21,17 +21,15 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import static leets.weeth.domain.user.application.dto.request.UserRequestDto.NormalLogin;
-import static leets.weeth.domain.user.application.dto.response.UserResponseDto.SocialAuthResponse;
-import static leets.weeth.domain.user.application.dto.response.UserResponseDto.SocialLoginResponse;
 import java.util.AbstractMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static leets.weeth.domain.user.domain.entity.enums.LoginStatus.LOGIN;
-import static leets.weeth.domain.user.domain.entity.enums.LoginStatus.REGISTER;
+import static leets.weeth.domain.user.application.dto.request.UserRequestDto.*;
+import static leets.weeth.domain.user.application.dto.response.UserResponseDto.SocialAuthResponse;
+import static leets.weeth.domain.user.application.dto.response.UserResponseDto.SocialLoginResponse;
 import static leets.weeth.domain.user.domain.entity.enums.Status.ACTIVE;
 
 @Slf4j
@@ -130,7 +128,7 @@ public class UserUseCaseImpl implements UserUseCase {
     }
 
     @Override
-    public void update(UserRequestDto.Update dto, Long userId) {
+    public void update(Update dto, Long userId) {
         validate(dto, userId);
         User user = userGetService.find(userId);
         userUpdateService.update(user, dto, passwordEncoder);
@@ -168,29 +166,26 @@ public class UserUseCaseImpl implements UserUseCase {
         return userInfo.id();
     }
 
-    private void validate(SignUp dto) {
-
-    private void validate(UserRequestDto.Update dto, Long userId) {
+    private void validate(Update dto, Long userId) {
         if (userGetService.validateStudentId(dto.studentId(), userId))
             throw new StudentIdExistsException();
         if (userGetService.validateTel(dto.tel(), userId))
             throw new TelExistsException();
     }
 
-    private void validate(UserRequestDto.SignUp dto) {
+    private void validate(SignUp dto) {
         if (userGetService.validateStudentId(dto.studentId()))
             throw new StudentIdExistsException();
         if (userGetService.validateTel(dto.tel()))
             throw new TelExistsException();
     }
 
-    private void validate(UserRequestDto.Register dto, Long userId) {
-        if (userGetService.validateStudentId(dto.studentId(), userId)) {
+    private void validate(Register dto) {
+        if (userGetService.validateStudentId(dto.studentId())) {
             throw new StudentIdExistsException();
         }
-        if (userGetService.validateTel(dto.tel(), userId)) {
+        if (userGetService.validateTel(dto.tel())) {
             throw new TelExistsException();
         }
     }
-
 }

--- a/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCaseImpl.java
@@ -24,6 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.AbstractMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -50,12 +51,13 @@ public class UserUseCaseImpl implements UserUseCase {
     @Transactional(readOnly = true)
     public SocialLoginResponse login(Login dto) {
         long kakaoId = getKakaoId(dto);
-        User user = userGetService.find(kakaoId);
+        Optional<User> optionalUser = userGetService.find(kakaoId);
 
-        if (user == null) {
+        if (optionalUser.isEmpty()) {
             return mapper.toIntegrateResponse(kakaoId);
         }
 
+        User user = optionalUser.get();
         if (user.isInactive()) {
             throw new UserInActiveException();
         }

--- a/src/main/java/leets/weeth/domain/user/domain/entity/User.java
+++ b/src/main/java/leets/weeth/domain/user/domain/entity/User.java
@@ -36,6 +36,8 @@ public class User extends BaseEntity {
     @Column(name = "user_id")
     private Long id;
 
+    private Long kakaoId;
+
     private String name;
 
     private String email;
@@ -83,6 +85,10 @@ public class User extends BaseEntity {
         absenceCount = 0;
         attendanceRate = 0;
         penaltyCount = 0;
+    }
+
+    public void addKakaoId(long kakaoId) {
+        this.kakaoId = kakaoId;
     }
 
     public void leave() {

--- a/src/main/java/leets/weeth/domain/user/domain/entity/User.java
+++ b/src/main/java/leets/weeth/domain/user/domain/entity/User.java
@@ -99,6 +99,9 @@ public class User extends BaseEntity {
         this.cardinals.add(cardinal);
     }
 
+    /*
+    todo 차후 일반 로그인 비활성화시 해당 메서드에서 예외를 날리도록 수정
+     */
     public boolean isInactive() {
         return this.status != Status.ACTIVE;
     }

--- a/src/main/java/leets/weeth/domain/user/domain/entity/enums/LoginStatus.java
+++ b/src/main/java/leets/weeth/domain/user/domain/entity/enums/LoginStatus.java
@@ -1,5 +1,5 @@
 package leets.weeth.domain.user.domain.entity.enums;
 
 public enum LoginStatus {
-    LOGIN, REGISTER
+    LOGIN, REGISTER, INTEGRATE
 }

--- a/src/main/java/leets/weeth/domain/user/domain/repository/UserRepository.java
+++ b/src/main/java/leets/weeth/domain/user/domain/repository/UserRepository.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByEmail(String email);
+    Optional<User> findByKakaoId(long kakaoId);
 
     boolean existsByEmail(String email);
     boolean existsByStudentId(String studentId);

--- a/src/main/java/leets/weeth/domain/user/domain/service/UserGetService.java
+++ b/src/main/java/leets/weeth/domain/user/domain/service/UserGetService.java
@@ -25,6 +25,11 @@ public class UserGetService {
                 .orElseThrow(UserNotFoundException::new);
     }
 
+    public User find(long kakaoId){
+        return userRepository.findByKakaoId(kakaoId)
+                .orElse(null);
+    }
+
     public Boolean check(String email) {
         return !userRepository.existsByEmail(email);
     }

--- a/src/main/java/leets/weeth/domain/user/domain/service/UserGetService.java
+++ b/src/main/java/leets/weeth/domain/user/domain/service/UserGetService.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -25,9 +26,8 @@ public class UserGetService {
                 .orElseThrow(UserNotFoundException::new);
     }
 
-    public User find(long kakaoId){
-        return userRepository.findByKakaoId(kakaoId)
-                .orElse(null);
+    public Optional<User> find(long kakaoId){
+        return userRepository.findByKakaoId(kakaoId);
     }
 
     public Boolean check(String email) {

--- a/src/main/java/leets/weeth/domain/user/presentation/ResponseMessage.java
+++ b/src/main/java/leets/weeth/domain/user/presentation/ResponseMessage.java
@@ -22,6 +22,8 @@ public enum ResponseMessage {
     USER_LEAVE_SUCCESS("회원 탈퇴가 성공적으로 처리되었습니다."),
     SOCIAL_LOGIN_SUCCESS("소셜 로그인에 성공했습니다."),
     SOCIAL_REGISTER_SUCCESS("소셜 회원가입에 성공했습니다."),
+    SOCIAL_AUTH_SUCCESS("소셜 인증에 성공했습니다."),
+    SOCIAL_INTEGRATE_SUCCESS("소셜 로그인 연동에 성공했습니다."),
     JWT_REFRESH_SUCCESS("토큰 재발급에 성공했습니다.");
 
     private final String message;

--- a/src/main/java/leets/weeth/domain/user/presentation/UserController.java
+++ b/src/main/java/leets/weeth/domain/user/presentation/UserController.java
@@ -55,8 +55,8 @@ public class UserController {
         return CommonResponse.createSuccess(USER_APPLY_SUCCESS.getMessage());
     }
 
-    @PatchMapping("/register")
-    @Operation(summary = "소셜 회원가입 후 정보입력")
+    @PostMapping("/register")
+    @Operation(summary = "소셜 회원가입")
     public CommonResponse<Void> register(@RequestBody @Valid Register dto) {
         userUseCase.register(dto);
         return CommonResponse.createSuccess(USER_APPLY_SUCCESS.getMessage());

--- a/src/main/java/leets/weeth/domain/user/presentation/UserController.java
+++ b/src/main/java/leets/weeth/domain/user/presentation/UserController.java
@@ -3,8 +3,8 @@ package leets.weeth.domain.user.presentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
+import leets.weeth.domain.user.application.dto.response.UserResponseDto;
 import leets.weeth.domain.user.application.dto.response.UserResponseDto.SummaryResponse;
 import leets.weeth.domain.user.application.dto.response.UserResponseDto.UserResponse;
 import leets.weeth.domain.user.application.usecase.UserManageUseCase;
@@ -22,7 +22,6 @@ import java.util.Map;
 import static leets.weeth.domain.user.application.dto.request.UserRequestDto.*;
 import static leets.weeth.domain.user.application.dto.response.UserResponseDto.Response;
 import static leets.weeth.domain.user.application.dto.response.UserResponseDto.SocialLoginResponse;
-import static leets.weeth.domain.user.domain.entity.enums.LoginStatus.LOGIN;
 import static leets.weeth.domain.user.presentation.ResponseMessage.*;
 
 @Tag(name = "UserController", description = "사용자 관련 컨트롤러")
@@ -36,42 +35,51 @@ public class UserController {
     private final UserGetService userGetService;
 
     @PostMapping("/social-login")
-    @Operation(summary = "카카오 소셜 로그인/회원가입 API")
-    public CommonResponse<SocialLoginResponse> login(@RequestBody @Valid login dto) {
+    @Operation(summary = "카카오 소셜 로그인 API")
+    public CommonResponse<SocialLoginResponse> login(@RequestBody @Valid Login dto) {
         SocialLoginResponse response = userUseCase.login(dto);
-        if (response.status() == LOGIN) {
-            return CommonResponse.createSuccess(SOCIAL_LOGIN_SUCCESS.getMessage(), response);
-        }
-        return CommonResponse.createSuccess(SOCIAL_REGISTER_SUCCESS.getMessage(), response);
+        return CommonResponse.createSuccess(SOCIAL_LOGIN_SUCCESS.getMessage(), response);
+    }
+
+    @PostMapping("/social-auth")
+    @Operation(summary = "카카오 소셜 회원가입 전 요청 API")
+    public CommonResponse<UserResponseDto.SocialAuthResponse> beforeRegister(@RequestBody @Valid Login dto) {
+        UserResponseDto.SocialAuthResponse response = userUseCase.authenticate(dto);
+        return CommonResponse.createSuccess(SOCIAL_AUTH_SUCCESS.getMessage(), response);
     }
 
     @PostMapping("/apply")
-    @Operation(summary="동아리 지원 신청")
+    @Operation(summary = "동아리 지원 신청")
     public CommonResponse<Void> apply(@RequestBody @Valid SignUp dto) {
         userUseCase.apply(dto);
         return CommonResponse.createSuccess(USER_APPLY_SUCCESS.getMessage());
     }
 
     @PatchMapping("/register")
-    @Operation(summary = "소셜 로그인 후 정보입력")
-    public CommonResponse<Void> register(
-            @RequestBody @Valid Register dto,
-            @Parameter(hidden = true) @CurrentUser Long userId) {
-        userUseCase.register(dto, userId);
+    @Operation(summary = "소셜 회원가입 후 정보입력")
+    public CommonResponse<Void> register(@RequestBody @Valid Register dto) {
+        userUseCase.register(dto);
         return CommonResponse.createSuccess(USER_APPLY_SUCCESS.getMessage());
     }
 
+    @PatchMapping("/integrate")
+    @Operation(summary = "카카오 소셜 로그인 연동")
+    public CommonResponse<SocialLoginResponse> integrate(@RequestBody @Valid NormalLogin dto) {
+        return CommonResponse.createSuccess(SOCIAL_INTEGRATE_SUCCESS.getMessage(), userUseCase.integrate(dto));
+    }
+
     @GetMapping("/email")
-    @Operation(summary="이메일 중복 확인")
+    @Operation(summary = "이메일 중복 확인")
     public CommonResponse<Boolean> checkEmail(@RequestParam String email) {
         return CommonResponse.createSuccess(USER_EMAIL_CHECK_SUCCESS.getMessage(), userGetService.check(email));
     }
 
     @GetMapping("/all")
-    @Operation(summary="동아리 멤버 전체 조회(전체/기수별)")
+    @Operation(summary = "동아리 멤버 전체 조회(전체/기수별)")
     public CommonResponse<Map<Integer, List<SummaryResponse>>> findAllUser() {
         return CommonResponse.createSuccess(USER_FIND_ALL_SUCCESS.getMessage(), userManageUseCase.findAllUser());
     }
+
     @GetMapping("/details")
     @Operation(summary = "특정 멤버 상세 조회")
     public CommonResponse<UserResponse> findUser(@RequestParam Long userId) {
@@ -79,21 +87,22 @@ public class UserController {
                 USER_DETAILS_SUCCESS.getMessage(), userManageUseCase.findUserDetails(userId)
         );
     }
+
     @GetMapping
-    @Operation(summary="내 정보 조회")
+    @Operation(summary = "내 정보 조회")
     public CommonResponse<Response> find(@Parameter(hidden = true) @CurrentUser Long userId) {
         return CommonResponse.createSuccess(USER_FIND_BY_ID_SUCCESS.getMessage(), userManageUseCase.find(userId));
     }
 
     @PatchMapping
-    @Operation(summary="내 정보 수정")
+    @Operation(summary = "내 정보 수정")
     public CommonResponse<Void> update(@RequestBody @Valid Update dto, @Parameter(hidden = true) @CurrentUser Long userId) {
         userManageUseCase.update(dto, userId);
         return CommonResponse.createSuccess(USER_UPDATE_SUCCESS.getMessage());
     }
 
     @DeleteMapping
-    @Operation(summary="동아리 탈퇴")
+    @Operation(summary = "동아리 탈퇴")
     public CommonResponse<Void> leave(@Parameter(hidden = true) @CurrentUser Long userId) {
         userManageUseCase.leave(userId);
         return CommonResponse.createSuccess(USER_LEAVE_SUCCESS.getMessage());

--- a/src/main/java/leets/weeth/domain/user/presentation/UserController.java
+++ b/src/main/java/leets/weeth/domain/user/presentation/UserController.java
@@ -58,7 +58,7 @@ public class UserController {
     @PostMapping("/kakao/register")
     @Operation(summary = "소셜 회원가입")
     public CommonResponse<Void> register(@RequestBody @Valid Register dto) {
-        userUseCase.register(dto);
+        userUseCase.socialRegister(dto);
         return CommonResponse.createSuccess(USER_APPLY_SUCCESS.getMessage());
     }
 

--- a/src/main/java/leets/weeth/domain/user/presentation/UserController.java
+++ b/src/main/java/leets/weeth/domain/user/presentation/UserController.java
@@ -49,13 +49,13 @@ public class UserController {
     }
 
     @PostMapping("/apply")
-    @Operation(summary = "동아리 지원 신청")
+    @Operation(summary = "동아리 지원 신청. 현재 사용하지 않으므로 회원가입 시 social-register api로 요청 바람")
     public CommonResponse<Void> apply(@RequestBody @Valid SignUp dto) {
         userUseCase.apply(dto);
         return CommonResponse.createSuccess(USER_APPLY_SUCCESS.getMessage());
     }
 
-    @PostMapping("/register")
+    @PostMapping("/social-register")
     @Operation(summary = "소셜 회원가입")
     public CommonResponse<Void> register(@RequestBody @Valid Register dto) {
         userUseCase.register(dto);

--- a/src/main/java/leets/weeth/domain/user/presentation/UserController.java
+++ b/src/main/java/leets/weeth/domain/user/presentation/UserController.java
@@ -34,14 +34,14 @@ public class UserController {
     private final UserManageUseCase userManageUseCase;
     private final UserGetService userGetService;
 
-    @PostMapping("/social-login")
+    @PostMapping("/kakao/login")
     @Operation(summary = "카카오 소셜 로그인 API")
     public CommonResponse<SocialLoginResponse> login(@RequestBody @Valid Login dto) {
         SocialLoginResponse response = userUseCase.login(dto);
         return CommonResponse.createSuccess(SOCIAL_LOGIN_SUCCESS.getMessage(), response);
     }
 
-    @PostMapping("/social-auth")
+    @PostMapping("/kakao/auth")
     @Operation(summary = "카카오 소셜 회원가입 전 요청 API")
     public CommonResponse<UserResponseDto.SocialAuthResponse> beforeRegister(@RequestBody @Valid Login dto) {
         UserResponseDto.SocialAuthResponse response = userUseCase.authenticate(dto);
@@ -55,14 +55,14 @@ public class UserController {
         return CommonResponse.createSuccess(USER_APPLY_SUCCESS.getMessage());
     }
 
-    @PostMapping("/social-register")
+    @PostMapping("/kakao/register")
     @Operation(summary = "소셜 회원가입")
     public CommonResponse<Void> register(@RequestBody @Valid Register dto) {
         userUseCase.register(dto);
         return CommonResponse.createSuccess(USER_APPLY_SUCCESS.getMessage());
     }
 
-    @PatchMapping("/integrate")
+    @PatchMapping("/kakao/link")
     @Operation(summary = "카카오 소셜 로그인 연동")
     public CommonResponse<SocialLoginResponse> integrate(@RequestBody @Valid NormalLogin dto) {
         return CommonResponse.createSuccess(SOCIAL_INTEGRATE_SUCCESS.getMessage(), userUseCase.integrate(dto));

--- a/src/main/java/leets/weeth/global/config/SecurityConfig.java
+++ b/src/main/java/leets/weeth/global/config/SecurityConfig.java
@@ -73,7 +73,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(
                         authorize ->
                                 authorize
-                                        .requestMatchers("/api/v1/users/social-login", "/api/v1/users/apply", "/api/v1/users/email", "/api/v1/users/refresh").permitAll()
+                                        .requestMatchers("/api/v1/users/social-login", "api/v1/users/social-auth", "api/v1/users/integrate", "/api/v1/users/apply", "/api/v1/users/register", "/api/v1/users/email", "/api/v1/users/refresh").permitAll()
                                         .requestMatchers("/health-check").permitAll()
                                         .requestMatchers("/admin", "/admin/login", "/admin/account", "/admin/meeting", "/admin/member", "/admin/penalty",
                                                 "/js/**", "/img/**", "/scss/**", "/vendor/**").permitAll()


### PR DESCRIPTION
## PR 내용
- 기존 로그인으로 회원가입한 사용자가 카카오 소셜 로그인으로 연동할 수 있는 기능을 구현했습니다
- 가입 승인 이후에 JWT Token을 반환해야하기 떄문에 일부 로직을 수정했습니다
<br>

## PR 세부사항
- 카카오 소셜 로그인 연동을 위해 social-login , social-register, social-auth 메서드를 사용했습니다
- 로그인은 login/integrate로 사용되고, auth는 소셜 회원가입시 kakaoId를 프론트 측으로 전달하기 위한 api 입니다

- 자세한 플로우는 아래와 같습니다
### 소셜 회원가입
1. kakao 인증 (social-auth)
``` json
{
  "code": 200,
  "message": "소셜 인증에 성공했습니다.",
  "data": {
    "kakaoId": 3765018989
  }
}
```

2. 소셜 회원가입 (social-register)
``` json
{
  "kakaoId": 3765018989,
  "name": "이강혁",
  "studentId": "20203189",
  "department": "인공지능전공",
  "tel": "010",
  "cardinal": 1,
  "position": "BE"
}
```

```json
{
  "code": 200,
  "message": "회원 가입 신청이 성공적으로 처리되었습니다.",
  "data": null
}
```

3. 소셜 로그인(social-login)
```json
{
  "code": 403,
  "message": "가입 승인이 허가되지 않은 계정입니다.",
  "data": null
}
```

```json
{
  "code": 200,
  "message": "소셜 로그인에 성공했습니다.",
  "data": {
    "id": 3,
    "kakaoId": 3765018989,
    "status": "LOGIN",
    "accessToken": "eyJ0eXAiOiJKV1QiLCJhbGciOiW1haWwiOm51bGx9.ROvg88jFJ_D_RN_C69LQXie7uczNurTWEQE4pgCwGzTInKohs5tdOCYKzhaqVx_w",
    "refreshToken": "eyJ0eXAiOiJKV1QiLCJhIiOiJSZWZyZXNoVG9rZW4iLCJpZCI6MywiZXhwIjoxNzM0NTaRkr4XwfLTtyJC0Wow2Obqc8AJfFwoEmROQA"
  }
}
```

### 소셜 로그인
#### 연동 전
1. social-login api 요청
```json
{
  "code": 200,
  "message": "소셜 로그인에 성공했습니다.",
  "data": {
    "id": null,
    "kakaoId": 3765018989,
    "status": "INTEGRATE",
    "accessToken": null,
    "refreshToken": null
  }
}
```

2. integrate api 요청
- 이메일이 틀릴시
```json
{
  "code": 404,
  "message": "존재하지 않는 유저입니다.",
  "data": null
}
```

- 비밀번호 오류시
```json
{
  "code": 400,
  "message": "비밀번호가 일치하지 않습니다.",
  "data": null
}
```

- 가입 승인이 안될시(정말 만약에)
```json
{
  "code": 403,
  "message": "가입 승인이 허가되지 않은 계정입니다.",
  "data": null
}
```

- ID, 비번이 맞을시
```json
{
  "code": 200,
  "message": "소셜 로그인 연동에 성공했습니다.",
  "data": {
    "id": 2,
    "kakaoId": 3765018989,
    "status": "LOGIN",
    "accessToken": "eyJ0eXAiOiJKV1QixMiJ9.eyJzdHJpbmdAc3RyaW5nLmNvbSJ9.eWf6Nvom",
    "refreshToken": "eyJ0eXAiOiJKV1MiJ9.eyJzdWIiOiJSZWZyZXNoVG9rZW4iLCJpZCI6MiwiZXhwIjoxNzM0NTk3MDI3Q"
  }
}
```

#### 연동 후, 소셜 회원가입 후
``` json
{
  "code": 200,
  "message": "소셜 로그인에 성공했습니다.",
  "data": {
    "id": 3,
    "kakaoId": 3765018989,
    "status": "LOGIN",
    "accessToken": "eyJ0eXAiOiJKV1QJIUzUxMiJ9.eyJzdWIiOiJBY2Nlc3NUb2tlbiIsInJvbGUiOiJVU0VSIiwiaWQxbhVULxSGpgCwGzTInKoMEaoFhsqVx_w",
    "refreshToken": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9..6nF8xnyFN-z4_-wwGuidBdYvxWofy5ZXlFCzwaRkr4XwfLTtyJC0Wow2Obqc8AJfFwoEmROQA"
  }
}
```

<br>

## 관련 스크린샷

<br>

## 주의사항
- 소셜 회원가입시 이메일을 입력을 받아야할지 고민입니다. 기존 로그인이 없어진다면 이메일을 쓸 일이 없기 때문
- 토큰 발급 시기가 변함에 따라 register 메서드를 일부 수정했습니

<br>

## 체크 리스트

- [x] 리뷰어 설정
- [x] Assignee 설정
- [x] Label 설정
- [x] 제목 양식 맞췄나요? (ex. #0 Feat: 기능 추가)
- [x] 변경 사항에 대한 테스트