### PR TITLE
Feat #110 당일 출석 상태 함께 반환

### DIFF
--- a/src/main/java/leets/weeth/domain/attendance/application/dto/AttendanceDTO.java
+++ b/src/main/java/leets/weeth/domain/attendance/application/dto/AttendanceDTO.java
@@ -12,6 +12,7 @@ public class AttendanceDTO {
     public record Main(
             Integer attendanceRate,
             String title,
+            Status status,
             LocalDateTime start,
             LocalDateTime end,
             String location

--- a/src/main/java/leets/weeth/domain/attendance/application/mapper/AttendanceMapper.java
+++ b/src/main/java/leets/weeth/domain/attendance/application/mapper/AttendanceMapper.java
@@ -13,6 +13,7 @@ public interface AttendanceMapper {
     @Mappings({
             @Mapping(target = "attendanceRate", source = "user.attendanceRate"),
             @Mapping(target = "title", source = "attendance.meeting.title"),
+            @Mapping(target = "status", source = "attendance.status"),
             @Mapping(target = "start", source = "attendance.meeting.start"),
             @Mapping(target = "end", source = "attendance.meeting.end"),
             @Mapping(target = "location", source = "attendance.meeting.location"),


### PR DESCRIPTION
## PR 내용
- 출석 메인 페이지 API에서 당일 내 출석 상태를 알 수 있도록 응답 dto에 status를 추가했습니다
<br>

## PR 세부사항
- 응답 dto와 mapper를 수정해 당일 출석 상태를 알 수 있게 하였습니다
- 출석 버튼에 대한 동적인 상태 변화를 위해 사용됩니다
<br>

## 관련 스크린샷
<img width="440" alt="image" src="https://github.com/user-attachments/assets/38f51c46-6fb6-4ff6-9681-b1813aab8c15" />

<br>

## 주의사항
X
<br>

## 체크 리스트

- [x] 리뷰어 설정
- [x] Assignee 설정
- [x] Label 설정
- [x] 제목 양식 맞췄나요? (ex. #0 Feat: 기능 추가)
- [x] 변경 사항에 대한 테스트