### PR TITLE
Refactor #106 기수 테이블 분리

### DIFF
--- a/src/main/java/leets/weeth/domain/attendance/application/usecase/AttendanceUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/attendance/application/usecase/AttendanceUseCaseImpl.java
@@ -63,6 +63,9 @@ public class AttendanceUseCaseImpl implements AttendanceUseCase {
         return mapper.toMainDto(user, todayMeeting);
     }
 
+    /*
+    todo 출석 끝난 후 다음 기수 진행 시 다음 기수의 출석 정보만 나오는지 확인 필요
+     */
     @Override
     public AttendanceDTO.Detail findAll(Long userId) {
         User user = userGetService.find(userId);

--- a/src/main/java/leets/weeth/domain/penalty/application/usecase/PenaltyUsecaseImpl.java
+++ b/src/main/java/leets/weeth/domain/penalty/application/usecase/PenaltyUsecaseImpl.java
@@ -37,7 +37,6 @@ public class PenaltyUsecaseImpl implements PenaltyUsecase{
 
         penaltySaveService.save(penalty);
 
-        user.addPenalty(penalty);
         user.incrementPenaltyCount();
     }
 

--- a/src/main/java/leets/weeth/domain/schedule/application/usecase/MeetingUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/schedule/application/usecase/MeetingUseCaseImpl.java
@@ -11,7 +11,10 @@ import leets.weeth.domain.schedule.domain.service.MeetingDeleteService;
 import leets.weeth.domain.schedule.domain.service.MeetingGetService;
 import leets.weeth.domain.schedule.domain.service.MeetingSaveService;
 import leets.weeth.domain.schedule.domain.service.MeetingUpdateService;
+import leets.weeth.domain.user.domain.entity.Cardinal;
 import leets.weeth.domain.user.domain.entity.User;
+import leets.weeth.domain.user.domain.service.CardinalGetService;
+import leets.weeth.domain.user.domain.service.UserCardinalGetService;
 import leets.weeth.domain.user.domain.service.UserGetService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -37,6 +40,7 @@ public class MeetingUseCaseImpl implements MeetingUseCase {
     private final AttendanceSaveService attendanceSaveService;
     private final AttendanceDeleteService attendanceDeleteService;
     private final AttendanceUpdateService attendanceUpdateService;
+    private final CardinalGetService cardinalGetService;
 
     @Override
     public Response find(Long meetingId) {
@@ -47,7 +51,9 @@ public class MeetingUseCaseImpl implements MeetingUseCase {
     @Transactional
     public void save(Save dto, Long userId) {
         User user = userGetService.find(userId);
-        List<User> userList = userGetService.findAllByCardinal(dto.cardinal());
+        Cardinal cardinal = cardinalGetService.find(dto.cardinal());
+
+        List<User> userList = userGetService.findAllByCardinal(cardinal);
 
         Meeting meeting = mapper.from(dto, user);
         meetingSaveService.save(meeting);

--- a/src/main/java/leets/weeth/domain/user/application/dto/request/CardinalSaveRequest.java
+++ b/src/main/java/leets/weeth/domain/user/application/dto/request/CardinalSaveRequest.java
@@ -1,0 +1,10 @@
+package leets.weeth.domain.user.application.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record CardinalSaveRequest (
+        @NotNull Integer cardinalNumber,
+        @NotNull Integer year,
+        @NotNull Integer semester
+){
+}

--- a/src/main/java/leets/weeth/domain/user/application/dto/response/CardinalResponse.java
+++ b/src/main/java/leets/weeth/domain/user/application/dto/response/CardinalResponse.java
@@ -1,0 +1,13 @@
+package leets.weeth.domain.user.application.dto.response;
+
+import java.time.LocalDateTime;
+
+public record CardinalResponse(
+        Long id,
+        Integer cardinalNumber,
+        Integer year,
+        Integer semester,
+        LocalDateTime createdAt,
+        LocalDateTime modified_at
+) {
+}

--- a/src/main/java/leets/weeth/domain/user/application/dto/response/CardinalResponse.java
+++ b/src/main/java/leets/weeth/domain/user/application/dto/response/CardinalResponse.java
@@ -8,6 +8,6 @@ public record CardinalResponse(
         Integer year,
         Integer semester,
         LocalDateTime createdAt,
-        LocalDateTime modified_at
+        LocalDateTime modifiedAt
 ) {
 }

--- a/src/main/java/leets/weeth/domain/user/application/dto/response/UserCardinalDto.java
+++ b/src/main/java/leets/weeth/domain/user/application/dto/response/UserCardinalDto.java
@@ -1,0 +1,12 @@
+package leets.weeth.domain.user.application.dto.response;
+
+import leets.weeth.domain.user.domain.entity.User;
+import leets.weeth.domain.user.domain.entity.UserCardinal;
+
+import java.util.List;
+
+public record UserCardinalDto(
+        User user,
+        List<UserCardinal> cardinals
+) {
+}

--- a/src/main/java/leets/weeth/domain/user/application/exception/DuplicateCardinalException.java
+++ b/src/main/java/leets/weeth/domain/user/application/exception/DuplicateCardinalException.java
@@ -1,0 +1,9 @@
+package leets.weeth.domain.user.application.exception;
+
+import leets.weeth.global.common.exception.BusinessLogicException;
+
+public class DuplicateCardinalException extends BusinessLogicException {
+    public DuplicateCardinalException() {
+        super(400, "이미 존재하는 기수 입니다.");
+    }
+}

--- a/src/main/java/leets/weeth/domain/user/application/mapper/CardinalMapper.java
+++ b/src/main/java/leets/weeth/domain/user/application/mapper/CardinalMapper.java
@@ -2,10 +2,15 @@ package leets.weeth.domain.user.application.mapper;
 
 import leets.weeth.domain.user.application.dto.request.CardinalSaveRequest;
 import leets.weeth.domain.user.application.dto.response.CardinalResponse;
+import leets.weeth.domain.user.application.dto.response.UserCardinalDto;
 import leets.weeth.domain.user.domain.entity.Cardinal;
+import leets.weeth.domain.user.domain.entity.User;
+import leets.weeth.domain.user.domain.entity.UserCardinal;
 import org.mapstruct.Mapper;
 import org.mapstruct.MappingConstants;
 import org.mapstruct.ReportingPolicy;
+
+import java.util.List;
 
 @Mapper(componentModel = MappingConstants.ComponentModel.SPRING, unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface CardinalMapper {
@@ -13,4 +18,6 @@ public interface CardinalMapper {
     Cardinal from(CardinalSaveRequest dto);
 
     CardinalResponse to(Cardinal cardinal);
+
+    UserCardinalDto toUserCardinalDto(User user, List<UserCardinal> userCardinals);
 }

--- a/src/main/java/leets/weeth/domain/user/application/mapper/CardinalMapper.java
+++ b/src/main/java/leets/weeth/domain/user/application/mapper/CardinalMapper.java
@@ -1,0 +1,16 @@
+package leets.weeth.domain.user.application.mapper;
+
+import leets.weeth.domain.user.application.dto.request.CardinalSaveRequest;
+import leets.weeth.domain.user.application.dto.response.CardinalResponse;
+import leets.weeth.domain.user.domain.entity.Cardinal;
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingConstants;
+import org.mapstruct.ReportingPolicy;
+
+@Mapper(componentModel = MappingConstants.ComponentModel.SPRING, unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface CardinalMapper {
+
+    Cardinal from(CardinalSaveRequest dto);
+
+    CardinalResponse to(Cardinal cardinal);
+}

--- a/src/main/java/leets/weeth/domain/user/application/mapper/UserMapper.java
+++ b/src/main/java/leets/weeth/domain/user/application/mapper/UserMapper.java
@@ -1,14 +1,16 @@
 package leets.weeth.domain.user.application.mapper;
 
-import leets.weeth.domain.user.application.dto.response.UserResponseDto.*;
 import leets.weeth.domain.user.application.dto.response.UserResponseDto;
-import leets.weeth.domain.user.application.dto.response.UserResponseDto.SummaryResponse;
-import leets.weeth.domain.user.application.dto.response.UserResponseDto.UserResponse;
 import leets.weeth.domain.user.domain.entity.User;
+import leets.weeth.domain.user.domain.entity.UserCardinal;
 import leets.weeth.domain.user.domain.entity.enums.Department;
 import leets.weeth.global.auth.jwt.application.dto.JwtDto;
 import org.mapstruct.*;
 import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import static leets.weeth.domain.user.application.dto.request.UserRequestDto.Register;
 import static leets.weeth.domain.user.application.dto.request.UserRequestDto.SignUp;
@@ -18,27 +20,28 @@ import static leets.weeth.domain.user.application.dto.response.UserResponseDto.*
 public interface UserMapper {
 
     @Mappings({
-            @Mapping(target = "cardinals", expression = "java( java.util.List.of(dto.cardinal()) )"),
             @Mapping(target = "password", expression = "java( passwordEncoder.encode(dto.password()) )"),
             @Mapping(target = "department", expression = "java( leets.weeth.domain.user.domain.entity.enums.Department.to(dto.department()) )")
     })
     User from(SignUp dto, @Context PasswordEncoder passwordEncoder);
 
     @Mappings({
-            @Mapping(target = "cardinals", expression = "java( java.util.List.of(dto.cardinal()) )"),
             @Mapping(target = "department", expression = "java( leets.weeth.domain.user.domain.entity.enums.Department.to(dto.department()) )")
     })
     User from(Register dto);
 
     @Mapping(target = "department", expression = "java( toString(user.getDepartment()) )")
-    Response to(User user);
+    @Mapping(target = "cardinals", expression = "java( toCardinalNumbers(userCardinals) )")
+    Response to(User user, List<UserCardinal> userCardinals);
 
     @Mappings({
             // 수정: 출석률, 출석 횟수, 결석 횟수 매핑 추후 추가 예정
+            @Mapping(target = "cardinals", expression = "java( toCardinalNumbers(userCardinals) )")
     })
-    AdminResponse toAdminResponse(User user);
+    AdminResponse toAdminResponse(User user, List<UserCardinal> userCardinals);
 
-    SummaryResponse toSummaryResponse(User user);
+    @Mapping(target = "cardinals", expression = "java( toCardinalNumbers(userCardinals) )")
+    SummaryResponse toSummaryResponse(User user, List<UserCardinal> userCardinals);
 
     SocialAuthResponse toSocialAuthResponse(Long kakaoId);
 
@@ -56,13 +59,25 @@ public interface UserMapper {
 
     @Mappings({
             // 상세 데이터 매핑
+            @Mapping(target = "cardinals", expression = "java( toCardinalNumbers(userCardinals) )")
     })
-    UserResponse toUserResponse(User user);
+    UserResponse toUserResponse(User user, List<UserCardinal> userCardinals);
 
-    UserResponseDto.UserInfo toUserInfoDto(User user);
+    @Mapping(target = "cardinals", expression = "java( toCardinalNumbers(userCardinals) )")
+    UserResponseDto.UserInfo toUserInfoDto(User user, List<UserCardinal> userCardinals);
 
     default String toString(Department department) {
         return department.getValue();
+    }
+
+    default List<Integer> toCardinalNumbers(List<UserCardinal> userCardinals) {
+        if (userCardinals == null || userCardinals.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return userCardinals.stream()
+                .map(uc -> uc.getCardinal().getCardinalNumber())
+                .collect(Collectors.toList());
     }
 }
 

--- a/src/main/java/leets/weeth/domain/user/application/usecase/CardinalUseCase.java
+++ b/src/main/java/leets/weeth/domain/user/application/usecase/CardinalUseCase.java
@@ -1,0 +1,36 @@
+package leets.weeth.domain.user.application.usecase;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import leets.weeth.domain.user.application.dto.request.CardinalSaveRequest;
+import leets.weeth.domain.user.application.dto.response.CardinalResponse;
+import leets.weeth.domain.user.application.mapper.CardinalMapper;
+import leets.weeth.domain.user.domain.entity.Cardinal;
+import leets.weeth.domain.user.domain.service.CardinalGetService;
+import leets.weeth.domain.user.domain.service.CardinalSaveService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CardinalUseCase {
+
+    private final CardinalGetService cardinalGetService;
+    private final CardinalSaveService cardinalSaveService;
+
+    private final CardinalMapper cardinalMapper;
+
+    @Transactional
+    public void save(CardinalSaveRequest dto) {
+        cardinalSaveService.save(cardinalMapper.from(dto));
+    }
+
+    public List<CardinalResponse> findAll() {
+        List<Cardinal> cardinals = cardinalGetService.findAll();
+        return cardinals.stream()
+                .map(cardinalMapper::to)
+                .toList();
+    }
+}

--- a/src/main/java/leets/weeth/domain/user/application/usecase/CardinalUseCase.java
+++ b/src/main/java/leets/weeth/domain/user/application/usecase/CardinalUseCase.java
@@ -24,6 +24,8 @@ public class CardinalUseCase {
 
     @Transactional
     public void save(CardinalSaveRequest dto) {
+        cardinalGetService.validateCardinal(dto.cardinalNumber());
+
         cardinalSaveService.save(cardinalMapper.from(dto));
     }
 

--- a/src/main/java/leets/weeth/domain/user/application/usecase/UserManageUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/user/application/usecase/UserManageUseCaseImpl.java
@@ -6,12 +6,12 @@ import leets.weeth.domain.schedule.domain.entity.Meeting;
 import leets.weeth.domain.schedule.domain.service.MeetingGetService;
 import leets.weeth.domain.user.application.exception.InvalidUserOrderException;
 import leets.weeth.domain.user.application.mapper.UserMapper;
+import leets.weeth.domain.user.domain.entity.Cardinal;
 import leets.weeth.domain.user.domain.entity.User;
+import leets.weeth.domain.user.domain.entity.UserCardinal;
 import leets.weeth.domain.user.domain.entity.enums.StatusPriority;
 import leets.weeth.domain.user.domain.entity.enums.UsersOrderBy;
-import leets.weeth.domain.user.domain.service.UserDeleteService;
-import leets.weeth.domain.user.domain.service.UserGetService;
-import leets.weeth.domain.user.domain.service.UserUpdateService;
+import leets.weeth.domain.user.domain.service.*;
 import leets.weeth.global.auth.jwt.service.JwtRedisService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -20,10 +20,9 @@ import org.springframework.stereotype.Service;
 import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static leets.weeth.domain.user.application.dto.response.UserResponseDto.AdminResponse;
-import static leets.weeth.domain.user.domain.entity.enums.UsersOrderBy.*;
+import static leets.weeth.domain.user.domain.entity.enums.UsersOrderBy.NAME_ASCENDING;
 
 @Service
 @RequiredArgsConstructor
@@ -36,21 +35,24 @@ public class UserManageUseCaseImpl implements UserManageUseCase {
     private final AttendanceSaveService attendanceSaveService;
     private final MeetingGetService meetingGetService;
     private final JwtRedisService jwtRedisService;
+    private final CardinalGetService cardinalGetService;
+    private final UserCardinalSaveService userCardinalSaveService;
+    private final UserCardinalGetService userCardinalGetService;
 
     private final UserMapper mapper;
     private final PasswordEncoder passwordEncoder;
 
     @Override
     public List<AdminResponse> findAllByAdmin(UsersOrderBy orderBy) {
-        if(orderBy == null || !EnumSet.allOf(UsersOrderBy.class).contains(orderBy)){
+        if (orderBy == null || !EnumSet.allOf(UsersOrderBy.class).contains(orderBy)) {
             throw new InvalidUserOrderException();
         }
 
-        if(orderBy.equals(NAME_ASCENDING)){
+        if (orderBy.equals(NAME_ASCENDING)) {
             return userGetService.findAll().stream()
-                .sorted(Comparator.comparingInt((user->(StatusPriority.fromStatus(user.getStatus())).getPriority())))
-                .map(mapper::toAdminResponse)
-                .toList();
+                    .sorted(Comparator.comparingInt((user -> (StatusPriority.fromStatus(user.getStatus())).getPriority())))
+                    .map(mapper::toAdminResponse)
+                    .toList();
         }
         // To do : 추후 기수 분리 후 작업 예정
 
@@ -62,9 +64,11 @@ public class UserManageUseCaseImpl implements UserManageUseCase {
     public void accept(Long userId) {
         User user = userGetService.find(userId);
 
+        Integer cardinal = userCardinalGetService.getCurrentCardinal(user).getCardinalNumber();
+
         if (user.isInactive()) {
             userUpdateService.accept(user);
-            List<Meeting> meetings = meetingGetService.find(user.getCardinals().get(0));
+            List<Meeting> meetings = meetingGetService.find(cardinal);
             attendanceSaveService.init(user, meetings);
         }
     }
@@ -95,15 +99,17 @@ public class UserManageUseCaseImpl implements UserManageUseCase {
     @Transactional
     public void applyOB(Long userId, Integer cardinal) {
         User user = userGetService.find(userId);
+        Cardinal nextCardinal = cardinalGetService.find(cardinal);
 
-        if (user.notContains(cardinal)) {
-            if (user.isCurrent(cardinal)) {
+        if (userCardinalGetService.notContains(user, nextCardinal)) {
+            if (userCardinalGetService.isCurrent(user, nextCardinal)) {
                 user.initAttendance();
                 List<Meeting> meetings = meetingGetService.find(cardinal);
                 attendanceSaveService.init(user, meetings);
             }
+            UserCardinal userCardinal = new UserCardinal(user, nextCardinal);
 
-            userUpdateService.applyOB(user, cardinal);
+            userCardinalSaveService.save(userCardinal);
         }
     }
 

--- a/src/main/java/leets/weeth/domain/user/application/usecase/UserManageUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/user/application/usecase/UserManageUseCaseImpl.java
@@ -51,7 +51,10 @@ public class UserManageUseCaseImpl implements UserManageUseCase {
         if (orderBy.equals(NAME_ASCENDING)) {
             return userGetService.findAll().stream()
                     .sorted(Comparator.comparingInt((user -> (StatusPriority.fromStatus(user.getStatus())).getPriority())))
-                    .map(mapper::toAdminResponse)
+                    .map(user -> {
+                        List<UserCardinal> userCardinals = userCardinalGetService.getUserCardinals(user);
+                        return mapper.toAdminResponse(user, userCardinals);
+                    })
                     .toList();
         }
         // To do : 추후 기수 분리 후 작업 예정

--- a/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCase.java
+++ b/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCase.java
@@ -24,9 +24,7 @@ public interface UserUseCase {
 
     UserResponseDto.Response find(Long userId);
 
-    Map<Integer, List<UserResponseDto.Response>> findAll();
-
-    Map<Integer, List<UserResponseDto.SummaryResponse>> findAllUser();
+    List<UserResponseDto.SummaryResponse> findAllUser();
 
     UserResponseDto.UserResponse findUserDetails(Long userId);
 

--- a/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCase.java
+++ b/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCase.java
@@ -3,6 +3,7 @@ package leets.weeth.domain.user.application.usecase;
 import leets.weeth.domain.user.application.dto.request.UserRequestDto;
 import leets.weeth.domain.user.application.dto.response.UserResponseDto;
 import leets.weeth.global.auth.jwt.application.dto.JwtDto;
+import org.springframework.data.domain.Slice;
 
 import java.util.List;
 import java.util.Map;
@@ -24,7 +25,7 @@ public interface UserUseCase {
 
     UserResponseDto.Response find(Long userId);
 
-    List<UserResponseDto.SummaryResponse> findAllUser();
+    Slice<SummaryResponse> findAllUser(int pageNumber, int pageSize);
 
     UserResponseDto.UserResponse findUserDetails(Long userId);
 

--- a/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCaseImpl.java
@@ -105,9 +105,9 @@ public class UserUseCaseImpl implements UserUseCase {
         Pageable pageable = PageRequest.of(pageNumber, pageSize);
         Slice<User> users = userGetService.findAll(pageable);
 
-        List<UserCardinal> sliceUserCardinals = userCardinalGetService.findAll(users.getContent());
+        List<UserCardinal> allUserCardinals = userCardinalGetService.findAll(users.getContent());
 
-        Map<Long, List<UserCardinal>> userCardinalMap = sliceUserCardinals.stream()
+        Map<Long, List<UserCardinal>> userCardinalMap = allUserCardinals.stream()
                 .collect(Collectors.groupingBy(userCardinal -> userCardinal.getUser().getId()));
 
         return users.map(user -> {

--- a/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCaseImpl.java
@@ -105,10 +105,9 @@ public class UserUseCaseImpl implements UserUseCase {
         Pageable pageable = PageRequest.of(pageNumber, pageSize);
         Slice<User> users = userGetService.findAll(pageable);
 
+        List<UserCardinal> sliceUserCardinals = userCardinalGetService.findAll(users.getContent());
 
-        List<UserCardinal> allUserCardinals = userCardinalGetService.findAll(users.getContent());
-
-        Map<Long, List<UserCardinal>> userCardinalMap = allUserCardinals.stream()
+        Map<Long, List<UserCardinal>> userCardinalMap = sliceUserCardinals.stream()
                 .collect(Collectors.groupingBy(userCardinal -> userCardinal.getUser().getId()));
 
         return users.map(user -> {

--- a/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCaseImpl.java
@@ -139,6 +139,7 @@ public class UserUseCaseImpl implements UserUseCase {
     }
 
     @Override
+    @Transactional
     public void apply(SignUp dto) {
         validate(dto);
 

--- a/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCaseImpl.java
@@ -1,15 +1,17 @@
 package leets.weeth.domain.user.application.usecase;
 
+import leets.weeth.domain.user.application.dto.response.UserCardinalDto;
 import leets.weeth.domain.user.application.dto.response.UserResponseDto;
 import leets.weeth.domain.user.application.exception.PasswordMismatchException;
 import leets.weeth.domain.user.application.exception.StudentIdExistsException;
 import leets.weeth.domain.user.application.exception.TelExistsException;
 import leets.weeth.domain.user.application.exception.UserInActiveException;
+import leets.weeth.domain.user.application.mapper.CardinalMapper;
 import leets.weeth.domain.user.application.mapper.UserMapper;
+import leets.weeth.domain.user.domain.entity.Cardinal;
 import leets.weeth.domain.user.domain.entity.User;
-import leets.weeth.domain.user.domain.service.UserGetService;
-import leets.weeth.domain.user.domain.service.UserSaveService;
-import leets.weeth.domain.user.domain.service.UserUpdateService;
+import leets.weeth.domain.user.domain.entity.UserCardinal;
+import leets.weeth.domain.user.domain.service.*;
 import leets.weeth.global.auth.jwt.application.dto.JwtDto;
 import leets.weeth.global.auth.jwt.application.usecase.JwtManageUseCase;
 import leets.weeth.global.auth.kakao.KakaoAuthService;
@@ -17,21 +19,22 @@ import leets.weeth.global.auth.kakao.dto.KakaoTokenResponse;
 import leets.weeth.global.auth.kakao.dto.KakaoUserInfoResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.AbstractMap;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static leets.weeth.domain.user.application.dto.request.UserRequestDto.*;
 import static leets.weeth.domain.user.application.dto.response.UserResponseDto.SocialAuthResponse;
 import static leets.weeth.domain.user.application.dto.response.UserResponseDto.SocialLoginResponse;
-import static leets.weeth.domain.user.domain.entity.enums.Status.ACTIVE;
 
 @Slf4j
 @Service
@@ -43,8 +46,12 @@ public class UserUseCaseImpl implements UserUseCase {
     private final UserGetService userGetService;
     private final UserUpdateService userUpdateService;
     private final KakaoAuthService kakaoAuthService;
+    private final CardinalGetService cardinalGetService;
+    private final UserCardinalSaveService userCardinalSaveService;
+    private final UserCardinalGetService userCardinalGetService;
 
     private final UserMapper mapper;
+    private final CardinalMapper cardinalMapper;
     private final PasswordEncoder passwordEncoder;
 
     @Override
@@ -93,40 +100,36 @@ public class UserUseCaseImpl implements UserUseCase {
     }
 
     @Override
-    public Map<Integer, List<UserResponseDto.Response>> findAll() {
-        return userGetService.findAllByStatus(ACTIVE).stream()
-                .flatMap(user -> Stream.concat(
-                        user.getCardinals().stream()
-                                .map(cardinal -> new AbstractMap.SimpleEntry<>(cardinal, mapper.to(user))), // 기수별 Map
-                        Stream.of(new AbstractMap.SimpleEntry<>(0, mapper.to(user)))    // 모든 기수는 cardinal 0에 저장
-                ))
-                .collect(Collectors.groupingBy(Map.Entry::getKey,   // key = 기수, value = 유저 정보
-                        Collectors.mapping(Map.Entry::getValue, Collectors.toList())));
-    }
+    public Slice<UserResponseDto.SummaryResponse> findAllUser(int pageNumber, int pageSize) {
 
-    @Override
-    public Map<Integer, List<UserResponseDto.SummaryResponse>> findAllUser() {
-        return userGetService.findAllByStatus(ACTIVE).stream()
-                .map(user -> new AbstractMap.SimpleEntry<>(user.getCardinals(), mapper.toSummaryResponse(user)))
-                .flatMap(entry -> Stream.concat(
-                        entry.getKey().stream().map(cardinal -> new AbstractMap.SimpleEntry<>(cardinal, entry.getValue())), // 기수별 Map
-                        Stream.of(new AbstractMap.SimpleEntry<>(0, entry.getValue())) // 모든 기수는 cardinal 0에 저장
-                ))
-                .collect(Collectors.groupingBy(
-                        Map.Entry::getKey, // key = 기수
-                        Collectors.mapping(Map.Entry::getValue, Collectors.toList()) // value = 요약 정보 리스트
-                ));
+        Pageable pageable = PageRequest.of(pageNumber, pageSize);
+        Slice<User> users = userGetService.findAll(pageable);
+
+
+        List<UserCardinal> allUserCardinals = userCardinalGetService.findAll(users.getContent());
+
+        Map<Long, List<UserCardinal>> userCardinalMap = allUserCardinals.stream()
+                .collect(Collectors.groupingBy(userCardinal -> userCardinal.getUser().getId()));
+
+        return users.map(user -> {
+            List<UserCardinal> userCardinals = userCardinalMap.getOrDefault(user.getId(), Collections.emptyList());
+
+            return mapper.toSummaryResponse(user, userCardinals);
+        });
     }
 
     @Override
     public UserResponseDto.UserResponse findUserDetails(Long userId) {
-        User user = userGetService.find(userId);
-        return mapper.toUserResponse(user);
+        UserCardinalDto dto = getUserCardinalDto(userId);
+
+        return mapper.toUserResponse(dto.user(), dto.cardinals());
     }
 
     @Override
     public UserResponseDto.Response find(Long userId) {
-        return mapper.to(userGetService.find(userId));
+        UserCardinalDto dto = getUserCardinalDto(userId);
+
+        return mapper.to(dto.user(), dto.cardinals());
     }
 
     @Override
@@ -139,14 +142,27 @@ public class UserUseCaseImpl implements UserUseCase {
     @Override
     public void apply(SignUp dto) {
         validate(dto);
-        userSaveService.save(mapper.from(dto, passwordEncoder));
+
+        Cardinal cardinal = cardinalGetService.find(dto.cardinal());
+        User user = mapper.from(dto, passwordEncoder);
+        UserCardinal userCardinal = new UserCardinal(user, cardinal);
+
+        userSaveService.save(user);
+        userCardinalSaveService.save(userCardinal);
     }
 
     @Override
     @Transactional
     public void socialRegister(Register dto) {
         validate(dto);
-        userSaveService.save(mapper.from(dto));
+
+        Cardinal cardinal = cardinalGetService.find(dto.cardinal());
+
+        User user = mapper.from(dto);
+        UserCardinal userCardinal = new UserCardinal(user, cardinal);
+
+        userSaveService.save(user);
+        userCardinalSaveService.save(userCardinal);
     }
 
     @Override
@@ -163,10 +179,11 @@ public class UserUseCaseImpl implements UserUseCase {
 
     @Override
     public UserResponseDto.UserInfo findUserInfo(Long userId) {
-        User user = userGetService.find(userId);
+        UserCardinalDto dto = getUserCardinalDto(userId);
 
-        return mapper.toUserInfoDto(user);
+        return mapper.toUserInfoDto(dto.user(), dto.cardinals());
     }
+
     private long getKakaoId(Login dto) {
         KakaoTokenResponse tokenResponse = kakaoAuthService.getKakaoToken(dto.authCode());
         KakaoUserInfoResponse userInfo = kakaoAuthService.getUserInfo(tokenResponse.access_token());
@@ -195,5 +212,12 @@ public class UserUseCaseImpl implements UserUseCase {
         if (userGetService.validateTel(dto.tel())) {
             throw new TelExistsException();
         }
+    }
+
+    private UserCardinalDto getUserCardinalDto(Long userId) {
+        User user = userGetService.find(userId);
+        List<UserCardinal> userCardinals = userCardinalGetService.getUserCardinals(user);
+
+        return cardinalMapper.toUserCardinalDto(user, userCardinals);
     }
 }

--- a/src/main/java/leets/weeth/domain/user/domain/entity/Cardinal.java
+++ b/src/main/java/leets/weeth/domain/user/domain/entity/Cardinal.java
@@ -1,0 +1,27 @@
+package leets.weeth.domain.user.domain.entity;
+
+import jakarta.persistence.*;
+import leets.weeth.global.common.entity.BaseEntity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SuperBuilder
+public class Cardinal extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "cardinal_id")
+    private Long id;
+
+    @Column(unique = true, nullable = false)
+    private Integer cardinalNumber;
+
+    private Integer year;
+
+    private Integer semester;
+}

--- a/src/main/java/leets/weeth/domain/user/domain/entity/UserCardinal.java
+++ b/src/main/java/leets/weeth/domain/user/domain/entity/UserCardinal.java
@@ -1,0 +1,33 @@
+package leets.weeth.domain.user.domain.entity;
+
+import jakarta.persistence.*;
+import leets.weeth.global.common.entity.BaseEntity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SuperBuilder
+public class UserCardinal extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_cardinal_id")
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne
+    @JoinColumn(name = "cardinal_id")
+    private Cardinal cardinal;
+
+    public UserCardinal(User user, Cardinal cardinal) {
+        this.user = user;
+        this.cardinal = cardinal;
+    }
+}

--- a/src/main/java/leets/weeth/domain/user/domain/repository/CardinalRepository.java
+++ b/src/main/java/leets/weeth/domain/user/domain/repository/CardinalRepository.java
@@ -1,0 +1,11 @@
+package leets.weeth.domain.user.domain.repository;
+
+import leets.weeth.domain.user.domain.entity.Cardinal;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CardinalRepository extends JpaRepository<Cardinal, Long> {
+
+    Optional<Cardinal> findByCardinalNumber(Integer cardinal);
+}

--- a/src/main/java/leets/weeth/domain/user/domain/repository/UserCardinalRepository.java
+++ b/src/main/java/leets/weeth/domain/user/domain/repository/UserCardinalRepository.java
@@ -1,0 +1,7 @@
+package leets.weeth.domain.user.domain.repository;
+
+import leets.weeth.domain.user.domain.entity.UserCardinal;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserCardinalRepository extends JpaRepository<UserCardinal, Long> {
+}

--- a/src/main/java/leets/weeth/domain/user/domain/repository/UserCardinalRepository.java
+++ b/src/main/java/leets/weeth/domain/user/domain/repository/UserCardinalRepository.java
@@ -1,7 +1,17 @@
 package leets.weeth.domain.user.domain.repository;
 
+import leets.weeth.domain.user.domain.entity.Cardinal;
+import leets.weeth.domain.user.domain.entity.User;
 import leets.weeth.domain.user.domain.entity.UserCardinal;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface UserCardinalRepository extends JpaRepository<UserCardinal, Long> {
+
+    List<UserCardinal> findAllByUser(User user);
+
+    @Query("SELECT uc FROM UserCardinal uc WHERE uc.user IN :users")
+    List<UserCardinal> findAllByUsers(List<User> users);
 }

--- a/src/main/java/leets/weeth/domain/user/domain/repository/UserRepository.java
+++ b/src/main/java/leets/weeth/domain/user/domain/repository/UserRepository.java
@@ -3,6 +3,8 @@ package leets.weeth.domain.user.domain.repository;
 import leets.weeth.domain.user.domain.entity.Cardinal;
 import leets.weeth.domain.user.domain.entity.User;
 import leets.weeth.domain.user.domain.entity.enums.Status;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -13,18 +15,29 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByEmail(String email);
+
     Optional<User> findByKakaoId(long kakaoId);
 
     boolean existsByEmail(String email);
+
     boolean existsByStudentId(String studentId);
+
     boolean existsByTel(String tel);
 
     boolean existsByStudentIdAndIdIsNot(String studentId, Long id);
+
     boolean existsByTelAndIdIsNot(String tel, Long id);
 
     List<User> findAllByStatusOrderByName(Status status);
+
     List<User> findAllByOrderByNameAsc();
 
     @Query("SELECT uc.user FROM UserCardinal uc WHERE uc.cardinal = :cardinal AND uc.user.status = :status")
     List<User> findAllByCardinalAndStatus(@Param("cardinal") Cardinal cardinal, @Param("status") Status status);
+
+    @Query("SELECT uc.user FROM UserCardinal uc " +
+            "JOIN uc.cardinal c " +
+            "WHERE uc.user.status = :status " +
+            "ORDER BY c.cardinalNumber DESC, uc.user.name ASC")
+    Slice<User> findAllByStatusOrderedByCardinalAndName(@Param("status") Status status, Pageable pageable);
 }

--- a/src/main/java/leets/weeth/domain/user/domain/repository/UserRepository.java
+++ b/src/main/java/leets/weeth/domain/user/domain/repository/UserRepository.java
@@ -1,5 +1,6 @@
 package leets.weeth.domain.user.domain.repository;
 
+import leets.weeth.domain.user.domain.entity.Cardinal;
 import leets.weeth.domain.user.domain.entity.User;
 import leets.weeth.domain.user.domain.entity.enums.Status;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -24,6 +25,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     List<User> findAllByStatusOrderByName(Status status);
     List<User> findAllByOrderByNameAsc();
 
-    @Query(value = "SELECT * FROM users u WHERE JSON_CONTAINS(u.cardinals, CAST(:cardinal AS JSON), '$')", nativeQuery = true)
-    List<User> findByCardinal(@Param("cardinal") int cardinal);
+    @Query("SELECT uc.user FROM UserCardinal uc WHERE uc.cardinal = :cardinal AND uc.user.status = :status")
+    List<User> findAllByCardinalAndStatus(@Param("cardinal") Cardinal cardinal, @Param("status") Status status);
 }

--- a/src/main/java/leets/weeth/domain/user/domain/repository/UserRepository.java
+++ b/src/main/java/leets/weeth/domain/user/domain/repository/UserRepository.java
@@ -35,9 +35,21 @@ public interface UserRepository extends JpaRepository<User, Long> {
     @Query("SELECT uc.user FROM UserCardinal uc WHERE uc.cardinal = :cardinal AND uc.user.status = :status")
     List<User> findAllByCardinalAndStatus(@Param("cardinal") Cardinal cardinal, @Param("status") Status status);
 
-    @Query("SELECT uc.user FROM UserCardinal uc " +
-            "JOIN uc.cardinal c " +
-            "WHERE uc.user.status = :status " +
-            "ORDER BY c.cardinalNumber DESC, uc.user.name ASC")
+    /*
+    todo 차후 리팩토링
+     */
+    @Query("""
+                SELECT u FROM User u
+                JOIN UserCardinal uc ON uc.user.id = u.id
+                JOIN Cardinal c ON c.id = uc.cardinal.id
+                WHERE u.status = :status
+                AND c.cardinalNumber = (
+                    SELECT MAX(subC.cardinalNumber)
+                    FROM Cardinal subC
+                    JOIN UserCardinal subUc ON subUc.cardinal.id = subC.id
+                    WHERE subUc.user.id = u.id
+                )
+                ORDER BY u.name ASC
+            """)
     Slice<User> findAllByStatusOrderedByCardinalAndName(@Param("status") Status status, Pageable pageable);
 }

--- a/src/main/java/leets/weeth/domain/user/domain/service/CardinalGetService.java
+++ b/src/main/java/leets/weeth/domain/user/domain/service/CardinalGetService.java
@@ -1,0 +1,30 @@
+package leets.weeth.domain.user.domain.service;
+
+import leets.weeth.domain.user.application.exception.CardinalNotFoundException;
+import leets.weeth.domain.user.domain.entity.Cardinal;
+import leets.weeth.domain.user.domain.repository.CardinalRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CardinalGetService {
+
+    private final CardinalRepository cardinalRepository;
+
+    public Cardinal find(Integer cardinal) {
+        return cardinalRepository.findByCardinalNumber(cardinal)
+                .orElseThrow(CardinalNotFoundException::new);
+    }
+
+    public List<Cardinal> findAll() {
+        return cardinalRepository.findAll();
+    }
+
+    public void validateCardinal(Integer cardinal) {
+        cardinalRepository.findByCardinalNumber(cardinal)
+                .orElseThrow(CardinalNotFoundException::new);
+    }
+}

--- a/src/main/java/leets/weeth/domain/user/domain/service/CardinalGetService.java
+++ b/src/main/java/leets/weeth/domain/user/domain/service/CardinalGetService.java
@@ -1,6 +1,7 @@
 package leets.weeth.domain.user.domain.service;
 
 import leets.weeth.domain.user.application.exception.CardinalNotFoundException;
+import leets.weeth.domain.user.application.exception.DuplicateCardinalException;
 import leets.weeth.domain.user.domain.entity.Cardinal;
 import leets.weeth.domain.user.domain.repository.CardinalRepository;
 import lombok.RequiredArgsConstructor;
@@ -24,7 +25,8 @@ public class CardinalGetService {
     }
 
     public void validateCardinal(Integer cardinal) {
-        cardinalRepository.findByCardinalNumber(cardinal)
-                .orElseThrow(CardinalNotFoundException::new);
+        if (cardinalRepository.findByCardinalNumber(cardinal).isPresent()) {
+            throw new DuplicateCardinalException();
+        }
     }
 }

--- a/src/main/java/leets/weeth/domain/user/domain/service/CardinalSaveService.java
+++ b/src/main/java/leets/weeth/domain/user/domain/service/CardinalSaveService.java
@@ -1,0 +1,17 @@
+package leets.weeth.domain.user.domain.service;
+
+import leets.weeth.domain.user.domain.entity.Cardinal;
+import leets.weeth.domain.user.domain.repository.CardinalRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CardinalSaveService {
+
+    private final CardinalRepository cardinalRepository;
+
+    public void save(Cardinal cardinal) {
+        cardinalRepository.save(cardinal);
+    }
+}

--- a/src/main/java/leets/weeth/domain/user/domain/service/UserCardinalGetService.java
+++ b/src/main/java/leets/weeth/domain/user/domain/service/UserCardinalGetService.java
@@ -1,0 +1,53 @@
+package leets.weeth.domain.user.domain.service;
+
+import leets.weeth.domain.user.application.exception.CardinalNotFoundException;
+import leets.weeth.domain.user.domain.entity.Cardinal;
+import leets.weeth.domain.user.domain.entity.User;
+import leets.weeth.domain.user.domain.entity.UserCardinal;
+import leets.weeth.domain.user.domain.repository.UserCardinalRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Comparator;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class UserCardinalGetService {
+
+    private final UserCardinalRepository userCardinalRepository;
+
+    public List<UserCardinal> getUserCardinals(User user) {
+        return userCardinalRepository.findAllByUser(user);
+    }
+
+    public List<UserCardinal> findAll() {
+        return userCardinalRepository.findAll();
+    }
+
+    public List<UserCardinal> findAll(List<User> users) {
+        return userCardinalRepository.findAllByUsers(users);
+    }
+
+    public boolean notContains(User user, Cardinal cardinal) {
+        return getUserCardinals(user).stream()
+                .noneMatch(userCardinal -> userCardinal.getCardinal().equals(cardinal));
+    }
+
+    public boolean isCurrent(User user, Cardinal cardinal) {
+        Integer maxCardinalNumber = getUserCardinals(user).stream()
+                .map(UserCardinal::getCardinal)
+                .map(Cardinal::getCardinalNumber)
+                .max(Integer::compareTo)
+                .orElseThrow(CardinalNotFoundException::new);
+
+        return maxCardinalNumber < cardinal.getCardinalNumber();
+    }
+
+    public Cardinal getCurrentCardinal(User user) {
+        return getUserCardinals(user).stream()
+                .map(UserCardinal::getCardinal)
+                .max(Comparator.comparing(Cardinal::getCardinalNumber))
+                .orElseThrow(CardinalNotFoundException::new);
+    }
+}

--- a/src/main/java/leets/weeth/domain/user/domain/service/UserCardinalSaveService.java
+++ b/src/main/java/leets/weeth/domain/user/domain/service/UserCardinalSaveService.java
@@ -1,0 +1,17 @@
+package leets.weeth.domain.user.domain.service;
+
+import leets.weeth.domain.user.domain.entity.UserCardinal;
+import leets.weeth.domain.user.domain.repository.UserCardinalRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserCardinalSaveService {
+
+    private final UserCardinalRepository userCardinalRepository;
+
+    public void save(UserCardinal userCardinal) {
+        userCardinalRepository.save(userCardinal);
+    }
+}

--- a/src/main/java/leets/weeth/domain/user/domain/service/UserGetService.java
+++ b/src/main/java/leets/weeth/domain/user/domain/service/UserGetService.java
@@ -6,6 +6,8 @@ import leets.weeth.domain.user.domain.entity.enums.Status;
 import leets.weeth.domain.user.domain.repository.UserRepository;
 import leets.weeth.domain.user.application.exception.UserNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -45,6 +47,10 @@ public class UserGetService {
 
     public List<User> findAllByCardinal(Cardinal cardinal) {
         return userRepository.findAllByCardinalAndStatus(cardinal, Status.ACTIVE);
+    }
+
+    public Slice<User> findAll(Pageable pageable) {
+        return userRepository.findAllByStatusOrderedByCardinalAndName(Status.ACTIVE, pageable);
     }
 
     public boolean validateStudentId(String studentId) {

--- a/src/main/java/leets/weeth/domain/user/domain/service/UserGetService.java
+++ b/src/main/java/leets/weeth/domain/user/domain/service/UserGetService.java
@@ -1,5 +1,6 @@
 package leets.weeth.domain.user.domain.service;
 
+import leets.weeth.domain.user.domain.entity.Cardinal;
 import leets.weeth.domain.user.domain.entity.User;
 import leets.weeth.domain.user.domain.entity.enums.Status;
 import leets.weeth.domain.user.domain.repository.UserRepository;
@@ -38,12 +39,12 @@ public class UserGetService {
         return userRepository.findAllByStatusOrderByName(status);
     }
 
-    public List<User> findAllByCardinal(int cardinal) {
-        return userRepository.findByCardinal(cardinal);
-    }
-
     public List<User> findAll() {
         return userRepository.findAllByOrderByNameAsc();
+    }
+
+    public List<User> findAllByCardinal(Cardinal cardinal) {
+        return userRepository.findAllByCardinalAndStatus(cardinal, Status.ACTIVE);
     }
 
     public boolean validateStudentId(String studentId) {

--- a/src/main/java/leets/weeth/domain/user/domain/service/UserUpdateService.java
+++ b/src/main/java/leets/weeth/domain/user/domain/service/UserUpdateService.java
@@ -2,7 +2,9 @@ package leets.weeth.domain.user.domain.service;
 
 import jakarta.transaction.Transactional;
 import leets.weeth.domain.user.application.dto.request.UserRequestDto;
+import leets.weeth.domain.user.domain.entity.Cardinal;
 import leets.weeth.domain.user.domain.entity.User;
+import leets.weeth.domain.user.domain.entity.UserCardinal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -18,19 +20,13 @@ public class UserUpdateService {
     public void update(User user, Update dto, PasswordEncoder passwordEncoder) {
         user.update(dto, passwordEncoder);
     }
-    public void update(User user, Register dto) {
-        user.update(dto);
-    }
+
     public void accept(User user) {
         user.accept();
     }
 
     public void update(User user, String role) {
         user.update(role);
-    }
-
-    public void applyOB(User user, Integer cardinal) {
-        user.applyOB(cardinal);
     }
 
     public void reset(User user, PasswordEncoder passwordEncoder) {

--- a/src/main/java/leets/weeth/domain/user/presentation/CardinalController.java
+++ b/src/main/java/leets/weeth/domain/user/presentation/CardinalController.java
@@ -1,0 +1,42 @@
+package leets.weeth.domain.user.presentation;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import leets.weeth.domain.user.application.dto.request.CardinalSaveRequest;
+import leets.weeth.domain.user.application.dto.response.CardinalResponse;
+import leets.weeth.domain.user.application.usecase.CardinalUseCase;
+import leets.weeth.global.common.response.CommonResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+import static leets.weeth.domain.user.presentation.ResponseMessage.CARDINAL_FIND_ALL_SUCCESS;
+import static leets.weeth.domain.user.presentation.ResponseMessage.CARDINAL_SAVE_SUCCESS;
+
+@Tag(name = "CARDINAL")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/cardinals")
+public class CardinalController {
+
+    private final CardinalUseCase cardinalUseCase;
+
+    @GetMapping
+    @Operation(summary = "현재 저장된 기수 목록 조회 API")
+    public CommonResponse<List<CardinalResponse>> findAllCardinals() {
+        List<CardinalResponse> response = cardinalUseCase.findAll();
+
+        return CommonResponse.createSuccess(CARDINAL_FIND_ALL_SUCCESS.getMessage(), response);
+    }
+
+    @PostMapping
+    @Operation(summary = "새로운 기수 정보 저장 API")
+    public CommonResponse<Void> save(@RequestBody @Valid CardinalSaveRequest dto) {
+        cardinalUseCase.save(dto);
+
+        return CommonResponse.createSuccess(CARDINAL_SAVE_SUCCESS.getMessage());
+    }
+
+}

--- a/src/main/java/leets/weeth/domain/user/presentation/CardinalController.java
+++ b/src/main/java/leets/weeth/domain/user/presentation/CardinalController.java
@@ -18,7 +18,7 @@ import static leets.weeth.domain.user.presentation.ResponseMessage.CARDINAL_SAVE
 @Tag(name = "CARDINAL")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/cardinals")
+@RequestMapping("/api/v1/admin/cardinals")
 public class CardinalController {
 
     private final CardinalUseCase cardinalUseCase;

--- a/src/main/java/leets/weeth/domain/user/presentation/CardinalController.java
+++ b/src/main/java/leets/weeth/domain/user/presentation/CardinalController.java
@@ -18,12 +18,12 @@ import static leets.weeth.domain.user.presentation.ResponseMessage.CARDINAL_SAVE
 @Tag(name = "CARDINAL")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/admin/cardinals")
+@RequestMapping("/api/v1")
 public class CardinalController {
 
     private final CardinalUseCase cardinalUseCase;
 
-    @GetMapping
+    @GetMapping("/cardinals")
     @Operation(summary = "현재 저장된 기수 목록 조회 API")
     public CommonResponse<List<CardinalResponse>> findAllCardinals() {
         List<CardinalResponse> response = cardinalUseCase.findAll();
@@ -31,8 +31,8 @@ public class CardinalController {
         return CommonResponse.createSuccess(CARDINAL_FIND_ALL_SUCCESS.getMessage(), response);
     }
 
-    @PostMapping
-    @Operation(summary = "새로운 기수 정보 저장 API")
+    @PostMapping("/admin/cardinals")
+    @Operation(summary = "[admin] 새로운 기수 정보 저장 API")
     public CommonResponse<Void> save(@RequestBody @Valid CardinalSaveRequest dto) {
         cardinalUseCase.save(dto);
 

--- a/src/main/java/leets/weeth/domain/user/presentation/ResponseMessage.java
+++ b/src/main/java/leets/weeth/domain/user/presentation/ResponseMessage.java
@@ -24,7 +24,11 @@ public enum ResponseMessage {
     SOCIAL_REGISTER_SUCCESS("소셜 회원가입에 성공했습니다."),
     SOCIAL_AUTH_SUCCESS("소셜 인증에 성공했습니다."),
     SOCIAL_INTEGRATE_SUCCESS("소셜 로그인 연동에 성공했습니다."),
-    JWT_REFRESH_SUCCESS("토큰 재발급에 성공했습니다.");
+    JWT_REFRESH_SUCCESS("토큰 재발급에 성공했습니다."),
+
+    // CardinalController 관련
+    CARDINAL_FIND_ALL_SUCCESS("전체 기수 조회에 성공했습니다."),
+    CARDINAL_SAVE_SUCCESS("기수 저장에 성공했습니다.");
 
     private final String message;
 }

--- a/src/main/java/leets/weeth/domain/user/presentation/ResponseMessage.java
+++ b/src/main/java/leets/weeth/domain/user/presentation/ResponseMessage.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ResponseMessage {
     // UserAdminController 관련
-    USER_FIND_ALL_SUCCESS("관리자가 모든 회원 정보를 성공적으로 조회했습니다."),
+    USER_FIND_ALL_SUCCESS("모든 회원 정보를 성공적으로 조회했습니다."),
     USER_DETAILS_SUCCESS("특정 회원의 상세 정보를 성공적으로 조회했습니다."),
     USER_ACCEPT_SUCCESS("회원 가입 승인이 성공적으로 처리되었습니다."),
     USER_BAN_SUCCESS("회원이 성공적으로 차단되었습니다."),

--- a/src/main/java/leets/weeth/domain/user/presentation/UserController.java
+++ b/src/main/java/leets/weeth/domain/user/presentation/UserController.java
@@ -14,6 +14,7 @@ import leets.weeth.global.auth.annotation.CurrentUser;
 import leets.weeth.global.auth.jwt.application.dto.JwtDto;
 import leets.weeth.global.common.response.CommonResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Slice;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -76,8 +77,9 @@ public class UserController {
 
     @GetMapping("/all")
     @Operation(summary = "동아리 멤버 전체 조회(전체/기수별)")
-    public CommonResponse<Map<Integer, List<SummaryResponse>>> findAllUser() {
-        return CommonResponse.createSuccess(USER_FIND_ALL_SUCCESS.getMessage(), userUseCase.findAllUser());
+    public CommonResponse<Slice<SummaryResponse>> findAllUser(@RequestParam("pageNumber") int pageNumber,
+                                                              @RequestParam("pageSize") int pageSize) {
+        return CommonResponse.createSuccess(USER_FIND_ALL_SUCCESS.getMessage(), userUseCase.findAllUser(pageNumber, pageSize));
     }
 
     @GetMapping("/details")


### PR DESCRIPTION
## PR 내용
- 기존 List<int>로 관리되던 기수를 분리했습니다
- 요구사항 수정 및 관리 용이성 때문에 분리를 진행했습니다
- user-cardinal은 M:N 관계이기 때문에 UserCardinal이라는 중간 객체를 설정했습니다

- 작업 중 OneToMany로 설정해둔  출석, 기수, 패널티 때문에 User 객체 생성이 불가능한 오류가 있어서 해당 매핑을 전부 제거했습니다
- 따라서 관련 매핑을 제거를 했고, 출석은 관련 로직이 많아 제거하지 못했습니다. 우선적으로 User 객체 생성은 가능하게 수정해뒀습니다
- 성능 최적화를 위해 부득이하게 쿼리를 일부 사용했습니다
<br>

## PR 세부사항
- 기수 저장, 조회 어드민 API 구현
- 기수, 패널티 1:N 매핑 제거
- 기수, 유저-기수 테이블 생성
- [서비스] 멤버 조회 무한 스크롤 구현 (최신 기수별, 같은 기수 안에서는 이름별 정렬)
<br>

## 관련 스크린샷
```
Response body
Download
{
  "code": 200,
  "message": "모든 회원 정보를 성공적으로 조회했습니다.",
  "data": {
    "content": [
      {
        "id": 15,
        "name": "a",
        "cardinals": [
          5
        ],
        "position": "BE",
        "role": "USER"
      },
      {
        "id": 16,
        "name": "b",
        "cardinals": [
          5
        ],
        "position": "BE",
        "role": "USER"
      },
      {
        "id": 17,
        "name": "c",
        "cardinals": [
          5
        ],
        "position": "BE",
        "role": "USER"
      },
      {
        "id": 18,
        "name": "d",
        "cardinals": [
          5
        ],
        "position": "BE",
        "role": "USER"
      },
      {
        "id": 19,
        "name": "e",
        "cardinals": [
          5
        ],
        "position": "BE",
        "role": "USER"
      }
    ],
    "pageable": {
      "pageNumber": 0,
      "pageSize": 5,
      "sort": {
        "empty": true,
        "unsorted": true,
        "sorted": false
      },
      "offset": 0,
      "unpaged": false,
      "paged": true
    },
    "size": 5,
    "number": 0,
    "sort": {
      "empty": true,
      "unsorted": true,
      "sorted": false
    },
    "numberOfElements": 5,
    "first": true,
    "last": false,
    "empty": false
  }
}
```
<br>

## 주의사항
- 멤버 조회시 기수 별로 Slice를 조회하는 부분에서 중복 제거를 위해 복잡한 쿼리를 사용했습니다
- 아무리 고민을 해봐도 DB 의존도를 낮추고 페이지 별로 데이터를 가져와 중복을 제거하는 방법을 찾을 수 없어 차후 리팩토링 예정입니다.
- 쿼리 성능은 해당 방식이 가장 좋았습니다
<br>

## 체크 리스트

- [x] 리뷰어 설정
- [x] Assignee 설정
- [x] Label 설정
- [x] 제목 양식 맞췄나요? (ex. #0 Feat: 기능 추가)
- [x] 변경 사항에 대한 테스트