### PR TITLE
Refactor #97 일정 생성 로직 수정

### DIFF
--- a/src/main/java/leets/weeth/domain/attendance/application/usecase/AttendanceUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/attendance/application/usecase/AttendanceUseCaseImpl.java
@@ -79,7 +79,7 @@ public class AttendanceUseCaseImpl implements AttendanceUseCase {
         List<Meeting> meetings = meetingGetService.find(cardinal);
 
         /*
-        todo 차후 리팩토링
+        todo 차후 리팩토링 정기모임 id를 입력받아서 해당 정기모임의 출석을 마감하도록 수정
          */
         Meeting targetMeeting = meetings.stream()
                 .filter(meeting -> meeting.getStart().toLocalDate().isEqual(now)

--- a/src/main/java/leets/weeth/domain/attendance/domain/repository/AttendanceRepository.java
+++ b/src/main/java/leets/weeth/domain/attendance/domain/repository/AttendanceRepository.java
@@ -13,6 +13,6 @@ public interface AttendanceRepository extends JpaRepository<Attendance, Long> {
     List<Attendance> findAllByMeeting(Meeting meeting);
 
     @Modifying
-    @Query("DELETE FROM Attendance a WHERE a IN :attendances")
-    void deleteAll(@Param("attendances") List<Attendance> attendances);
+    @Query("DELETE FROM Attendance a WHERE a.meeting = :meeting")
+    void deleteAllByMeeting(Meeting meeting);
 }

--- a/src/main/java/leets/weeth/domain/attendance/domain/repository/AttendanceRepository.java
+++ b/src/main/java/leets/weeth/domain/attendance/domain/repository/AttendanceRepository.java
@@ -1,7 +1,18 @@
 package leets.weeth.domain.attendance.domain.repository;
 
 import leets.weeth.domain.attendance.domain.entity.Attendance;
+import leets.weeth.domain.schedule.domain.entity.Meeting;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface AttendanceRepository extends JpaRepository<Attendance, Long> {
+    List<Attendance> findAllByMeeting(Meeting meeting);
+
+    @Modifying
+    @Query("DELETE FROM Attendance a WHERE a IN :attendances")
+    void deleteAll(@Param("attendances") List<Attendance> attendances);
 }

--- a/src/main/java/leets/weeth/domain/attendance/domain/service/AttendanceDeleteService.java
+++ b/src/main/java/leets/weeth/domain/attendance/domain/service/AttendanceDeleteService.java
@@ -1,0 +1,19 @@
+package leets.weeth.domain.attendance.domain.service;
+
+import leets.weeth.domain.attendance.domain.entity.Attendance;
+import leets.weeth.domain.attendance.domain.repository.AttendanceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AttendanceDeleteService {
+
+    private final AttendanceRepository attendanceRepository;
+
+    public void deleteAll(List<Attendance> attendances) {
+        attendanceRepository.deleteAll(attendances);
+    }
+}

--- a/src/main/java/leets/weeth/domain/attendance/domain/service/AttendanceDeleteService.java
+++ b/src/main/java/leets/weeth/domain/attendance/domain/service/AttendanceDeleteService.java
@@ -2,6 +2,7 @@ package leets.weeth.domain.attendance.domain.service;
 
 import leets.weeth.domain.attendance.domain.entity.Attendance;
 import leets.weeth.domain.attendance.domain.repository.AttendanceRepository;
+import leets.weeth.domain.schedule.domain.entity.Meeting;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -13,7 +14,7 @@ public class AttendanceDeleteService {
 
     private final AttendanceRepository attendanceRepository;
 
-    public void deleteAll(List<Attendance> attendances) {
-        attendanceRepository.deleteAll(attendances);
+    public void deleteAll(Meeting meeting) {
+        attendanceRepository.deleteAllByMeeting(meeting);
     }
 }

--- a/src/main/java/leets/weeth/domain/attendance/domain/service/AttendanceGetService.java
+++ b/src/main/java/leets/weeth/domain/attendance/domain/service/AttendanceGetService.java
@@ -1,0 +1,20 @@
+package leets.weeth.domain.attendance.domain.service;
+
+import leets.weeth.domain.attendance.domain.entity.Attendance;
+import leets.weeth.domain.attendance.domain.repository.AttendanceRepository;
+import leets.weeth.domain.schedule.domain.entity.Meeting;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AttendanceGetService {
+
+    private final AttendanceRepository attendanceRepository;
+
+    public List<Attendance> findAllByMeeting(Meeting meeting) {
+        return attendanceRepository.findAllByMeeting(meeting);
+    }
+}

--- a/src/main/java/leets/weeth/domain/attendance/domain/service/AttendanceSaveService.java
+++ b/src/main/java/leets/weeth/domain/attendance/domain/service/AttendanceSaveService.java
@@ -8,6 +8,7 @@ import leets.weeth.domain.user.domain.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -26,8 +27,10 @@ public class AttendanceSaveService {
     }
 
     public void saveAll(List<User> userList, Meeting meeting) {
-        for (User user : userList) {
-            attendanceRepository.save(new Attendance(meeting, user));
-        }
+        List<Attendance> attendances = userList.stream()
+                .map(user -> new Attendance(meeting, user))
+                .toList();
+
+        attendanceRepository.saveAll(attendances);
     }
 }

--- a/src/main/java/leets/weeth/domain/attendance/domain/service/AttendanceSaveService.java
+++ b/src/main/java/leets/weeth/domain/attendance/domain/service/AttendanceSaveService.java
@@ -16,14 +16,18 @@ public class AttendanceSaveService {
 
     private final AttendanceRepository attendanceRepository;
 
-    @Transactional
-    public void save(User user, List<Meeting> meetings) {
+    public void init(User user, List<Meeting> meetings) {
         if (meetings != null) {
             meetings.forEach(meeting -> {
                 Attendance attendance = attendanceRepository.save(new Attendance(meeting, user));
                 user.add(attendance);
-                meeting.add(attendance);
-        });
+            });
+        }
+    }
+
+    public void saveAll(List<User> userList, Meeting meeting) {
+        for (User user : userList) {
+            attendanceRepository.save(new Attendance(meeting, user));
         }
     }
 }

--- a/src/main/java/leets/weeth/domain/attendance/domain/service/AttendanceUpdateService.java
+++ b/src/main/java/leets/weeth/domain/attendance/domain/service/AttendanceUpdateService.java
@@ -28,7 +28,7 @@ public class AttendanceUpdateService {
                 });
     }
 
-    public void updateByAttendanceStatus(List<Attendance> attendances) {
+    public void updateUserAttendanceByStatus(List<Attendance> attendances) {
         for (Attendance attendance : attendances) {
             User user = attendance.getUser();
             if (attendance.getStatus().equals(Status.ATTEND)) {

--- a/src/main/java/leets/weeth/domain/attendance/domain/service/AttendanceUpdateService.java
+++ b/src/main/java/leets/weeth/domain/attendance/domain/service/AttendanceUpdateService.java
@@ -2,6 +2,8 @@ package leets.weeth.domain.attendance.domain.service;
 
 import jakarta.transaction.Transactional;
 import leets.weeth.domain.attendance.domain.entity.Attendance;
+import leets.weeth.domain.attendance.domain.entity.enums.Status;
+import leets.weeth.domain.user.domain.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -24,5 +26,16 @@ public class AttendanceUpdateService {
                     attendance.close();
                     attendance.getUser().absent();
                 });
+    }
+
+    public void updateByAttendanceStatus(List<Attendance> attendances) {
+        for (Attendance attendance : attendances) {
+            User user = attendance.getUser();
+            if (attendance.getStatus().equals(Status.ATTEND)) {
+                user.removeAttend();
+            } else {
+                user.removeAbsent();
+            }
+        }
     }
 }

--- a/src/main/java/leets/weeth/domain/file/service/S3Service.java
+++ b/src/main/java/leets/weeth/domain/file/service/S3Service.java
@@ -13,8 +13,10 @@ import java.io.IOException;
 import java.util.List;
 import java.util.UUID;
 
+/*
+미사용 클래스
+ */
 @Slf4j
-@Service
 @RequiredArgsConstructor
 public class S3Service {
 

--- a/src/main/java/leets/weeth/domain/schedule/application/mapper/MeetingMapper.java
+++ b/src/main/java/leets/weeth/domain/schedule/application/mapper/MeetingMapper.java
@@ -12,12 +12,12 @@ import static leets.weeth.domain.schedule.application.dto.MeetingDTO.*;
 @Mapper(componentModel = MappingConstants.ComponentModel.SPRING, unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface MeetingMapper {
 
-    @Mapping(target = "memberCount", expression = "java( getMemberCount(meeting) )")
+//    @Mapping(target = "memberCount", expression = "java( getMemberCount(meeting) )")
     @Mapping(target = "requiredItem", expression = "java(\"노트북\")")
     @Mapping(target = "name", source = "user.name")
     Response to(Meeting meeting);
 
-    @Mapping(target = "memberCount", expression = "java( getMemberCount(meeting) )")
+//    @Mapping(target = "memberCount", expression = "java( getMemberCount(meeting) )")
     @Mapping(target = "name", source = "user.name")
     ResponseAll toAll(Meeting meeting);
 
@@ -40,10 +40,10 @@ public interface MeetingMapper {
     -> 정기 모임의 참여하는 인원의 멤버수를 어떻게 관리할지.
     해당 코드는 일시적인 대안책임
      */
-    default Integer getMemberCount(Meeting meeting) {
-        return (int)meeting.getAttendances().stream()
-                .filter(attendance -> !attendance.getUser().getStatus().equals(Status.BANNED))
-                .filter(attendance -> !attendance.getUser().getStatus().equals(Status.LEFT))
-                .count();
-    }
+//    default Integer getMemberCount(Meeting meeting) {
+//        return (int)meeting.getAttendances().stream()
+//                .filter(attendance -> !attendance.getUser().getStatus().equals(Status.BANNED))
+//                .filter(attendance -> !attendance.getUser().getStatus().equals(Status.LEFT))
+//                .count();
+//    }
 }

--- a/src/main/java/leets/weeth/domain/schedule/application/usecase/EventUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/schedule/application/usecase/EventUseCaseImpl.java
@@ -10,6 +10,7 @@ import leets.weeth.domain.user.domain.entity.User;
 import leets.weeth.domain.user.domain.service.UserGetService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import static leets.weeth.domain.schedule.application.dto.EventDTO.*;
 
@@ -30,12 +31,14 @@ public class EventUseCaseImpl implements EventUseCase {
     }
 
     @Override
+    @Transactional
     public void save(Save dto, Long userId) {
         User user = userGetService.find(userId);
         eventSaveService.save(mapper.from(dto, user));
     }
 
     @Override
+    @Transactional
     public void update(Long eventId, Update dto, Long userId) {
         User user = userGetService.find(userId);
         Event event = eventGetService.find(eventId);
@@ -43,6 +46,7 @@ public class EventUseCaseImpl implements EventUseCase {
     }
 
     @Override
+    @Transactional
     public void delete(Long eventId) {
         Event event = eventGetService.find(eventId);
         eventDeleteService.delete(event);

--- a/src/main/java/leets/weeth/domain/schedule/application/usecase/MeetingUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/schedule/application/usecase/MeetingUseCaseImpl.java
@@ -71,8 +71,8 @@ public class MeetingUseCaseImpl implements MeetingUseCase {
 
         attendanceUpdateService.updateByAttendanceStatus(attendances);
 
+        attendanceDeleteService.deleteAll(meeting);
         meetingDeleteService.delete(meeting);
-        attendanceDeleteService.deleteAll(attendances);
     }
 
     @Override

--- a/src/main/java/leets/weeth/domain/schedule/application/usecase/MeetingUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/schedule/application/usecase/MeetingUseCaseImpl.java
@@ -69,7 +69,7 @@ public class MeetingUseCaseImpl implements MeetingUseCase {
         Meeting meeting = meetingGetService.find(meetingId);
         List<Attendance> attendances = attendanceGetService.findAllByMeeting(meeting);
 
-        attendanceUpdateService.updateByAttendanceStatus(attendances);
+        attendanceUpdateService.updateUserAttendanceByStatus(attendances);
 
         attendanceDeleteService.deleteAll(meeting);
         meetingDeleteService.delete(meeting);

--- a/src/main/java/leets/weeth/domain/schedule/domain/entity/Meeting.java
+++ b/src/main/java/leets/weeth/domain/schedule/domain/entity/Meeting.java
@@ -1,8 +1,6 @@
 package leets.weeth.domain.schedule.domain.entity;
 
 import jakarta.persistence.Entity;
-import jakarta.persistence.OneToMany;
-import leets.weeth.domain.attendance.domain.entity.Attendance;
 import leets.weeth.domain.schedule.application.dto.MeetingDTO;
 import leets.weeth.domain.user.domain.entity.User;
 import lombok.AccessLevel;
@@ -10,9 +8,6 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Entity
 @Getter
@@ -27,16 +22,11 @@ public class Meeting extends Schedule {
 
     private Integer code;
 
-    @OneToMany(mappedBy = "meeting")
-    private List<Attendance> attendances = new ArrayList<>();
-
     public void update(MeetingDTO.Update dto, User user) {
         this.updateUpperClass(dto, user);
         this.weekNumber = dto.weekNumber();
         this.cardinal = dto.cardinal();
     }
 
-    public void add(Attendance attendance) {
-        this.attendances.add(attendance);
-    }
+
 }

--- a/src/main/java/leets/weeth/domain/user/application/usecase/UserManageUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/user/application/usecase/UserManageUseCaseImpl.java
@@ -48,7 +48,7 @@ public class UserManageUseCaseImpl implements UserManageUseCase {
         if (user.isInactive()) {
             userUpdateService.accept(user);
             List<Meeting> meetings = meetingGetService.find(user.getCardinals().get(0));
-            attendanceSaveService.save(user, meetings);
+            attendanceSaveService.init(user, meetings);
         }
     }
 
@@ -83,7 +83,7 @@ public class UserManageUseCaseImpl implements UserManageUseCase {
             if (user.isCurrent(cardinal)) {
                 user.initAttendance();
                 List<Meeting> meetings = meetingGetService.find(cardinal);
-                attendanceSaveService.save(user, meetings);
+                attendanceSaveService.init(user, meetings);
             }
 
             userUpdateService.applyOB(user, cardinal);

--- a/src/main/java/leets/weeth/domain/user/domain/entity/User.java
+++ b/src/main/java/leets/weeth/domain/user/domain/entity/User.java
@@ -54,6 +54,9 @@ public class User extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private Department department;
 
+    /*
+    todo 차후 기수가 많아지면 관리가 어려울 수 있음
+     */
     @Convert(converter = CardinalListConverter.class)
     private List<Integer> cardinals;
 

--- a/src/main/java/leets/weeth/domain/user/domain/entity/User.java
+++ b/src/main/java/leets/weeth/domain/user/domain/entity/User.java
@@ -4,13 +4,12 @@ import jakarta.persistence.*;
 import leets.weeth.domain.attendance.domain.entity.Attendance;
 import leets.weeth.domain.penalty.domain.entity.Penalty;
 import leets.weeth.domain.user.application.converter.CardinalListConverter;
-import leets.weeth.domain.user.application.dto.request.UserRequestDto;
+import leets.weeth.domain.user.application.exception.CardinalNotFoundException;
 import leets.weeth.domain.user.domain.entity.enums.Department;
 import leets.weeth.domain.user.domain.entity.enums.Position;
 import leets.weeth.domain.user.domain.entity.enums.Role;
 import leets.weeth.domain.user.domain.entity.enums.Status;
 import leets.weeth.global.common.entity.BaseEntity;
-import leets.weeth.domain.user.application.exception.CardinalNotFoundException;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -21,7 +20,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import java.util.ArrayList;
 import java.util.List;
 
-import static leets.weeth.domain.user.application.dto.request.UserRequestDto.*;
+import static leets.weeth.domain.user.application.dto.request.UserRequestDto.Register;
+import static leets.weeth.domain.user.application.dto.request.UserRequestDto.Update;
 
 @Entity
 @Getter
@@ -114,6 +114,7 @@ public class User extends BaseEntity {
         this.tel = dto.tel();
         this.department = Department.to(dto.department());
     }
+
     public void update(Register dto) {
         this.name = dto.name();
         this.studentId = dto.studentId();
@@ -122,6 +123,7 @@ public class User extends BaseEntity {
         this.cardinals = List.of(dto.cardinal());
         this.position = Position.valueOf(dto.position());
     }
+
     public void accept() {
         this.status = Status.ACTIVE;
     }
@@ -146,7 +148,7 @@ public class User extends BaseEntity {
         this.attendances.add(attendance);
     }
 
-    public void addPenalty(Penalty penalty){
+    public void addPenalty(Penalty penalty) {
         this.penalties.add(penalty);
     }
 
@@ -169,13 +171,31 @@ public class User extends BaseEntity {
         calculateRate();
     }
 
+    public void removeAttend() {
+        if(attendanceCount > 0) {
+            attendanceCount--;
+            calculateRate();
+        }
+    }
+
     public void absent() {
         absenceCount++;
         calculateRate();
     }
 
+    public void removeAbsent() {
+        if(absenceCount > 0) {
+            absenceCount--;
+            calculateRate();
+        }
+    }
+
     private void calculateRate() {
-        attendanceRate = (attendanceCount * 100) / (attendanceCount + absenceCount);
+        if (attendanceCount + absenceCount > 0) {
+            attendanceRate = (attendanceCount * 100) / (attendanceCount + absenceCount);
+        } else {
+            attendanceRate = 0;
+        }
     }
 
     public void incrementPenaltyCount() {

--- a/src/main/java/leets/weeth/domain/user/domain/repository/UserRepository.java
+++ b/src/main/java/leets/weeth/domain/user/domain/repository/UserRepository.java
@@ -3,6 +3,8 @@ package leets.weeth.domain.user.domain.repository;
 import leets.weeth.domain.user.domain.entity.User;
 import leets.weeth.domain.user.domain.entity.enums.Status;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -20,4 +22,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByTelAndIdIsNot(String tel, Long id);
 
     List<User> findAllByStatusOrderByName(Status status);
+
+    @Query(value = "SELECT * FROM users u WHERE JSON_CONTAINS(u.cardinals, CAST(:cardinal AS JSON), '$')", nativeQuery = true)
+    List<User> findByCardinal(@Param("cardinal") int cardinal);
 }

--- a/src/main/java/leets/weeth/domain/user/domain/service/UserGetService.java
+++ b/src/main/java/leets/weeth/domain/user/domain/service/UserGetService.java
@@ -38,6 +38,10 @@ public class UserGetService {
         return userRepository.findAllByStatusOrderByName(status);
     }
 
+    public List<User> findAllByCardinal(int cardinal) {
+        return userRepository.findByCardinal(cardinal);
+    }
+
     public List<User> findAll() {
         return userRepository.findAll();
     }

--- a/src/main/java/leets/weeth/global/config/AwsS3Config.java
+++ b/src/main/java/leets/weeth/global/config/AwsS3Config.java
@@ -23,14 +23,17 @@ public class AwsS3Config {
     @Value("${cloud.aws.region.static}")
     private String region;
 
-    @Bean
-    public S3Client s3Client() {
-        AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKey, accessSecret);
-        return S3Client.builder()
-                .region(Region.of(region))
-                .credentialsProvider(StaticCredentialsProvider.create(credentials))
-                .build();
-    }
+    /*
+    미사용 빈
+     */
+//    @Bean
+//    public S3Client s3Client() {
+//        AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKey, accessSecret);
+//        return S3Client.builder()
+//                .region(Region.of(region))
+//                .credentialsProvider(StaticCredentialsProvider.create(credentials))
+//                .build();
+//    }
 
     @Bean
     public S3Presigner s3Presigner() {


### PR DESCRIPTION
## PR 내용
- 기존 정기모임과 강하게 결합되어있던 출석 로직을 수정했습니다
- 기존 로직: 정기모임 미리 전부 생성 -> 사용자 가입승인 / 다음 기수 진행 -> 정기모임에 맞게 출석 객체 초기화 -> 정기모임 추가/삭제가 불가능
- 현재 로직: 정기모임 생성 -> 사용자 가입승인 / 다음 기수 진행 -> 출석 객체 초기화 -> 정기모임 생성/삭제 -> 출석 객체 생성/삭제 -> 출석 횟수 및 출석률 재계산
<br>

## PR 세부사항
- 정기모임이 컬렉션으로 가지고 있던 OneToMany 매핑을 삭제했습니다. 그에 따라 정기모임으로 출석 객체를 조회할 수 있는 메서드를 추가 구현했습니다
- 출석 객체 삭제 시 기본 메서드를 사용하면 객체 개수 만큼 반복 쿼리가 날라가서 단일 쿼리로 삭제할 수 있도록 JPQL을 추가 구현했습니다
- 정기모임이 생성될 때 출석 객체들이 추가 생성될 수 있도록 / 삭제될 때 출석 객체들이 삭제되고, 해당 사용자의 출석 여부에 따라 횟수와 출석률을 재계산하도록 수정했습니다
<br>

## 관련 스크린샷
- 정기모임 추가, 출석, 마감, 정기모임 삭제시 정상 동작하는 것을 테스트 완료 했습니다.
- 더 추가적인 케이스는 찾지 못했는데 생각나시는게 있다면 알려주세용
<br>

## 주의사항
- 사용하지 않는 S3Service와 S3Client에서 빌드 오류가 발생해 삭제하진 않고 비활성화 해뒀습니다
- 정기모임에서 memberCount를 조회할 때마다 계산하는 방식으로 구현이 되어있어 현재 비활성화 하고 차후 작업에서 수정할 계획입니다
- 현재 사용자의 기수를 관리하는 방식이 기수가 많아질 때마다 점점 관리하기 어려워질 것 같아 차후 Enum으로 빼고 별도의 테이블로 관리해야할 것 같습니다
<br>

## 체크 리스트

- [x] 리뷰어 설정
- [x] Assignee 설정
- [x] Label 설정
- [x] 제목 양식 맞췄나요? (ex. #0 Feat: 기능 추가)
- [x] 변경 사항에 대한 테스트