### PR TITLE
Feat #92 전역 내정보 조회

### DIFF
--- a/src/main/java/leets/weeth/domain/user/application/dto/response/UserResponseDto.java
+++ b/src/main/java/leets/weeth/domain/user/application/dto/response/UserResponseDto.java
@@ -36,7 +36,8 @@ public class UserResponseDto {
             Integer id,
             String name,
             List<Integer> cardinals,
-            Position position
+            Position position,
+            Role role
     ) {
     }
 
@@ -73,6 +74,14 @@ public class UserResponseDto {
 
     public record SocialAuthResponse(
             Long kakaoId
+    ) {
+    }
+
+    public record UserInfo(
+            Long id,
+            String name,
+            List<Integer> cardinals,
+            Role role
     ) {
     }
 }

--- a/src/main/java/leets/weeth/domain/user/application/mapper/UserMapper.java
+++ b/src/main/java/leets/weeth/domain/user/application/mapper/UserMapper.java
@@ -60,6 +60,7 @@ public interface UserMapper {
     UserResponse toUserResponse(User user);
 
     UserResponseDto.UserInfo toUserInfoDto(User user);
+
     default String toString(Department department) {
         return department.getValue();
     }

--- a/src/main/java/leets/weeth/domain/user/application/mapper/UserMapper.java
+++ b/src/main/java/leets/weeth/domain/user/application/mapper/UserMapper.java
@@ -1,6 +1,9 @@
 package leets.weeth.domain.user.application.mapper;
 
 import leets.weeth.domain.user.application.dto.response.UserResponseDto.*;
+import leets.weeth.domain.user.application.dto.response.UserResponseDto;
+import leets.weeth.domain.user.application.dto.response.UserResponseDto.SummaryResponse;
+import leets.weeth.domain.user.application.dto.response.UserResponseDto.UserResponse;
 import leets.weeth.domain.user.domain.entity.User;
 import leets.weeth.domain.user.domain.entity.enums.Department;
 import leets.weeth.global.auth.jwt.application.dto.JwtDto;
@@ -56,6 +59,7 @@ public interface UserMapper {
     })
     UserResponse toUserResponse(User user);
 
+    UserResponseDto.UserInfo toUserInfoDto(User user);
     default String toString(Department department) {
         return department.getValue();
     }

--- a/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCase.java
+++ b/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCase.java
@@ -38,4 +38,6 @@ public interface UserUseCase {
 
     JwtDto refresh(String refreshToken);
 
+    UserResponseDto.UserInfo findUserInfo(Long userId);
+
 }

--- a/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCaseImpl.java
@@ -164,6 +164,7 @@ public class UserUseCaseImpl implements UserUseCase {
     @Override
     public UserResponseDto.UserInfo findUserInfo(Long userId) {
         User user = userGetService.find(userId);
+
         return mapper.toUserInfoDto(user);
     }
     private long getKakaoId(Login dto) {

--- a/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCaseImpl.java
@@ -161,6 +161,11 @@ public class UserUseCaseImpl implements UserUseCase {
         return new JwtDto(token.accessToken(), token.refreshToken());
     }
 
+    @Override
+    public UserResponseDto.UserInfo findUserInfo(Long userId) {
+        User user = userGetService.find(userId);
+        return mapper.toUserInfoDto(user);
+    }
     private long getKakaoId(Login dto) {
         KakaoTokenResponse tokenResponse = kakaoAuthService.getKakaoToken(dto.authCode());
         KakaoUserInfoResponse userInfo = kakaoAuthService.getUserInfo(tokenResponse.access_token());

--- a/src/main/java/leets/weeth/domain/user/presentation/UserAdminController.java
+++ b/src/main/java/leets/weeth/domain/user/presentation/UserAdminController.java
@@ -3,7 +3,6 @@ package leets.weeth.domain.user.presentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import leets.weeth.domain.user.application.usecase.UserManageUseCase;
-import leets.weeth.domain.user.application.usecase.UserUseCase;
 import leets.weeth.global.common.response.CommonResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -22,41 +21,41 @@ public class UserAdminController {
     private final UserManageUseCase userManageUseCase;
 
     @GetMapping("/all")
-    @Operation(summary="어드민용 회원 조회")
+    @Operation(summary = "어드민용 회원 조회")
     public CommonResponse<List<AdminResponse>> findAll() {
         return CommonResponse.createSuccess(USER_FIND_ALL_SUCCESS.getMessage(), userManageUseCase.findAllByAdmin());
     }
 
     @PatchMapping
-    @Operation(summary="가입 신청 승인")
+    @Operation(summary = "가입 신청 승인")
     public CommonResponse<Void> accept(@RequestParam Long userId) {
         userManageUseCase.accept(userId);
         return CommonResponse.createSuccess(USER_ACCEPT_SUCCESS.getMessage());
     }
 
     @DeleteMapping
-    @Operation(summary="유저 추방")
+    @Operation(summary = "유저 추방")
     public CommonResponse<Void> ban(@RequestParam Long userId) {
         userManageUseCase.ban(userId);
         return CommonResponse.createSuccess(USER_BAN_SUCCESS.getMessage());
     }
 
     @PatchMapping("/role")
-    @Operation(summary="관리자로 승격/강등")
+    @Operation(summary = "관리자로 승격/강등")
     public CommonResponse<Void> update(@RequestParam Long userId, @RequestParam String role) {
         userManageUseCase.update(userId, role);
         return CommonResponse.createSuccess(USER_ROLE_UPDATE_SUCCESS.getMessage());
     }
 
     @PatchMapping("/apply")
-    @Operation(summary="다음 기수도 이어서 진행")
+    @Operation(summary = "다음 기수도 이어서 진행")
     public CommonResponse<Void> applyOB(@RequestParam Long userId, @RequestParam Integer cardinal) {
         userManageUseCase.applyOB(userId, cardinal);
         return CommonResponse.createSuccess(USER_APPLY_OB_SUCCESS.getMessage());
     }
 
     @PatchMapping("/reset")
-    @Operation(summary="회원 비밀번호 초기화")
+    @Operation(summary = "회원 비밀번호 초기화")
     public CommonResponse<Void> resetPassword(@RequestParam Long userId) {
         userManageUseCase.reset(userId);
         return CommonResponse.createSuccess(USER_PASSWORD_RESET_SUCCESS.getMessage());

--- a/src/main/java/leets/weeth/domain/user/presentation/UserController.java
+++ b/src/main/java/leets/weeth/domain/user/presentation/UserController.java
@@ -3,6 +3,7 @@ package leets.weeth.domain.user.presentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import leets.weeth.domain.user.application.dto.response.UserResponseDto;
 import leets.weeth.domain.user.application.dto.response.UserResponseDto.SummaryResponse;
@@ -92,6 +93,12 @@ public class UserController {
     @Operation(summary = "내 정보 조회")
     public CommonResponse<Response> find(@Parameter(hidden = true) @CurrentUser Long userId) {
         return CommonResponse.createSuccess(USER_FIND_BY_ID_SUCCESS.getMessage(), userUseCase.find(userId));
+    }
+
+    @GetMapping("/info")
+    @Operation(summary = "전역 내 정보 조회 API")
+    public CommonResponse<UserResponseDto.UserInfo> findMyInfo(@Parameter(hidden = true) @CurrentUser Long userId) {
+        return CommonResponse.createSuccess(USER_FIND_BY_ID_SUCCESS.getMessage(), userUseCase.findUserInfo(userId));
     }
 
     @PatchMapping

--- a/src/main/java/leets/weeth/domain/user/presentation/UserController.java
+++ b/src/main/java/leets/weeth/domain/user/presentation/UserController.java
@@ -3,7 +3,6 @@ package leets.weeth.domain.user.presentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import leets.weeth.domain.user.application.dto.response.UserResponseDto;
 import leets.weeth.domain.user.application.dto.response.UserResponseDto.SummaryResponse;


### PR DESCRIPTION
## PR 내용
- 프론트에서 전역적으로 사용하는 데이터가 담긴 내 정보조회 API를 구현했습니다
- 기존 GET /users 에서 내 정보를 조회하던 것에서 Dto를 축소한 API를 하나 더 추가 구현했습니다
<br>

## PR 세부사항
- 프론트 요구사항이 있어 /users/all api에 role을 담아서 반환하도록 추가했습니다

<br>

## 관련 스크린샷
<img width="1093" alt="image" src="https://github.com/user-attachments/assets/79116dfa-bf33-418e-a232-548ccc554bdc" />

<br>

## 주의사항
X
<br>

## 체크 리스트

- [x] 리뷰어 설정
- [x] Assignee 설정
- [x] Label 설정
- [x] 제목 양식 맞췄나요? (ex. #0 Feat: 기능 추가)
- [x] 변경 사항에 대한 테스트