### PR TITLE
Refactor#111 글 조회시 포지션과 역할 같이 반환하도록 수정

### DIFF
--- a/src/main/java/leets/weeth/domain/board/application/dto/NoticeDTO.java
+++ b/src/main/java/leets/weeth/domain/board/application/dto/NoticeDTO.java
@@ -5,6 +5,8 @@ import jakarta.validation.constraints.NotNull;
 import leets.weeth.domain.comment.application.dto.CommentDTO;
 import leets.weeth.domain.file.application.dto.request.FileSaveRequest;
 import leets.weeth.domain.file.application.dto.response.FileResponse;
+import leets.weeth.domain.user.domain.entity.enums.Position;
+import leets.weeth.domain.user.domain.entity.enums.Role;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
@@ -32,6 +34,8 @@ public class NoticeDTO {
     public record Response(
             Long id,
             String name,
+            Position position,
+            Role role,
             String title,
             String content,
             LocalDateTime time,//modifiedAt
@@ -45,6 +49,8 @@ public class NoticeDTO {
     public record ResponseAll(
             Long id,
             String name,
+            Position position,
+            Role role,
             String title,
             String content,
             LocalDateTime time,//modifiedAt

--- a/src/main/java/leets/weeth/domain/board/application/dto/PostDTO.java
+++ b/src/main/java/leets/weeth/domain/board/application/dto/PostDTO.java
@@ -6,6 +6,8 @@ import leets.weeth.domain.comment.application.dto.CommentDTO;
 import leets.weeth.domain.file.application.dto.request.FileSaveRequest;
 import leets.weeth.domain.file.application.dto.request.FileUpdateRequest;
 import leets.weeth.domain.file.application.dto.response.FileResponse;
+import leets.weeth.domain.user.domain.entity.enums.Position;
+import leets.weeth.domain.user.domain.entity.enums.Role;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
@@ -31,6 +33,8 @@ public class PostDTO {
     public record Response(
             Long id,
             String name,
+            Position position,
+            Role role,
             String title,
             String content,
             LocalDateTime time,//modifiedAt
@@ -43,6 +47,8 @@ public class PostDTO {
     public record ResponseAll(
             Long id,
             String name,
+            Position position,
+            Role role,
             String title,
             String content,
             LocalDateTime time,//modifiedAt

--- a/src/main/java/leets/weeth/domain/board/application/mapper/NoticeMapper.java
+++ b/src/main/java/leets/weeth/domain/board/application/mapper/NoticeMapper.java
@@ -36,43 +36,8 @@ public interface NoticeMapper {
             @Mapping(target = "name", source = "notice.user.name"),
             @Mapping(target = "position", source = "notice.user.position"),
             @Mapping(target = "role", source = "notice.user.role"),
-            @Mapping(target = "comments", expression = "java(filterParentComments(notice.getComments()))"),
             @Mapping(target = "time", source = "notice.modifiedAt")
     })
-    NoticeDTO.Response toNoticeDto(Notice notice, List<FileResponse> fileUrls);
-
-    default List<CommentDTO.Response> filterParentComments(List<Comment> comments) {
-        if (comments == null || comments.isEmpty()) {
-            return Collections.emptyList();
-        }
-
-        // 부모 댓글만 필터링하고, 각 부모 댓글에 대해 자식 댓글을 매핑
-        return comments.stream()
-                .filter(comment -> comment.getParent() == null) // 부모 댓글만 필터링
-                .map(this::mapCommentWithChildren) // 자식 댓글 포함하여 매핑
-                .toList();
-    }
-
-    default CommentDTO.Response mapCommentWithChildren(Comment comment) {
-        if (comment == null) {
-            return null;
-        }
-
-        // 기본 댓글 정보 매핑
-        CommentDTO.Response.ResponseBuilder response = CommentDTO.Response.builder();
-
-        response.name(comment.getUser().getName());
-        response.time(comment.getModifiedAt());
-        response.id(comment.getId());
-        response.content(comment.getContent());
-
-        // 자식 댓글들을 재귀적으로 매핑하여 children 필드에 설정
-        List<CommentDTO.Response> childrenResponses = comment.getChildren().stream()
-                .map(this::mapCommentWithChildren) // 자식 댓글도 동일하게 처리
-                .collect(Collectors.toList());
-        response.children(childrenResponses);
-
-        return response.build();
-    }
+    NoticeDTO.Response toNoticeDto(Notice notice, List<FileResponse> fileUrls, List<CommentDTO.Response> comments);
 
 }

--- a/src/main/java/leets/weeth/domain/board/application/mapper/NoticeMapper.java
+++ b/src/main/java/leets/weeth/domain/board/application/mapper/NoticeMapper.java
@@ -25,6 +25,8 @@ public interface NoticeMapper {
 
     @Mappings({
             @Mapping(target = "name", source = "notice.user.name"),
+            @Mapping(target = "position", source = "notice.user.position"),
+            @Mapping(target = "role", source = "notice.user.role"),
             @Mapping(target = "time", source = "notice.modifiedAt"),
             @Mapping(target = "hasFile", expression = "java(fileExists)")
     })
@@ -32,6 +34,8 @@ public interface NoticeMapper {
 
     @Mappings({
             @Mapping(target = "name", source = "notice.user.name"),
+            @Mapping(target = "position", source = "notice.user.position"),
+            @Mapping(target = "role", source = "notice.user.role"),
             @Mapping(target = "comments", expression = "java(filterParentComments(notice.getComments()))"),
             @Mapping(target = "time", source = "notice.modifiedAt")
     })

--- a/src/main/java/leets/weeth/domain/board/application/mapper/PostMapper.java
+++ b/src/main/java/leets/weeth/domain/board/application/mapper/PostMapper.java
@@ -25,6 +25,8 @@ public interface PostMapper {
 
     @Mappings({
             @Mapping(target = "name", source = "post.user.name"),
+            @Mapping(target = "position", source = "post.user.position"),
+            @Mapping(target = "role", source = "post.user.role"),
             @Mapping(target = "time", source = "post.modifiedAt"),
             @Mapping(target = "hasFile", expression = "java(fileExists)")
     })
@@ -33,6 +35,8 @@ public interface PostMapper {
 
     @Mappings({
             @Mapping(target = "name", source = "post.user.name"),
+            @Mapping(target = "position", source = "post.user.position"),
+            @Mapping(target = "role", source = "post.user.role"),
             @Mapping(target = "comments", expression = "java(filterParentComments(post.getComments()))"),
             @Mapping(target = "time", source = "post.modifiedAt")
     })

--- a/src/main/java/leets/weeth/domain/board/application/mapper/PostMapper.java
+++ b/src/main/java/leets/weeth/domain/board/application/mapper/PostMapper.java
@@ -37,43 +37,8 @@ public interface PostMapper {
             @Mapping(target = "name", source = "post.user.name"),
             @Mapping(target = "position", source = "post.user.position"),
             @Mapping(target = "role", source = "post.user.role"),
-            @Mapping(target = "comments", expression = "java(filterParentComments(post.getComments()))"),
             @Mapping(target = "time", source = "post.modifiedAt")
     })
-    PostDTO.Response toPostDto(Post post, List<FileResponse> fileUrls);
-
-    default List<CommentDTO.Response> filterParentComments(List<Comment> comments) {
-        if (comments == null || comments.isEmpty()) {
-            return Collections.emptyList();
-        }
-
-        // 부모 댓글만 필터링하고, 각 부모 댓글에 대해 자식 댓글을 매핑
-        return comments.stream()
-                .filter(comment -> comment.getParent() == null) // 부모 댓글만 필터링
-                .map(this::mapCommentWithChildren) // 자식 댓글 포함하여 매핑
-                .toList();
-    }
-
-    default CommentDTO.Response mapCommentWithChildren(Comment comment) {
-        if (comment == null) {
-            return null;
-        }
-
-        // 기본 댓글 정보 매핑
-        CommentDTO.Response.ResponseBuilder response = CommentDTO.Response.builder();
-
-        response.name(comment.getUser().getName());
-        response.time(comment.getModifiedAt());
-        response.id(comment.getId());
-        response.content(comment.getContent());
-
-        // 자식 댓글들을 재귀적으로 매핑하여 children 필드에 설정
-        List<CommentDTO.Response> childrenResponses = comment.getChildren().stream()
-                .map(this::mapCommentWithChildren) // 자식 댓글도 동일하게 처리
-                .collect(Collectors.toList());
-        response.children(childrenResponses);
-
-        return response.build();
-    }
+    PostDTO.Response toPostDto(Post post, List<FileResponse> fileUrls, List<CommentDTO.Response> comments);
 
 }

--- a/src/main/java/leets/weeth/domain/board/application/usecase/NoticeUsecaseImpl.java
+++ b/src/main/java/leets/weeth/domain/board/application/usecase/NoticeUsecaseImpl.java
@@ -121,7 +121,7 @@ public class NoticeUsecaseImpl implements NoticeUsecase {
         return notice;
     }
 
-    public boolean checkFileExistsByNotice(Long noticeId){
+    private boolean checkFileExistsByNotice(Long noticeId){
         return !fileGetService.findAllByNotice(noticeId).isEmpty();
     }
 

--- a/src/main/java/leets/weeth/domain/board/application/usecase/PostUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/board/application/usecase/PostUseCaseImpl.java
@@ -8,6 +8,8 @@ import leets.weeth.domain.board.domain.service.PostDeleteService;
 import leets.weeth.domain.board.domain.service.PostFindService;
 import leets.weeth.domain.board.domain.service.PostSaveService;
 import leets.weeth.domain.board.domain.service.PostUpdateService;
+import leets.weeth.domain.comment.application.dto.CommentDTO;
+import leets.weeth.domain.comment.domain.entity.Comment;
 import leets.weeth.domain.file.application.dto.response.FileResponse;
 import leets.weeth.domain.file.application.mapper.FileMapper;
 import leets.weeth.domain.file.domain.entity.File;
@@ -23,7 +25,9 @@ import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -64,7 +68,8 @@ public class PostUseCaseImpl implements PostUsecase {
                 .map(fileMapper::toFileResponse)
                 .toList();
 
-        return mapper.toPostDto(post, response);
+
+        return mapper.toPostDto(post, response, filterParentComments(post.getComments()));
     }
 
     @Override
@@ -118,6 +123,40 @@ public class PostUseCaseImpl implements PostUsecase {
 
     public boolean checkFileExistsByPost(Long postId){
         return !fileGetService.findAllByPost(postId).isEmpty();
+    }
+
+    private List<CommentDTO.Response> filterParentComments(List<Comment> comments) {
+        if (comments == null || comments.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        // 부모 댓글만 필터링하고, 각 부모 댓글에 대해 자식 댓글을 매핑
+        return comments.stream()
+            .filter(comment -> comment.getParent() == null) // 부모 댓글만 필터링
+            .map(this::mapCommentWithChildren) // 자식 댓글 포함하여 매핑
+            .toList();
+    }
+
+    private CommentDTO.Response mapCommentWithChildren(Comment comment) {
+        if (comment == null) {
+            return null;
+        }
+
+        // 기본 댓글 정보 매핑
+        CommentDTO.Response.ResponseBuilder response = CommentDTO.Response.builder();
+
+        response.name(comment.getUser().getName());
+        response.time(comment.getModifiedAt());
+        response.id(comment.getId());
+        response.content(comment.getContent());
+
+        // 자식 댓글들을 재귀적으로 매핑하여 children 필드에 설정
+        List<CommentDTO.Response> childrenResponses = comment.getChildren().stream()
+            .map(this::mapCommentWithChildren) // 자식 댓글도 동일하게 처리
+            .collect(Collectors.toList());
+        response.children(childrenResponses);
+
+        return response.build();
     }
 
 }

--- a/src/main/java/leets/weeth/domain/comment/application/dto/CommentDTO.java
+++ b/src/main/java/leets/weeth/domain/comment/application/dto/CommentDTO.java
@@ -1,6 +1,8 @@
 package leets.weeth.domain.comment.application.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import leets.weeth.domain.user.domain.entity.enums.Position;
+import leets.weeth.domain.user.domain.entity.enums.Role;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
@@ -23,6 +25,8 @@ public class CommentDTO {
     public record Response(
             Long id,
             String name,
+            Position position,
+            Role role,
             String content,
             LocalDateTime time, //modifiedAt
             List<CommentDTO.Response> children

--- a/src/main/java/leets/weeth/domain/comment/application/mapper/CommentMapper.java
+++ b/src/main/java/leets/weeth/domain/comment/application/mapper/CommentMapper.java
@@ -36,7 +36,9 @@ public interface CommentMapper {
     })
     Comment fromCommentDto(CommentDTO.Save dto, Notice notice, User user, Comment parent);
 
-    @Mapping(target = "name", source = "user.name")
+    @Mapping(target = "name", source = "comment.user.name")
+    @Mapping(target = "position", source = "comment.user.position")
+    @Mapping(target = "role", source = "comment.user.role")
     @Mapping(target = "time", source = "modifiedAt")
     CommentDTO.Response toCommentDto(Comment comment);
 }


### PR DESCRIPTION
## PR 내용
- 글 조회시 파트랑 역할 같이 반환하도록 수정 하였습니다
- 피그마에서 확인해보니, 공지사항, 게시판, 댓글에서 포지션이 필요해 추가하였습니다

<br>

## PR 세부사항
- 공지사항, 게시판, 댓글 조회시 포지션과 역할을 같이 반환하도록 수정하였습니다

<br>

## 관련 스크린샷
![image](https://github.com/user-attachments/assets/87879b9f-1c3e-418b-8404-fa040f2676bb)


<br>

## 주의사항
없습니다
<br>

## 체크 리스트

- [x] 리뷰어 설정
- [x] Assignee 설정
- [x] Label 설정
- [x] 제목 양식 맞췄나요? (ex. #0 Feat: 기능 추가)
- [x] 변경 사항에 대한 테스트