### PR TITLE
Refactor#99 멤버 조회 방식 변경 및 추가

### DIFF
--- a/src/main/java/leets/weeth/domain/user/application/exception/InvalidUserOrderException.java
+++ b/src/main/java/leets/weeth/domain/user/application/exception/InvalidUserOrderException.java
@@ -1,0 +1,7 @@
+package leets.weeth.domain.user.application.exception;
+
+import leets.weeth.global.common.exception.BusinessLogicException;
+
+public class InvalidUserOrderException extends BusinessLogicException {
+	public InvalidUserOrderException() {super(400, "올바른 유저 조회 순서가 아닙니다.");}
+}

--- a/src/main/java/leets/weeth/domain/user/application/exception/StatusNotFoundException.java
+++ b/src/main/java/leets/weeth/domain/user/application/exception/StatusNotFoundException.java
@@ -1,0 +1,9 @@
+package leets.weeth.domain.user.application.exception;
+
+import leets.weeth.global.common.exception.BusinessLogicException;
+
+public class StatusNotFoundException extends BusinessLogicException {
+	public StatusNotFoundException() {
+		super(400, "존재하지 않는 status 입니다.");
+	}
+}

--- a/src/main/java/leets/weeth/domain/user/application/usecase/UserManageUseCase.java
+++ b/src/main/java/leets/weeth/domain/user/application/usecase/UserManageUseCase.java
@@ -1,13 +1,14 @@
 package leets.weeth.domain.user.application.usecase;
 
 import leets.weeth.domain.user.application.dto.response.UserResponseDto;
+import leets.weeth.domain.user.domain.entity.enums.UsersOrderBy;
 
 import java.util.List;
 
 public interface UserManageUseCase {
 
 
-    List<UserResponseDto.AdminResponse> findAllByAdmin();
+    List<UserResponseDto.AdminResponse> findAllByAdmin(UsersOrderBy orderBy);
 
     void accept(Long userId);
 

--- a/src/main/java/leets/weeth/domain/user/application/usecase/UserManageUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/user/application/usecase/UserManageUseCaseImpl.java
@@ -49,7 +49,7 @@ public class UserManageUseCaseImpl implements UserManageUseCase {
             return userGetService.findAll().stream()
                 .sorted(Comparator.comparingInt((user->(StatusPriority.fromStatus(user.getStatus())).getPriority())))
                 .map(mapper::toAdminResponse)
-                .collect(Collectors.toList());
+                .toList();
         }
         // To do : 추후 기수 분리 후 작업 예정
         return null;

--- a/src/main/java/leets/weeth/domain/user/application/usecase/UserManageUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/user/application/usecase/UserManageUseCaseImpl.java
@@ -4,9 +4,11 @@ import jakarta.transaction.Transactional;
 import leets.weeth.domain.attendance.domain.service.AttendanceSaveService;
 import leets.weeth.domain.schedule.domain.entity.Meeting;
 import leets.weeth.domain.schedule.domain.service.MeetingGetService;
+import leets.weeth.domain.user.application.exception.InvalidUserOrderException;
 import leets.weeth.domain.user.application.mapper.UserMapper;
 import leets.weeth.domain.user.domain.entity.User;
-import leets.weeth.domain.user.domain.entity.enums.Status;
+import leets.weeth.domain.user.domain.entity.enums.StatusPriority;
+import leets.weeth.domain.user.domain.entity.enums.UsersOrderBy;
 import leets.weeth.domain.user.domain.service.UserDeleteService;
 import leets.weeth.domain.user.domain.service.UserGetService;
 import leets.weeth.domain.user.domain.service.UserUpdateService;
@@ -16,12 +18,12 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import java.util.Comparator;
+import java.util.EnumSet;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 import static leets.weeth.domain.user.application.dto.response.UserResponseDto.AdminResponse;
-import static leets.weeth.domain.user.domain.entity.enums.Status.*;
+import static leets.weeth.domain.user.domain.entity.enums.UsersOrderBy.*;
 
 @Service
 @RequiredArgsConstructor
@@ -39,19 +41,18 @@ public class UserManageUseCaseImpl implements UserManageUseCase {
     private final PasswordEncoder passwordEncoder;
 
     @Override
-    public List<AdminResponse> findAllByAdmin() {
-        // 우선순위 지정
-        Map<Status, Integer> statusPriority = Map.of(
-                ACTIVE, 1,
-                WAITING, 2,
-                LEFT, 3,
-                BANNED, 4
-        );
-
-        return userGetService.findAll().stream()
-                .sorted(Comparator.comparingInt(user -> statusPriority.getOrDefault(user.getStatus(), Integer.MAX_VALUE)))
+    public List<AdminResponse> findAllByAdmin(UsersOrderBy orderBy) {
+        if(orderBy == null || !EnumSet.allOf(UsersOrderBy.class).contains(orderBy)){
+            throw new InvalidUserOrderException();
+        }
+        if(orderBy.equals(NAME_ASCENDING)){
+            return userGetService.findAll().stream()
+                .sorted(Comparator.comparingInt((user->(StatusPriority.fromStatus(user.getStatus())).getPriority())))
                 .map(mapper::toAdminResponse)
                 .collect(Collectors.toList());
+        }
+        // To do : 추후 기수 분리 후 작업 예정
+        return null;
     }
 
     @Override

--- a/src/main/java/leets/weeth/domain/user/application/usecase/UserManageUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/user/application/usecase/UserManageUseCaseImpl.java
@@ -6,6 +6,7 @@ import leets.weeth.domain.schedule.domain.entity.Meeting;
 import leets.weeth.domain.schedule.domain.service.MeetingGetService;
 import leets.weeth.domain.user.application.mapper.UserMapper;
 import leets.weeth.domain.user.domain.entity.User;
+import leets.weeth.domain.user.domain.entity.enums.Status;
 import leets.weeth.domain.user.domain.service.UserDeleteService;
 import leets.weeth.domain.user.domain.service.UserGetService;
 import leets.weeth.domain.user.domain.service.UserUpdateService;
@@ -14,9 +15,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import static leets.weeth.domain.user.application.dto.response.UserResponseDto.AdminResponse;
+import static leets.weeth.domain.user.domain.entity.enums.Status.*;
 
 @Service
 @RequiredArgsConstructor
@@ -35,9 +40,18 @@ public class UserManageUseCaseImpl implements UserManageUseCase {
 
     @Override
     public List<AdminResponse> findAllByAdmin() {
+        // 우선순위 지정
+        Map<Status, Integer> statusPriority = Map.of(
+                ACTIVE, 1,
+                WAITING, 2,
+                LEFT, 3,
+                BANNED, 4
+        );
+
         return userGetService.findAll().stream()
+                .sorted(Comparator.comparingInt(user -> statusPriority.getOrDefault(user.getStatus(), Integer.MAX_VALUE)))
                 .map(mapper::toAdminResponse)
-                .toList();
+                .collect(Collectors.toList());
     }
 
     @Override

--- a/src/main/java/leets/weeth/domain/user/application/usecase/UserManageUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/user/application/usecase/UserManageUseCaseImpl.java
@@ -45,6 +45,7 @@ public class UserManageUseCaseImpl implements UserManageUseCase {
         if(orderBy == null || !EnumSet.allOf(UsersOrderBy.class).contains(orderBy)){
             throw new InvalidUserOrderException();
         }
+
         if(orderBy.equals(NAME_ASCENDING)){
             return userGetService.findAll().stream()
                 .sorted(Comparator.comparingInt((user->(StatusPriority.fromStatus(user.getStatus())).getPriority())))
@@ -52,6 +53,7 @@ public class UserManageUseCaseImpl implements UserManageUseCase {
                 .toList();
         }
         // To do : 추후 기수 분리 후 작업 예정
+
         return null;
     }
 

--- a/src/main/java/leets/weeth/domain/user/domain/entity/enums/StatusPriority.java
+++ b/src/main/java/leets/weeth/domain/user/domain/entity/enums/StatusPriority.java
@@ -1,0 +1,25 @@
+package leets.weeth.domain.user.domain.entity.enums;
+
+import leets.weeth.domain.user.application.exception.StatusNotFoundException;
+import lombok.Getter;
+
+@Getter
+public enum StatusPriority {
+	ACTIVE(1),
+	WAITING(2),
+	LEFT(3),
+	BANNED(4);
+
+	private final int priority;
+
+	StatusPriority(int priority) {
+		this.priority = priority;
+	}
+
+	public static StatusPriority fromStatus(Status status) {
+		if (status == null) {
+			throw new StatusNotFoundException();
+		}
+		return StatusPriority.valueOf(status.name());
+	}
+}

--- a/src/main/java/leets/weeth/domain/user/domain/entity/enums/UsersOrderBy.java
+++ b/src/main/java/leets/weeth/domain/user/domain/entity/enums/UsersOrderBy.java
@@ -1,0 +1,6 @@
+package leets.weeth.domain.user.domain.entity.enums;
+
+public enum UsersOrderBy {
+	NAME_ASCENDING,		// 이름순 정렬
+	CARDINAL_DESCENDING;	// 기수 기준으로 내림차순 정렬
+}

--- a/src/main/java/leets/weeth/domain/user/domain/repository/UserRepository.java
+++ b/src/main/java/leets/weeth/domain/user/domain/repository/UserRepository.java
@@ -20,4 +20,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByTelAndIdIsNot(String tel, Long id);
 
     List<User> findAllByStatusOrderByName(Status status);
+    List<User> findAllByOrderByNameAsc();
 }

--- a/src/main/java/leets/weeth/domain/user/domain/service/UserGetService.java
+++ b/src/main/java/leets/weeth/domain/user/domain/service/UserGetService.java
@@ -39,7 +39,7 @@ public class UserGetService {
     }
 
     public List<User> findAll() {
-        return userRepository.findAll();
+        return userRepository.findAllByOrderByNameAsc();
     }
 
     public boolean validateStudentId(String studentId) {

--- a/src/main/java/leets/weeth/domain/user/presentation/UserAdminController.java
+++ b/src/main/java/leets/weeth/domain/user/presentation/UserAdminController.java
@@ -3,14 +3,12 @@ package leets.weeth.domain.user.presentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import leets.weeth.domain.user.application.usecase.UserManageUseCase;
-import leets.weeth.domain.user.application.usecase.UserUseCase;
+import leets.weeth.domain.user.domain.entity.enums.UsersOrderBy;
 import leets.weeth.global.common.response.CommonResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 import static leets.weeth.domain.user.application.dto.response.UserResponseDto.AdminResponse;
 import static leets.weeth.domain.user.presentation.ResponseMessage.*;
@@ -25,45 +23,40 @@ public class UserAdminController {
 
     @GetMapping("/all")
     @Operation(summary = "어드민용 회원 조회")
-    public CommonResponse<Map<Integer, List<AdminResponse>>> findAll() {
-        // to do : 추후 기수 분리 후 작업 예정
-        List <AdminResponse> usersByCardinal = new ArrayList<>();
-        List<AdminResponse> usersByName = userManageUseCase.findAllByAdmin();
-
-        return CommonResponse.createSuccess(USER_FIND_ALL_SUCCESS.getMessage(), Map.of(0, usersByCardinal,
-                1, usersByName));
+    public CommonResponse<List<AdminResponse>> findAll(@RequestParam UsersOrderBy orderBy) {
+        return CommonResponse.createSuccess(USER_FIND_ALL_SUCCESS.getMessage(), userManageUseCase.findAllByAdmin(orderBy));
     }
 
     @PatchMapping
-    @Operation(summary="가입 신청 승인")
+    @Operation(summary = "가입 신청 승인")
     public CommonResponse<Void> accept(@RequestParam Long userId) {
         userManageUseCase.accept(userId);
         return CommonResponse.createSuccess(USER_ACCEPT_SUCCESS.getMessage());
     }
 
     @DeleteMapping
-    @Operation(summary="유저 추방")
+    @Operation(summary = "유저 추방")
     public CommonResponse<Void> ban(@RequestParam Long userId) {
         userManageUseCase.ban(userId);
         return CommonResponse.createSuccess(USER_BAN_SUCCESS.getMessage());
     }
 
     @PatchMapping("/role")
-    @Operation(summary="관리자로 승격/강등")
+    @Operation(summary = "관리자로 승격/강등")
     public CommonResponse<Void> update(@RequestParam Long userId, @RequestParam String role) {
         userManageUseCase.update(userId, role);
         return CommonResponse.createSuccess(USER_ROLE_UPDATE_SUCCESS.getMessage());
     }
 
     @PatchMapping("/apply")
-    @Operation(summary="다음 기수도 이어서 진행")
+    @Operation(summary = "다음 기수도 이어서 진행")
     public CommonResponse<Void> applyOB(@RequestParam Long userId, @RequestParam Integer cardinal) {
         userManageUseCase.applyOB(userId, cardinal);
         return CommonResponse.createSuccess(USER_APPLY_OB_SUCCESS.getMessage());
     }
 
     @PatchMapping("/reset")
-    @Operation(summary="회원 비밀번호 초기화")
+    @Operation(summary = "회원 비밀번호 초기화")
     public CommonResponse<Void> resetPassword(@RequestParam Long userId) {
         userManageUseCase.reset(userId);
         return CommonResponse.createSuccess(USER_PASSWORD_RESET_SUCCESS.getMessage());

--- a/src/main/java/leets/weeth/domain/user/presentation/UserAdminController.java
+++ b/src/main/java/leets/weeth/domain/user/presentation/UserAdminController.java
@@ -8,7 +8,9 @@ import leets.weeth.global.common.response.CommonResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static leets.weeth.domain.user.application.dto.response.UserResponseDto.AdminResponse;
 import static leets.weeth.domain.user.presentation.ResponseMessage.*;
@@ -23,8 +25,13 @@ public class UserAdminController {
 
     @GetMapping("/all")
     @Operation(summary="어드민용 회원 조회")
-    public CommonResponse<List<AdminResponse>> findAll() {
-        return CommonResponse.createSuccess(USER_FIND_ALL_SUCCESS.getMessage(), userManageUseCase.findAllByAdmin());
+    public CommonResponse<Map<Integer, List<AdminResponse>>> findAll() {
+        // to do : 추후 기수 분리 후 작업 예정
+        List <AdminResponse> usersByCardinal = new ArrayList<>();
+        List<AdminResponse> usersByName = userManageUseCase.findAllByAdmin();
+
+        return CommonResponse.createSuccess(USER_FIND_ALL_SUCCESS.getMessage(), Map.of(0, usersByCardinal,
+                1, usersByName));
     }
 
     @PatchMapping


### PR DESCRIPTION
## PR 내용
멤버 조회 방식 변경 및 추가 (이름 오름차순)
<br>

## PR 세부사항
- 이름 오름차순으로 조회하되, 활동중, 승인 대기, 탈퇴, 추방을 베이스로 함
- 다음 브랜치에서 기수 분리 후 기수 순서대로 조회 예정
<br>

## 관련 스크린샷
- status = ACTIVE인 유저부터 이름순으로 정렬

![image](https://github.com/user-attachments/assets/b0daf7b4-3de6-45b5-8185-2d101e12c8e7)

- status = WAITING인 유저
![image](https://github.com/user-attachments/assets/99c60886-5b6f-4694-8c2d-5e5fc9cadab7)


- status = LEFT인 유저

![image](https://github.com/user-attachments/assets/767492ec-75e9-48dc-9534-4998dd8199e8)
![image](https://github.com/user-attachments/assets/9060b8a1-c6c5-45e3-b524-9daecf1d03d9)

- status = BANNED인 유저
![image](https://github.com/user-attachments/assets/c1eb00aa-c4b6-48bd-9832-6856523a67e9)

- 한글 테스트
![image](https://github.com/user-attachments/assets/eb38a41d-d865-44f3-bcfe-4adf5826335d)
![image](https://github.com/user-attachments/assets/c54a9452-a991-4092-b110-955a512e138c)


<br>

## 주의사항
- 없습니다
<br>

## 체크 리스트

- [x] 리뷰어 설정
- [x] Assignee 설정
- [x] Label 설정
- [x] 제목 양식 맞췄나요? (ex. #0 Feat: 기능 추가)
- [x] 변경 사항에 대한 테스트