### PR TITLE
Feat #108 영수증 사용처 추가

### DIFF
--- a/src/main/java/leets/weeth/domain/account/application/dto/ReceiptDTO.java
+++ b/src/main/java/leets/weeth/domain/account/application/dto/ReceiptDTO.java
@@ -11,26 +11,32 @@ import java.util.List;
 public class ReceiptDTO {
 
     public record Response(
-        Long id,
-        String description,
-        Integer amount,
-        LocalDate date,
-        List<FileResponse> fileUrls
-    ) {}
+            Long id,
+            String description,
+            String source,
+            Integer amount,
+            LocalDate date,
+            List<FileResponse> fileUrls
+    ) {
+    }
 
     public record Save(
             String description,
+            String source,
             @NotNull Integer amount,
             @NotNull LocalDate date,
             @NotNull Integer cardinal,
             @Valid List<@NotNull FileSaveRequest> files
-    ) {}
+    ) {
+    }
 
     public record Update(
             String description,
+            String source,
             @NotNull Integer amount,
             @NotNull LocalDate date,
             @NotNull Integer cardinal,
             @Valid List<@NotNull FileSaveRequest> files
-    ) {}
+    ) {
+    }
 }

--- a/src/main/java/leets/weeth/domain/account/domain/entity/Receipt.java
+++ b/src/main/java/leets/weeth/domain/account/domain/entity/Receipt.java
@@ -27,6 +27,8 @@ public class Receipt extends BaseEntity {
 
     private String description;
 
+    private String source;
+
     private Integer amount;
 
     private LocalDate date;
@@ -37,6 +39,7 @@ public class Receipt extends BaseEntity {
 
     public void update(ReceiptDTO.Update dto){
         this.description = dto.description();
+        this.source = dto.source();
         this.amount = dto.amount();
         this.date = dto.date();
     }


### PR DESCRIPTION
## PR 내용
- 영수증 DB에 source. 사용처 컬럼을 추가했습니다

<br>

## PR 세부사항
- 엔티티에 변수를 추가하고, 생성, 수정, 조회시 사용되는 dto에 동일한 변수명으로 추가했습니다
- 동일한 변수명을 사용했기에 mapper에 별도 매핑을 해주지 않았습니다
- 마찬가지로 필수값은 아니라 판단해 선택적으로 입력할 수 있도록 했습니다
<br>

## 관련 스크린샷
<img width="415" alt="image" src="https://github.com/user-attachments/assets/c4a6def7-7c8f-43fd-ad46-fe36c41e2243" />

<br>

## 주의사항
x
<br>

## 체크 리스트

- [x] 리뷰어 설정
- [x] Assignee 설정
- [x] Label 설정
- [x] 제목 양식 맞췄나요? (ex. #0 Feat: 기능 추가)
- [x] 변경 사항에 대한 테스트