### PR TITLE
Feat #115 멤버 조회

### DIFF
--- a/src/main/java/leets/weeth/domain/user/application/mapper/CardinalMapper.java
+++ b/src/main/java/leets/weeth/domain/user/application/mapper/CardinalMapper.java
@@ -19,5 +19,5 @@ public interface CardinalMapper {
 
     CardinalResponse to(Cardinal cardinal);
 
-    UserCardinalDto toUserCardinalDto(User user, List<UserCardinal> userCardinals);
+    UserCardinalDto toUserCardinalDto(User user, List<UserCardinal> cardinals);
 }

--- a/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCase.java
+++ b/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCase.java
@@ -25,7 +25,7 @@ public interface UserUseCase {
 
     UserResponseDto.Response find(Long userId);
 
-    Slice<SummaryResponse> findAllUser(int pageNumber, int pageSize);
+    Slice<SummaryResponse> findAllUser(int pageNumber, int pageSize, Integer cardinal);
 
     UserResponseDto.UserResponse findUserDetails(Long userId);
 

--- a/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCase.java
+++ b/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCase.java
@@ -6,11 +6,7 @@ import leets.weeth.global.auth.jwt.application.dto.JwtDto;
 import org.springframework.data.domain.Slice;
 
 import java.util.List;
-import java.util.Map;
 
-import static leets.weeth.domain.user.application.dto.request.UserRequestDto.Register;
-import static leets.weeth.domain.user.application.dto.request.UserRequestDto.SignUp;
-import static leets.weeth.domain.user.application.dto.response.UserResponseDto.SocialLoginResponse;
 import static leets.weeth.domain.user.application.dto.request.UserRequestDto.*;
 import static leets.weeth.domain.user.application.dto.response.UserResponseDto.*;
 
@@ -38,5 +34,7 @@ public interface UserUseCase {
     JwtDto refresh(String refreshToken);
 
     UserResponseDto.UserInfo findUserInfo(Long userId);
+
+    List<SummaryResponse> searchUser(String keyword);
 
 }

--- a/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCaseImpl.java
@@ -100,10 +100,18 @@ public class UserUseCaseImpl implements UserUseCase {
     }
 
     @Override
-    public Slice<UserResponseDto.SummaryResponse> findAllUser(int pageNumber, int pageSize) {
+    public Slice<UserResponseDto.SummaryResponse> findAllUser(int pageNumber, int pageSize, Integer cardinal) {
 
         Pageable pageable = PageRequest.of(pageNumber, pageSize);
-        Slice<User> users = userGetService.findAll(pageable);
+        Slice<User> users;
+
+        if (cardinal == null) {
+            users = userGetService.findAll(pageable);
+
+        } else {
+            Cardinal inputCardinal = cardinalGetService.find(cardinal);
+            users = userGetService.findAll(pageable, inputCardinal);
+        }
 
         List<UserCardinal> allUserCardinals = userCardinalGetService.findAll(users.getContent());
 

--- a/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCaseImpl.java
@@ -1,7 +1,6 @@
 package leets.weeth.domain.user.application.usecase;
 
 import leets.weeth.domain.user.application.dto.response.UserCardinalDto;
-import leets.weeth.domain.user.application.dto.response.UserResponseDto;
 import leets.weeth.domain.user.application.exception.PasswordMismatchException;
 import leets.weeth.domain.user.application.exception.StudentIdExistsException;
 import leets.weeth.domain.user.application.exception.TelExistsException;
@@ -33,8 +32,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static leets.weeth.domain.user.application.dto.request.UserRequestDto.*;
-import static leets.weeth.domain.user.application.dto.response.UserResponseDto.SocialAuthResponse;
-import static leets.weeth.domain.user.application.dto.response.UserResponseDto.SocialLoginResponse;
+import static leets.weeth.domain.user.application.dto.response.UserResponseDto.*;
 
 @Slf4j
 @Service
@@ -100,7 +98,7 @@ public class UserUseCaseImpl implements UserUseCase {
     }
 
     @Override
-    public Slice<UserResponseDto.SummaryResponse> findAllUser(int pageNumber, int pageSize, Integer cardinal) {
+    public Slice<SummaryResponse> findAllUser(int pageNumber, int pageSize, Integer cardinal) {
 
         Pageable pageable = PageRequest.of(pageNumber, pageSize);
         Slice<User> users;
@@ -126,14 +124,14 @@ public class UserUseCaseImpl implements UserUseCase {
     }
 
     @Override
-    public UserResponseDto.UserResponse findUserDetails(Long userId) {
+    public UserResponse findUserDetails(Long userId) {
         UserCardinalDto dto = getUserCardinalDto(userId);
 
         return mapper.toUserResponse(dto.user(), dto.cardinals());
     }
 
     @Override
-    public UserResponseDto.Response find(Long userId) {
+    public Response find(Long userId) {
         UserCardinalDto dto = getUserCardinalDto(userId);
 
         return mapper.to(dto.user(), dto.cardinals());
@@ -186,10 +184,22 @@ public class UserUseCaseImpl implements UserUseCase {
     }
 
     @Override
-    public UserResponseDto.UserInfo findUserInfo(Long userId) {
+    public UserInfo findUserInfo(Long userId) {
         UserCardinalDto dto = getUserCardinalDto(userId);
 
         return mapper.toUserInfoDto(dto.user(), dto.cardinals());
+    }
+
+    @Override
+    public List<SummaryResponse> searchUser(String keyword) {
+        List<User> users = userGetService.search(keyword);
+
+        return users.stream()
+                .map(user -> {
+                    List<UserCardinal> userCardinals = userCardinalGetService.getUserCardinals(user);
+                    return mapper.toSummaryResponse(user, userCardinals);
+                })
+                .toList();
     }
 
     private long getKakaoId(Login dto) {

--- a/src/main/java/leets/weeth/domain/user/domain/repository/UserRepository.java
+++ b/src/main/java/leets/weeth/domain/user/domain/repository/UserRepository.java
@@ -18,6 +18,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByKakaoId(long kakaoId);
 
+    List<User>findAllByNameContainingAndStatus(String name, Status status);
+
     boolean existsByEmail(String email);
 
     boolean existsByStudentId(String studentId);

--- a/src/main/java/leets/weeth/domain/user/domain/repository/UserRepository.java
+++ b/src/main/java/leets/weeth/domain/user/domain/repository/UserRepository.java
@@ -39,17 +39,22 @@ public interface UserRepository extends JpaRepository<User, Long> {
     todo 차후 리팩토링
      */
     @Query("""
-                SELECT u FROM User u
-                JOIN UserCardinal uc ON uc.user.id = u.id
-                JOIN Cardinal c ON c.id = uc.cardinal.id
+                SELECT u
+                FROM User u
+                JOIN UserCardinal uc ON u.id = uc.user.id
+                JOIN uc.cardinal c
                 WHERE u.status = :status
-                AND c.cardinalNumber = (
-                    SELECT MAX(subC.cardinalNumber)
-                    FROM Cardinal subC
-                    JOIN UserCardinal subUc ON subUc.cardinal.id = subC.id
-                    WHERE subUc.user.id = u.id
-                )
-                ORDER BY u.name ASC
+                GROUP BY u.id
+                ORDER BY MAX(c.cardinalNumber) DESC, u.name ASC
             """)
     Slice<User> findAllByStatusOrderedByCardinalAndName(@Param("status") Status status, Pageable pageable);
+
+    @Query("""
+                SELECT u FROM User u
+                JOIN UserCardinal uc ON uc.user.id = u.id
+                WHERE u.status = :status
+                AND uc.cardinal = :cardinal
+                ORDER BY u.name ASC
+            """)
+    Slice<User> findAllByCardinalOrderByNameAsc(@Param("status") Status status, @Param("cardinal") Cardinal cardinal, Pageable pageable);
 }

--- a/src/main/java/leets/weeth/domain/user/domain/service/UserGetService.java
+++ b/src/main/java/leets/weeth/domain/user/domain/service/UserGetService.java
@@ -33,6 +33,10 @@ public class UserGetService {
         return userRepository.findByKakaoId(kakaoId);
     }
 
+    public List<User> search(String keyword) {
+        return userRepository.findAllByNameContainingAndStatus(keyword, Status.ACTIVE);
+    }
+
     public Boolean check(String email) {
         return !userRepository.existsByEmail(email);
     }

--- a/src/main/java/leets/weeth/domain/user/domain/service/UserGetService.java
+++ b/src/main/java/leets/weeth/domain/user/domain/service/UserGetService.java
@@ -53,6 +53,10 @@ public class UserGetService {
         return userRepository.findAllByStatusOrderedByCardinalAndName(Status.ACTIVE, pageable);
     }
 
+    public Slice<User> findAll(Pageable pageable, Cardinal cardinal) {
+        return userRepository.findAllByCardinalOrderByNameAsc(Status.ACTIVE, cardinal, pageable);
+    }
+
     public boolean validateStudentId(String studentId) {
         return userRepository.existsByStudentId(studentId);
     }

--- a/src/main/java/leets/weeth/domain/user/presentation/UserController.java
+++ b/src/main/java/leets/weeth/domain/user/presentation/UserController.java
@@ -18,7 +18,6 @@ import org.springframework.data.domain.Slice;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
-import java.util.Map;
 
 import static leets.weeth.domain.user.application.dto.request.UserRequestDto.*;
 import static leets.weeth.domain.user.application.dto.response.UserResponseDto.Response;
@@ -81,6 +80,12 @@ public class UserController {
                                                               @RequestParam("pageSize") int pageSize,
                                                               @RequestParam(required = false) Integer cardinal) {
         return CommonResponse.createSuccess(USER_FIND_ALL_SUCCESS.getMessage(), userUseCase.findAllUser(pageNumber, pageSize, cardinal));
+    }
+
+    @GetMapping("/search")
+    @Operation(summary = "동아리 멤버 검색")
+    public CommonResponse<List<SummaryResponse>> searchUser(@RequestParam String keyword) {
+        return CommonResponse.createSuccess(USER_FIND_BY_ID_SUCCESS.getMessage(), userUseCase.searchUser(keyword));
     }
 
     @GetMapping("/details")

--- a/src/main/java/leets/weeth/domain/user/presentation/UserController.java
+++ b/src/main/java/leets/weeth/domain/user/presentation/UserController.java
@@ -78,8 +78,9 @@ public class UserController {
     @GetMapping("/all")
     @Operation(summary = "동아리 멤버 전체 조회(전체/기수별)")
     public CommonResponse<Slice<SummaryResponse>> findAllUser(@RequestParam("pageNumber") int pageNumber,
-                                                              @RequestParam("pageSize") int pageSize) {
-        return CommonResponse.createSuccess(USER_FIND_ALL_SUCCESS.getMessage(), userUseCase.findAllUser(pageNumber, pageSize));
+                                                              @RequestParam("pageSize") int pageSize,
+                                                              @RequestParam(required = false) Integer cardinal) {
+        return CommonResponse.createSuccess(USER_FIND_ALL_SUCCESS.getMessage(), userUseCase.findAllUser(pageNumber, pageSize, cardinal));
     }
 
     @GetMapping("/details")


### PR DESCRIPTION
## PR 내용
- 기수별 멤버 조회와 멤버 검색 API를 구현했습니다.
- 기수 조회는 1개 api에서 cardinal의 유무로 전체 조회, 기수별 조회를 할 수 있도록 했습니다
- 검색 API는 jpa의 containing 메서드를 이용해 db like 연산으로 검색어에 포함된 데이터를 리스트로 반환하도록 했습니다
<br>

## PR 세부사항
- find나 info를 가져오는 경우 cardinals가 매핑이 안되는 문제를 발견해 변수명 통일로 수정해줬습니다
<br>

## 관련 스크린샷
<img width="1074" alt="image" src="https://github.com/user-attachments/assets/9ca94c28-3823-49c6-bcf0-85e1d92f4dd1" />

<img width="432" alt="image" src="https://github.com/user-attachments/assets/8769de44-8b43-4ff5-a578-c727c81a54ea" />

<br>

## 주의사항

<br>

## 체크 리스트

- [x] 리뷰어 설정
- [x] Assignee 설정
- [x] Label 설정
- [x] 제목 양식 맞췄나요? (ex. #0 Feat: 기능 추가)
- [x] 변경 사항에 대한 테스트