### PR TITLE
Fix #101 api 경로 해제

### DIFF
--- a/src/main/java/leets/weeth/domain/user/presentation/UserController.java
+++ b/src/main/java/leets/weeth/domain/user/presentation/UserController.java
@@ -42,14 +42,14 @@ public class UserController {
     }
 
     @PostMapping("/kakao/auth")
-    @Operation(summary = "카카오 소셜 회원가입 전 요청 API")
+    @Operation(summary = "카카오 소셜 회원가입 전 요청 API (미사용 API)")
     public CommonResponse<UserResponseDto.SocialAuthResponse> beforeRegister(@RequestBody @Valid Login dto) {
         UserResponseDto.SocialAuthResponse response = userUseCase.authenticate(dto);
         return CommonResponse.createSuccess(SOCIAL_AUTH_SUCCESS.getMessage(), response);
     }
 
     @PostMapping("/apply")
-    @Operation(summary = "동아리 지원 신청. 현재 사용하지 않으므로 회원가입 시 social-register api로 요청 바람")
+    @Operation(summary = "동아리 지원 신청. 현재 사용하지 않으므로 회원가입 시 /kakao/register api로 요청 바람")
     public CommonResponse<Void> apply(@RequestBody @Valid SignUp dto) {
         userUseCase.apply(dto);
         return CommonResponse.createSuccess(USER_APPLY_SUCCESS.getMessage());

--- a/src/main/java/leets/weeth/global/config/SecurityConfig.java
+++ b/src/main/java/leets/weeth/global/config/SecurityConfig.java
@@ -73,7 +73,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(
                         authorize ->
                                 authorize
-                                        .requestMatchers("/api/v1/users/kakao/login", "api/v1/users/kakao/register", "api/v1/users/kakao/link", "api/v1/users/kakao/auth", "/api/v1/users/apply", "/api/v1/users/email", "/api/v1/users/refresh").permitAll()
+                                        .requestMatchers("/api/v1/users/kakao/login", "api/v1/users/kakao/register", "api/v1/users/kakao/link", "/api/v1/users/apply", "/api/v1/users/email", "/api/v1/users/refresh").permitAll()
                                         .requestMatchers("/health-check").permitAll()
                                         .requestMatchers("/admin", "/admin/login", "/admin/account", "/admin/meeting", "/admin/member", "/admin/penalty",
                                                 "/js/**", "/img/**", "/scss/**", "/vendor/**").permitAll()

--- a/src/main/java/leets/weeth/global/config/SecurityConfig.java
+++ b/src/main/java/leets/weeth/global/config/SecurityConfig.java
@@ -73,7 +73,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(
                         authorize ->
                                 authorize
-                                        .requestMatchers("/api/v1/users/social-login", "api/v1/users/social-auth", "api/v1/users/integrate", "/api/v1/users/apply", "/api/v1/users/register", "/api/v1/users/email", "/api/v1/users/refresh").permitAll()
+                                        .requestMatchers("/api/v1/users/kakao/login", "api/v1/users/kakao/register", "api/v1/users/kakao/link", "api/v1/users/kakao/auth", "/api/v1/users/apply", "/api/v1/users/email", "/api/v1/users/refresh").permitAll()
                                         .requestMatchers("/health-check").permitAll()
                                         .requestMatchers("/admin", "/admin/login", "/admin/account", "/admin/meeting", "/admin/member", "/admin/penalty",
                                                 "/js/**", "/img/**", "/scss/**", "/vendor/**").permitAll()


### PR DESCRIPTION
## PR 내용
- 소셜 로그인/회원가입 관련 api 엔드포인트 수정 후 SpringSecurity에서 경로 해제를 하지 않아서 수정했습니다
<br>

## PR 세부사항
- kakao/login, kakao/register, kakao/link 3가지 경로를 열어뒀습니다
- kakao/auth의 경우 로그인 플로우가 약간 변경됨에 따라 쓸 일이 없을 것 같아 닫아두고 스웨거 설명을 수정했습니다
<br>

## 관련 스크린샷
X
<br>

## 주의사항
X
<br>

## 체크 리스트

- [x] 리뷰어 설정
- [x] Assignee 설정
- [x] Label 설정
- [x] 제목 양식 맞췄나요? (ex. #0 Feat: 기능 추가)
- [x] 변경 사항에 대한 테스트