### PR TITLE
Refactor #116 일정 생성 로직 수정

### DIFF
--- a/src/main/java/leets/weeth/domain/attendance/application/dto/AttendanceDTO.java
+++ b/src/main/java/leets/weeth/domain/attendance/application/dto/AttendanceDTO.java
@@ -28,8 +28,6 @@ public class AttendanceDTO {
     public record Response(
             Long id,
             Status status,
-            Integer weekNumber,
-
             String title,
             LocalDateTime start,
             LocalDateTime end,
@@ -43,7 +41,6 @@ public class AttendanceDTO {
     public record AttendanceInfo(
             Long id,
             Status status,
-            Integer weekNumber,
             String name,
             String position,
             String department,

--- a/src/main/java/leets/weeth/domain/attendance/application/mapper/AttendanceMapper.java
+++ b/src/main/java/leets/weeth/domain/attendance/application/mapper/AttendanceMapper.java
@@ -27,7 +27,6 @@ public interface AttendanceMapper {
     AttendanceDTO.Detail toDetailDto(User user, List<AttendanceDTO.Response> attendances);
 
     @Mappings({
-            @Mapping(target = "weekNumber", source = "attendance.meeting.weekNumber"),
             @Mapping(target = "title", source = "attendance.meeting.title"),
             @Mapping(target = "start", source = "attendance.meeting.start"),
             @Mapping(target = "end", source = "attendance.meeting.end"),
@@ -37,7 +36,6 @@ public interface AttendanceMapper {
     @Mappings({
             @Mapping(target = "id", source = "attendance.id"),
             @Mapping(target = "status", source = "attendance.status"),
-            @Mapping(target = "weekNumber", source = "attendance.meeting.weekNumber"),
             @Mapping(target = "name", source = "attendance.user.name"),
             @Mapping(target = "position", source = "attendance.user.position"),
             @Mapping(target = "department", source = "attendance.user.department"),

--- a/src/main/java/leets/weeth/domain/schedule/application/dto/EventDTO.java
+++ b/src/main/java/leets/weeth/domain/schedule/application/dto/EventDTO.java
@@ -1,9 +1,5 @@
 package leets.weeth.domain.schedule.application.dto;
 
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-import org.springframework.format.annotation.DateTimeFormat;
-
 import java.time.LocalDateTime;
 
 public class EventDTO {
@@ -15,30 +11,10 @@ public class EventDTO {
             String location,
             String requiredItem,
             String name,
-            String memberCount,
             LocalDateTime start,
             LocalDateTime end,
             LocalDateTime createdAt,
             LocalDateTime modifiedAt
     ) {}
-
-    public record Save(
-            @NotBlank String title,
-            @NotBlank String content,
-            @NotBlank String location,
-            @NotBlank String requiredItem,
-            @NotNull String memberCount,
-            @NotNull @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime start,
-            @NotNull @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime end
-    ) {}
-
-    public record Update(
-            @NotBlank String title,
-            @NotBlank String content,
-            @NotBlank String location,
-            @NotBlank String requiredItem,
-            @NotNull String memberCount,
-            @NotNull @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime start,
-            @NotNull @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime end
-    ) {}
 }
+

--- a/src/main/java/leets/weeth/domain/schedule/application/dto/MeetingDTO.java
+++ b/src/main/java/leets/weeth/domain/schedule/application/dto/MeetingDTO.java
@@ -1,9 +1,12 @@
 package leets.weeth.domain.schedule.application.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import java.time.LocalDateTime;
 
 public class MeetingDTO {
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public record Response(
             Long id,
             String title,
@@ -11,6 +14,7 @@ public class MeetingDTO {
             String location,
             String requiredItem,
             String name,
+            Integer code,
             LocalDateTime start,
             LocalDateTime end,
             LocalDateTime createdAt,

--- a/src/main/java/leets/weeth/domain/schedule/application/dto/MeetingDTO.java
+++ b/src/main/java/leets/weeth/domain/schedule/application/dto/MeetingDTO.java
@@ -9,10 +9,10 @@ public class MeetingDTO {
             String title,
             String content,
             String location,
+            String requiredItem,
+            String name,
             LocalDateTime start,
             LocalDateTime end,
-            String name,
-            String requiredItem,
             LocalDateTime createdAt,
             LocalDateTime modifiedAt
     ) {}

--- a/src/main/java/leets/weeth/domain/schedule/application/dto/MeetingDTO.java
+++ b/src/main/java/leets/weeth/domain/schedule/application/dto/MeetingDTO.java
@@ -1,28 +1,8 @@
 package leets.weeth.domain.schedule.application.dto;
 
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-import org.springframework.format.annotation.DateTimeFormat;
-
 import java.time.LocalDateTime;
 
 public class MeetingDTO {
-
-    public record ResponseAll(
-            Long id,
-            String title,
-            String content,
-            String location,
-            LocalDateTime start,
-            LocalDateTime end,
-            Integer weekNumber,
-            Integer cardinal,
-            Integer code,
-            String name,
-            Integer memberCount,
-            LocalDateTime createdAt,
-            LocalDateTime modifiedAt
-    ) {}
 
     public record Response(
             Long id,
@@ -32,29 +12,9 @@ public class MeetingDTO {
             LocalDateTime start,
             LocalDateTime end,
             String name,
-            Integer memberCount,
             String requiredItem,
             LocalDateTime createdAt,
             LocalDateTime modifiedAt
     ) {}
 
-    public record Save(
-            @NotBlank String title,
-            @NotBlank String content,
-            @NotBlank String location,
-            @NotNull @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime start,
-            @NotNull @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime end,
-            @NotNull Integer weekNumber,
-            @NotNull Integer cardinal
-    ) {}
-
-    public record Update(
-            @NotBlank String title,
-            @NotBlank String content,
-            @NotBlank String location,
-            @NotNull @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime start,
-            @NotNull @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime end,
-            @NotNull Integer weekNumber,
-            @NotNull Integer cardinal
-    ) {}
 }

--- a/src/main/java/leets/weeth/domain/schedule/application/dto/ScheduleDTO.java
+++ b/src/main/java/leets/weeth/domain/schedule/application/dto/ScheduleDTO.java
@@ -1,6 +1,8 @@
 package leets.weeth.domain.schedule.application.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import leets.weeth.domain.schedule.domain.entity.enums.Type;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDateTime;
@@ -16,6 +18,27 @@ public class ScheduleDTO {
     ) {}
 
     public record Time(
+            @NotNull @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime start,
+            @NotNull @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime end
+    ) {}
+
+    public record Save(
+            @NotBlank String title,
+            @NotBlank String content,
+            @NotBlank String location,
+            @NotBlank String requiredItem,
+            @NotNull Type type,
+            @NotNull Integer cardinal,
+            @NotNull @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime start,
+            @NotNull @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime end
+    ) {}
+
+    public record Update(
+            @NotBlank String title,
+            @NotBlank String content,
+            @NotBlank String location,
+            @NotBlank String requiredItem,
+            @NotNull Type type,
             @NotNull @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime start,
             @NotNull @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime end
     ) {}

--- a/src/main/java/leets/weeth/domain/schedule/application/mapper/EventMapper.java
+++ b/src/main/java/leets/weeth/domain/schedule/application/mapper/EventMapper.java
@@ -1,5 +1,6 @@
 package leets.weeth.domain.schedule.application.mapper;
 
+import leets.weeth.domain.schedule.application.dto.ScheduleDTO;
 import leets.weeth.domain.schedule.domain.entity.Event;
 import leets.weeth.domain.user.domain.entity.User;
 import org.mapstruct.*;
@@ -16,8 +17,5 @@ public interface EventMapper {
             @Mapping(target = "id", ignore = true),
             @Mapping(target = "user", source = "user")
     })
-    Event from(Save dto, User user);
-
-    @Mapping(target = "user", source = "user")
-    Event update(Long id, Update dto, User user);
+    Event from(ScheduleDTO.Save dto, User user);
 }

--- a/src/main/java/leets/weeth/domain/schedule/application/mapper/MeetingMapper.java
+++ b/src/main/java/leets/weeth/domain/schedule/application/mapper/MeetingMapper.java
@@ -1,5 +1,6 @@
 package leets.weeth.domain.schedule.application.mapper;
 
+import leets.weeth.domain.schedule.application.dto.MeetingDTO;
 import leets.weeth.domain.schedule.application.dto.ScheduleDTO;
 import leets.weeth.domain.schedule.domain.entity.Meeting;
 import leets.weeth.domain.user.domain.entity.User;
@@ -12,9 +13,12 @@ import static leets.weeth.domain.schedule.application.dto.MeetingDTO.Response;
 @Mapper(componentModel = MappingConstants.ComponentModel.SPRING, unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface MeetingMapper {
 
-    @Mapping(target = "requiredItem", expression = "java(\"노트북\")")
     @Mapping(target = "name", source = "user.name")
+    @Mapping(target = "code", ignore = true)
     Response to(Meeting meeting);
+
+    @Mapping(target = "name", source = "user.name")
+    MeetingDTO.Response toAdminResponse(Meeting meeting);
 
     @Mappings({
             @Mapping(target = "id", ignore = true),

--- a/src/main/java/leets/weeth/domain/schedule/application/mapper/MeetingMapper.java
+++ b/src/main/java/leets/weeth/domain/schedule/application/mapper/MeetingMapper.java
@@ -1,35 +1,27 @@
 package leets.weeth.domain.schedule.application.mapper;
 
+import leets.weeth.domain.schedule.application.dto.ScheduleDTO;
 import leets.weeth.domain.schedule.domain.entity.Meeting;
 import leets.weeth.domain.user.domain.entity.User;
-import leets.weeth.domain.user.domain.entity.enums.Status;
 import org.mapstruct.*;
 
 import java.util.Random;
 
-import static leets.weeth.domain.schedule.application.dto.MeetingDTO.*;
+import static leets.weeth.domain.schedule.application.dto.MeetingDTO.Response;
 
 @Mapper(componentModel = MappingConstants.ComponentModel.SPRING, unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface MeetingMapper {
 
-//    @Mapping(target = "memberCount", expression = "java( getMemberCount(meeting) )")
     @Mapping(target = "requiredItem", expression = "java(\"노트북\")")
     @Mapping(target = "name", source = "user.name")
     Response to(Meeting meeting);
-
-//    @Mapping(target = "memberCount", expression = "java( getMemberCount(meeting) )")
-    @Mapping(target = "name", source = "user.name")
-    ResponseAll toAll(Meeting meeting);
 
     @Mappings({
             @Mapping(target = "id", ignore = true),
             @Mapping(target = "code", expression = "java( generateCode() )"),
             @Mapping(target = "user", source = "user")
     })
-    Meeting from(Save dto, User user);
-
-    @Mapping(target = "user", source = "user")
-    Meeting update(Long id, Update dto, User user);
+    Meeting from(ScheduleDTO.Save dto, User user);
 
     default Integer generateCode() {
         return new Random().nextInt(9000) + 1000;

--- a/src/main/java/leets/weeth/domain/schedule/application/usecase/EventUseCase.java
+++ b/src/main/java/leets/weeth/domain/schedule/application/usecase/EventUseCase.java
@@ -1,14 +1,16 @@
 package leets.weeth.domain.schedule.application.usecase;
 
+import leets.weeth.domain.schedule.application.dto.ScheduleDTO;
+
 import static leets.weeth.domain.schedule.application.dto.EventDTO.*;
 
 public interface EventUseCase {
 
     Response find(Long eventId);
 
-    void save(Save dto, Long userId);
+    void save(ScheduleDTO.Save dto, Long userId);
 
-    void update(Long eventId, Update dto, Long userId);
+    void update(Long eventId, ScheduleDTO.Update dto, Long userId);
 
     void delete(Long eventId);
 }

--- a/src/main/java/leets/weeth/domain/schedule/application/usecase/EventUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/schedule/application/usecase/EventUseCaseImpl.java
@@ -1,5 +1,6 @@
 package leets.weeth.domain.schedule.application.usecase;
 
+import leets.weeth.domain.schedule.application.dto.ScheduleDTO;
 import leets.weeth.domain.schedule.application.mapper.EventMapper;
 import leets.weeth.domain.schedule.domain.entity.Event;
 import leets.weeth.domain.schedule.domain.service.EventDeleteService;
@@ -7,12 +8,13 @@ import leets.weeth.domain.schedule.domain.service.EventGetService;
 import leets.weeth.domain.schedule.domain.service.EventSaveService;
 import leets.weeth.domain.schedule.domain.service.EventUpdateService;
 import leets.weeth.domain.user.domain.entity.User;
+import leets.weeth.domain.user.domain.service.CardinalGetService;
 import leets.weeth.domain.user.domain.service.UserGetService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import static leets.weeth.domain.schedule.application.dto.EventDTO.*;
+import static leets.weeth.domain.schedule.application.dto.EventDTO.Response;
 
 @Service
 @RequiredArgsConstructor
@@ -23,6 +25,7 @@ public class EventUseCaseImpl implements EventUseCase {
     private final EventSaveService eventSaveService;
     private final EventUpdateService eventUpdateService;
     private final EventDeleteService eventDeleteService;
+    private final CardinalGetService cardinalGetService;
     private final EventMapper mapper;
 
     @Override
@@ -32,14 +35,16 @@ public class EventUseCaseImpl implements EventUseCase {
 
     @Override
     @Transactional
-    public void save(Save dto, Long userId) {
+    public void save(ScheduleDTO.Save dto, Long userId) {
         User user = userGetService.find(userId);
+        cardinalGetService.find(dto.cardinal());
+
         eventSaveService.save(mapper.from(dto, user));
     }
 
     @Override
     @Transactional
-    public void update(Long eventId, Update dto, Long userId) {
+    public void update(Long eventId, ScheduleDTO.Update dto, Long userId) {
         User user = userGetService.find(userId);
         Event event = eventGetService.find(eventId);
         eventUpdateService.update(event, dto, user);

--- a/src/main/java/leets/weeth/domain/schedule/application/usecase/MeetingUseCase.java
+++ b/src/main/java/leets/weeth/domain/schedule/application/usecase/MeetingUseCase.java
@@ -6,7 +6,7 @@ import static leets.weeth.domain.schedule.application.dto.MeetingDTO.Response;
 
 public interface MeetingUseCase {
 
-    Response find(Long eventId);
+    Response find(Long userId, Long eventId);
 
     void save(ScheduleDTO.Save dto, Long userId);
 

--- a/src/main/java/leets/weeth/domain/schedule/application/usecase/MeetingUseCase.java
+++ b/src/main/java/leets/weeth/domain/schedule/application/usecase/MeetingUseCase.java
@@ -1,20 +1,16 @@
 package leets.weeth.domain.schedule.application.usecase;
 
-import java.util.List;
+import leets.weeth.domain.schedule.application.dto.ScheduleDTO;
 
-import static leets.weeth.domain.schedule.application.dto.MeetingDTO.*;
+import static leets.weeth.domain.schedule.application.dto.MeetingDTO.Response;
 
 public interface MeetingUseCase {
 
     Response find(Long eventId);
 
-    void save(Save dto, Long userId);
+    void save(ScheduleDTO.Save dto, Long userId);
 
-    void update(Update dto, Long userId, Long meetingId);
+    void update(ScheduleDTO.Update dto, Long userId, Long meetingId);
 
     void delete(Long meetingId);
-
-    List<ResponseAll> findAll(Integer cardinal);
-
-    List<ResponseAll> findAll();
 }

--- a/src/main/java/leets/weeth/domain/schedule/application/usecase/MeetingUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/schedule/application/usecase/MeetingUseCaseImpl.java
@@ -14,6 +14,7 @@ import leets.weeth.domain.schedule.domain.service.MeetingSaveService;
 import leets.weeth.domain.schedule.domain.service.MeetingUpdateService;
 import leets.weeth.domain.user.domain.entity.Cardinal;
 import leets.weeth.domain.user.domain.entity.User;
+import leets.weeth.domain.user.domain.entity.enums.Role;
 import leets.weeth.domain.user.domain.service.CardinalGetService;
 import leets.weeth.domain.user.domain.service.UserGetService;
 import lombok.RequiredArgsConstructor;
@@ -43,8 +44,15 @@ public class MeetingUseCaseImpl implements MeetingUseCase {
     private final CardinalGetService cardinalGetService;
 
     @Override
-    public Response find(Long meetingId) {
-        return mapper.to(meetingGetService.find(meetingId));
+    public Response find(Long userId, Long meetingId) {
+        User user = userGetService.find(userId);
+        Meeting meeting = meetingGetService.find(meetingId);
+
+        if (Role.ADMIN == user.getRole()) {
+            return mapper.toAdminResponse(meeting)  ;
+        }
+
+        return mapper.to(meeting);
     }
 
     @Override

--- a/src/main/java/leets/weeth/domain/schedule/application/usecase/MeetingUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/schedule/application/usecase/MeetingUseCaseImpl.java
@@ -5,6 +5,7 @@ import leets.weeth.domain.attendance.domain.service.AttendanceDeleteService;
 import leets.weeth.domain.attendance.domain.service.AttendanceGetService;
 import leets.weeth.domain.attendance.domain.service.AttendanceSaveService;
 import leets.weeth.domain.attendance.domain.service.AttendanceUpdateService;
+import leets.weeth.domain.schedule.application.dto.ScheduleDTO;
 import leets.weeth.domain.schedule.application.mapper.MeetingMapper;
 import leets.weeth.domain.schedule.domain.entity.Meeting;
 import leets.weeth.domain.schedule.domain.service.MeetingDeleteService;
@@ -14,7 +15,6 @@ import leets.weeth.domain.schedule.domain.service.MeetingUpdateService;
 import leets.weeth.domain.user.domain.entity.Cardinal;
 import leets.weeth.domain.user.domain.entity.User;
 import leets.weeth.domain.user.domain.service.CardinalGetService;
-import leets.weeth.domain.user.domain.service.UserCardinalGetService;
 import leets.weeth.domain.user.domain.service.UserGetService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,7 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
-import static leets.weeth.domain.schedule.application.dto.MeetingDTO.*;
+import static leets.weeth.domain.schedule.application.dto.MeetingDTO.Response;
 
 @Slf4j
 @Service
@@ -49,7 +49,7 @@ public class MeetingUseCaseImpl implements MeetingUseCase {
 
     @Override
     @Transactional
-    public void save(Save dto, Long userId) {
+    public void save(ScheduleDTO.Save dto, Long userId) {
         User user = userGetService.find(userId);
         Cardinal cardinal = cardinalGetService.find(dto.cardinal());
 
@@ -63,7 +63,7 @@ public class MeetingUseCaseImpl implements MeetingUseCase {
 
     @Override
     @Transactional
-    public void update(Update dto, Long userId, Long meetingId) {
+    public void update(ScheduleDTO.Update dto, Long userId, Long meetingId) {
         Meeting meeting = meetingGetService.find(meetingId);
         User user = userGetService.find(userId);
         meetingUpdateService.update(dto, user, meeting);
@@ -79,19 +79,5 @@ public class MeetingUseCaseImpl implements MeetingUseCase {
 
         attendanceDeleteService.deleteAll(meeting);
         meetingDeleteService.delete(meeting);
-    }
-
-    @Override
-    public List<ResponseAll> findAll(Integer cardinal) {
-        return meetingGetService.find(cardinal).stream()
-                .map(mapper::toAll)
-                .toList();
-    }
-
-    @Override
-    public List<ResponseAll> findAll() {
-        return meetingGetService.findAll().stream()
-                .map(mapper::toAll)
-                .toList();
     }
 }

--- a/src/main/java/leets/weeth/domain/schedule/application/usecase/ScheduleUseCase.java
+++ b/src/main/java/leets/weeth/domain/schedule/application/usecase/ScheduleUseCase.java
@@ -10,6 +10,6 @@ public interface ScheduleUseCase {
 
     List<Response> findByMonthly(LocalDateTime start, LocalDateTime end);
 
-    Map<Integer, List<Response>> findByYearly(LocalDateTime start, LocalDateTime end);
+    Map<Integer, List<Response>> findByYearly(Integer year, Integer semester);
 
 }

--- a/src/main/java/leets/weeth/domain/schedule/application/usecase/ScheduleUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/schedule/application/usecase/ScheduleUseCaseImpl.java
@@ -2,6 +2,8 @@ package leets.weeth.domain.schedule.application.usecase;
 
 import leets.weeth.domain.schedule.domain.service.EventGetService;
 import leets.weeth.domain.schedule.domain.service.MeetingGetService;
+import leets.weeth.domain.user.domain.entity.Cardinal;
+import leets.weeth.domain.user.domain.service.CardinalGetService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -19,6 +21,7 @@ public class ScheduleUseCaseImpl implements ScheduleUseCase {
 
     private final EventGetService eventGetService;
     private final MeetingGetService meetingGetService;
+    private final CardinalGetService cardinalGetService;
 
     @Override
     public List<Response> findByMonthly(LocalDateTime start, LocalDateTime end) {
@@ -32,9 +35,11 @@ public class ScheduleUseCaseImpl implements ScheduleUseCase {
     }
 
     @Override
-    public Map<Integer, List<Response>> findByYearly(LocalDateTime start, LocalDateTime end) {
-        List<Response> events = eventGetService.find(start, end);
-        List<Response> meetings = meetingGetService.find(start, end);
+    public Map<Integer, List<Response>> findByYearly(Integer year, Integer semester) {
+        Cardinal cardinal = cardinalGetService.find(year, semester);
+
+        List<Response> events = eventGetService.find(cardinal.getCardinalNumber());
+        List<Response> meetings = meetingGetService.findByCardinal(cardinal.getCardinalNumber());
 
         return Stream.of(events, meetings)
                 .flatMap(Collection::stream)    // 병합

--- a/src/main/java/leets/weeth/domain/schedule/domain/entity/Event.java
+++ b/src/main/java/leets/weeth/domain/schedule/domain/entity/Event.java
@@ -1,29 +1,20 @@
 package leets.weeth.domain.schedule.domain.entity;
 
 import jakarta.persistence.Entity;
+import leets.weeth.domain.schedule.application.dto.ScheduleDTO;
 import leets.weeth.domain.user.domain.entity.User;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
-import static leets.weeth.domain.schedule.application.dto.EventDTO.Update;
-
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 @SuperBuilder
 public class Event extends Schedule {
 
-    private String requiredItem;
-
-    private String memberCount;
-
-    public void update(Update dto, User user) {
+    public void update(ScheduleDTO.Update dto, User user) {
         this.updateUpperClass(dto, user);
-        this.memberCount = dto.memberCount();
-        this.requiredItem = dto.requiredItem();
     }
 }

--- a/src/main/java/leets/weeth/domain/schedule/domain/entity/Meeting.java
+++ b/src/main/java/leets/weeth/domain/schedule/domain/entity/Meeting.java
@@ -1,7 +1,7 @@
 package leets.weeth.domain.schedule.domain.entity;
 
 import jakarta.persistence.Entity;
-import leets.weeth.domain.schedule.application.dto.MeetingDTO;
+import leets.weeth.domain.schedule.application.dto.ScheduleDTO;
 import leets.weeth.domain.user.domain.entity.User;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -16,17 +16,10 @@ import lombok.experimental.SuperBuilder;
 @SuperBuilder
 public class Meeting extends Schedule {
 
-    private Integer weekNumber;
-
-    private Integer cardinal;
-
     private Integer code;
 
-    public void update(MeetingDTO.Update dto, User user) {
+    public void update(ScheduleDTO.Update dto, User user) {
         this.updateUpperClass(dto, user);
-        this.weekNumber = dto.weekNumber();
-        this.cardinal = dto.cardinal();
     }
-
 
 }

--- a/src/main/java/leets/weeth/domain/schedule/domain/entity/Schedule.java
+++ b/src/main/java/leets/weeth/domain/schedule/domain/entity/Schedule.java
@@ -1,8 +1,7 @@
 package leets.weeth.domain.schedule.domain.entity;
 
 import jakarta.persistence.*;
-import leets.weeth.domain.schedule.application.dto.EventDTO;
-import leets.weeth.domain.schedule.application.dto.MeetingDTO;
+import leets.weeth.domain.schedule.application.dto.ScheduleDTO;
 import leets.weeth.domain.user.domain.entity.User;
 import leets.weeth.global.common.entity.BaseEntity;
 import lombok.AccessLevel;
@@ -32,6 +31,10 @@ public class Schedule extends BaseEntity {
 
     private String location;
 
+    private Integer cardinal;
+
+    private String requiredItem;
+
     private LocalDateTime start;
 
     private LocalDateTime end;
@@ -40,19 +43,11 @@ public class Schedule extends BaseEntity {
     @JoinColumn(name = "user_id")
     private User user;
 
-    public void updateUpperClass(EventDTO.Update dto, User user) {
+    public void updateUpperClass(ScheduleDTO.Update dto, User user) {
         this.title = dto.title();
         this.content = dto.content();
         this.location = dto.location();
-        this.start = dto.start();
-        this.end = dto.end();
-        this.user = user;
-    }
-
-    public void updateUpperClass(MeetingDTO.Update dto, User user) {
-        this.title = dto.title();
-        this.content = dto.content();
-        this.location = dto.location();
+        this.requiredItem = dto.requiredItem();
         this.start = dto.start();
         this.end = dto.end();
         this.user = user;

--- a/src/main/java/leets/weeth/domain/schedule/domain/entity/enums/Type.java
+++ b/src/main/java/leets/weeth/domain/schedule/domain/entity/enums/Type.java
@@ -1,0 +1,5 @@
+package leets.weeth.domain.schedule.domain.entity.enums;
+
+public enum Type {
+    EVENT, MEETING
+}

--- a/src/main/java/leets/weeth/domain/schedule/domain/repository/EventRepository.java
+++ b/src/main/java/leets/weeth/domain/schedule/domain/repository/EventRepository.java
@@ -9,4 +9,6 @@ import java.util.List;
 public interface EventRepository extends JpaRepository<Event, Long> {
 
     List<Event> findByStartLessThanEqualAndEndGreaterThanEqualOrderByStartAsc(LocalDateTime end, LocalDateTime start);
+
+    List<Event> findAllByCardinal(int cardinal);
 }

--- a/src/main/java/leets/weeth/domain/schedule/domain/repository/MeetingRepository.java
+++ b/src/main/java/leets/weeth/domain/schedule/domain/repository/MeetingRepository.java
@@ -11,4 +11,6 @@ public interface MeetingRepository extends JpaRepository<Meeting, Long> {
     List<Meeting> findByStartLessThanEqualAndEndGreaterThanEqualOrderByStartAsc(LocalDateTime start, LocalDateTime end);
 
     List<Meeting> findAllByCardinalOrderByStartAsc(int cardinal);
+
+    List<Meeting> findAllByCardinal(int cardinal);
 }

--- a/src/main/java/leets/weeth/domain/schedule/domain/service/EventGetService.java
+++ b/src/main/java/leets/weeth/domain/schedule/domain/service/EventGetService.java
@@ -28,4 +28,10 @@ public class EventGetService {
                 .map(event -> mapper.toScheduleDTO(event, false))
                 .toList();
     }
+
+    public List<ScheduleDTO.Response> find(Integer cardinal) {
+        return eventRepository.findAllByCardinal(cardinal).stream()
+                .map(event -> mapper.toScheduleDTO(event, false))
+                .toList();
+    }
 }

--- a/src/main/java/leets/weeth/domain/schedule/domain/service/EventUpdateService.java
+++ b/src/main/java/leets/weeth/domain/schedule/domain/service/EventUpdateService.java
@@ -1,19 +1,18 @@
 package leets.weeth.domain.schedule.domain.service;
 
 import jakarta.transaction.Transactional;
+import leets.weeth.domain.schedule.application.dto.ScheduleDTO;
 import leets.weeth.domain.schedule.domain.entity.Event;
 import leets.weeth.domain.user.domain.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-
-import static leets.weeth.domain.schedule.application.dto.EventDTO.Update;
 
 @Service
 @Transactional
 @RequiredArgsConstructor
 public class EventUpdateService {
 
-    public void update(Event event, Update dto, User user) {
+    public void update(Event event, ScheduleDTO.Update dto, User user) {
         event.update(dto, user);
     }
 }

--- a/src/main/java/leets/weeth/domain/schedule/domain/service/MeetingGetService.java
+++ b/src/main/java/leets/weeth/domain/schedule/domain/service/MeetingGetService.java
@@ -36,4 +36,10 @@ public class MeetingGetService {
     public List<Meeting> findAll() {
         return meetingRepository.findAll();
     }
+
+    public List<ScheduleDTO.Response> findByCardinal(Integer cardinal) {
+        return meetingRepository.findAllByCardinal(cardinal).stream()
+                .map(meeting -> mapper.toScheduleDTO(meeting, true))
+                .toList();
+    }
 }

--- a/src/main/java/leets/weeth/domain/schedule/domain/service/MeetingUpdateService.java
+++ b/src/main/java/leets/weeth/domain/schedule/domain/service/MeetingUpdateService.java
@@ -1,19 +1,14 @@
 package leets.weeth.domain.schedule.domain.service;
 
-import jakarta.transaction.Transactional;
+import leets.weeth.domain.schedule.application.dto.ScheduleDTO;
 import leets.weeth.domain.schedule.domain.entity.Meeting;
 import leets.weeth.domain.user.domain.entity.User;
-import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import static leets.weeth.domain.schedule.application.dto.MeetingDTO.Update;
-
 @Service
-@Transactional
-@RequiredArgsConstructor
 public class MeetingUpdateService {
 
-    public void update(Update dto, User user, Meeting meeting) {
+    public void update(ScheduleDTO.Update dto, User user, Meeting meeting) {
         meeting.update(dto, user);
     }
 }

--- a/src/main/java/leets/weeth/domain/schedule/presentation/EventAdminController.java
+++ b/src/main/java/leets/weeth/domain/schedule/presentation/EventAdminController.java
@@ -4,17 +4,16 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import leets.weeth.domain.schedule.application.dto.EventDTO;
+import leets.weeth.domain.schedule.application.dto.ScheduleDTO;
 import leets.weeth.domain.schedule.application.usecase.EventUseCase;
+import leets.weeth.domain.schedule.application.usecase.MeetingUseCase;
+import leets.weeth.domain.schedule.domain.entity.enums.Type;
 import leets.weeth.global.auth.annotation.CurrentUser;
 import leets.weeth.global.common.response.CommonResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
-import static leets.weeth.domain.schedule.application.dto.EventDTO.Save;
-import static leets.weeth.domain.schedule.presentation.ResponseMessage.EVENT_DELETE_SUCCESS;
-import static leets.weeth.domain.schedule.presentation.ResponseMessage.EVENT_SAVE_SUCCESS;
-import static leets.weeth.domain.schedule.presentation.ResponseMessage.EVENT_UPDATE_SUCCESS;
+import static leets.weeth.domain.schedule.presentation.ResponseMessage.*;
 
 @Tag(name = "EVENT ADMIN", description = "[ADMIN] 일정 어드민 API")
 @RestController
@@ -23,27 +22,39 @@ import static leets.weeth.domain.schedule.presentation.ResponseMessage.EVENT_UPD
 public class EventAdminController {
 
     private final EventUseCase eventUseCase;
+    private final MeetingUseCase meetingUseCase;
 
     @PostMapping
-    @Operation(summary="일정 생성")
-    public CommonResponse<Void> save(@Valid @RequestBody Save dto,
+    @Operation(summary = "일정/정기모임 생성")
+    public CommonResponse<Void> save(@Valid @RequestBody ScheduleDTO.Save dto,
                                      @Parameter(hidden = true) @CurrentUser Long userId) {
-        eventUseCase.save(dto, userId);
+        if (dto.type() == Type.EVENT) {
+            eventUseCase.save(dto, userId);
+        } else {
+            meetingUseCase.save(dto, userId);
+        }
+
         return CommonResponse.createSuccess(EVENT_SAVE_SUCCESS.getMessage());
     }
 
     @PatchMapping("/{eventId}")
-    @Operation(summary="일정 수정")
-    public CommonResponse<Void> update(@PathVariable Long eventId, @Valid @RequestBody EventDTO.Update dto,
+    @Operation(summary = "일정 수정 (type은 변경할 수 없게 해주세요.)")
+    public CommonResponse<Void> update(@PathVariable Long eventId, @Valid @RequestBody ScheduleDTO.Update dto,
                                        @Parameter(hidden = true) @CurrentUser Long userId) {
-        eventUseCase.update(eventId, dto, userId);
+        if (dto.type() == Type.EVENT) {
+            eventUseCase.update(eventId, dto, userId);
+        } else {
+            meetingUseCase.update(dto, userId, eventId);
+        }
+
         return CommonResponse.createSuccess(EVENT_UPDATE_SUCCESS.getMessage());
     }
 
     @DeleteMapping("/{eventId}")
-    @Operation(summary="일정 삭제")
+    @Operation(summary = "일정 삭제")
     public CommonResponse<Void> delete(@PathVariable Long eventId) {
         eventUseCase.delete(eventId);
+
         return CommonResponse.createSuccess(EVENT_DELETE_SUCCESS.getMessage());
     }
 }

--- a/src/main/java/leets/weeth/domain/schedule/presentation/MeetingAdminController.java
+++ b/src/main/java/leets/weeth/domain/schedule/presentation/MeetingAdminController.java
@@ -1,25 +1,16 @@
 package leets.weeth.domain.schedule.presentation;
 
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
-import leets.weeth.domain.schedule.application.dto.MeetingDTO;
 import leets.weeth.domain.schedule.application.usecase.MeetingUseCase;
-import leets.weeth.global.auth.annotation.CurrentUser;
 import leets.weeth.global.common.response.CommonResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
-
-import static leets.weeth.domain.schedule.application.dto.MeetingDTO.Save;
-import static leets.weeth.domain.schedule.application.dto.MeetingDTO.Update;
-import static leets.weeth.domain.schedule.presentation.ResponseMessage.MEETING_ALL_FIND_SUCCESS;
-import static leets.weeth.domain.schedule.presentation.ResponseMessage.MEETING_CARDINAL_FIND_SUCCESS;
 import static leets.weeth.domain.schedule.presentation.ResponseMessage.MEETING_DELETE_SUCCESS;
-import static leets.weeth.domain.schedule.presentation.ResponseMessage.MEETING_SAVE_SUCCESS;
-import static leets.weeth.domain.schedule.presentation.ResponseMessage.MEETING_UPDATE_SUCCESS;
 
 @Tag(name = "MEETING ADMIN", description = "[ADMIN] 정기모임 어드민 API")
 @RestController
@@ -29,35 +20,8 @@ public class MeetingAdminController {
 
     private final MeetingUseCase meetingUseCase;
 
-    @PostMapping
-    @Operation(summary="정기모임 생성")
-    public CommonResponse<Void> save(@RequestBody @Valid Save dto, @Parameter(hidden = true) @CurrentUser Long userId) {
-        meetingUseCase.save(dto, userId);
-        return CommonResponse.createSuccess(MEETING_SAVE_SUCCESS.getMessage());
-    }
-
-    @PostMapping("/{cardinal}")
-    @Operation(summary="특정 기수 정기모임 조회")
-    public CommonResponse<List<MeetingDTO.ResponseAll>> findAll(@PathVariable Integer cardinal) {
-        return CommonResponse.createSuccess(MEETING_CARDINAL_FIND_SUCCESS.getMessage(),meetingUseCase.findAll(cardinal));
-
-    }
-
-    @GetMapping
-    @Operation(summary="정기모임 전체 조회")
-    public CommonResponse<List<MeetingDTO.ResponseAll>> findAll() {
-        return CommonResponse.createSuccess(MEETING_ALL_FIND_SUCCESS.getMessage(),meetingUseCase.findAll());
-    }
-
-    @PatchMapping("/{meetingId}")
-    @Operation(summary="정기모임 수정")
-    public CommonResponse<Void> update(@RequestBody @Valid Update dto, @Parameter(hidden = true) @CurrentUser Long userId, @PathVariable Long meetingId) {
-        meetingUseCase.update(dto, userId, meetingId);
-        return CommonResponse.createSuccess(MEETING_UPDATE_SUCCESS.getMessage());
-    }
-
     @DeleteMapping("/{meetingId}")
-    @Operation(summary="정기모임 삭제")
+    @Operation(summary = "정기모임 삭제")
     public CommonResponse<Void> delete(@PathVariable Long meetingId) {
         meetingUseCase.delete(meetingId);
         return CommonResponse.createSuccess(MEETING_DELETE_SUCCESS.getMessage());

--- a/src/main/java/leets/weeth/domain/schedule/presentation/MeetingController.java
+++ b/src/main/java/leets/weeth/domain/schedule/presentation/MeetingController.java
@@ -1,7 +1,5 @@
 package leets.weeth.domain.schedule.presentation;
 
-import static leets.weeth.domain.schedule.presentation.ResponseMessage.MEETING_FIND_SUCCESS;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import leets.weeth.domain.schedule.application.dto.MeetingDTO;
@@ -13,6 +11,8 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import static leets.weeth.domain.schedule.presentation.ResponseMessage.MEETING_FIND_SUCCESS;
+
 @Tag(name = "MEETING", description = "정기모임 API")
 @RestController
 @RequiredArgsConstructor
@@ -22,7 +22,7 @@ public class MeetingController {
     private final MeetingUseCase meetingUseCase;
 
     @GetMapping("/{meetingId}")
-    @Operation(summary="일정 상세 조회")
+    @Operation(summary="정기모임 상세 조회")
     public CommonResponse<MeetingDTO.Response> find(@PathVariable Long meetingId) {
         return CommonResponse.createSuccess(MEETING_FIND_SUCCESS.getMessage(),meetingUseCase.find(meetingId));
     }

--- a/src/main/java/leets/weeth/domain/schedule/presentation/MeetingController.java
+++ b/src/main/java/leets/weeth/domain/schedule/presentation/MeetingController.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import leets.weeth.domain.schedule.application.dto.MeetingDTO;
 import leets.weeth.domain.schedule.application.usecase.MeetingUseCase;
+import leets.weeth.global.auth.annotation.CurrentUser;
 import leets.weeth.global.common.response.CommonResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -23,7 +24,8 @@ public class MeetingController {
 
     @GetMapping("/{meetingId}")
     @Operation(summary="정기모임 상세 조회")
-    public CommonResponse<MeetingDTO.Response> find(@PathVariable Long meetingId) {
-        return CommonResponse.createSuccess(MEETING_FIND_SUCCESS.getMessage(),meetingUseCase.find(meetingId));
+    public CommonResponse<MeetingDTO.Response> find(@CurrentUser Long userId,
+                                                    @PathVariable Long meetingId) {
+        return CommonResponse.createSuccess(MEETING_FIND_SUCCESS.getMessage(),meetingUseCase.find(userId, meetingId));
     }
 }

--- a/src/main/java/leets/weeth/domain/schedule/presentation/ResponseMessage.java
+++ b/src/main/java/leets/weeth/domain/schedule/presentation/ResponseMessage.java
@@ -7,8 +7,8 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ResponseMessage {
     // EventAdminController 관련
-    EVENT_SAVE_SUCCESS("일정이 성공적으로 생성되었습니다."),
-    EVENT_UPDATE_SUCCESS("일정이 성공적으로 수정되었습니다."),
+    EVENT_SAVE_SUCCESS("일정/정기모임이 성공적으로 생성되었습니다."),
+    EVENT_UPDATE_SUCCESS("일정/정기모임이 성공적으로 수정되었습니다."),
     EVENT_DELETE_SUCCESS("일정이 성공적으로 삭제되었습니다."),
     // EventController 관련
     EVENT_FIND_SUCCESS("일정이 성공적으로 조회되었습니다."),

--- a/src/main/java/leets/weeth/domain/schedule/presentation/ScheduleController.java
+++ b/src/main/java/leets/weeth/domain/schedule/presentation/ScheduleController.java
@@ -36,8 +36,8 @@ public class ScheduleController {
 
     @GetMapping("/yearly")
     @Operation(summary="연도별 일정 조회")
-    public CommonResponse<Map<Integer, List<Response>>> findByYearly(@RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime start,
-                                                                     @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime end) {
-        return CommonResponse.createSuccess(SCHEDULE_YEARLY_FIND_SUCCESS.getMessage(),scheduleUseCase.findByYearly(start, end));
+    public CommonResponse<Map<Integer, List<Response>>> findByYearly(@RequestParam Integer year,
+                                                                     @RequestParam Integer semester) {
+        return CommonResponse.createSuccess(SCHEDULE_YEARLY_FIND_SUCCESS.getMessage(),scheduleUseCase.findByYearly(year, semester));
     }
 }

--- a/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCaseImpl.java
@@ -217,6 +217,7 @@ public class UserUseCaseImpl implements UserUseCase {
     private UserCardinalDto getUserCardinalDto(Long userId) {
         User user = userGetService.find(userId);
         List<UserCardinal> userCardinals = userCardinalGetService.getUserCardinals(user);
+        log.info("cardinal{}", userCardinals.get(0).getCardinal().getCardinalNumber());
 
         return cardinalMapper.toUserCardinalDto(user, userCardinals);
     }

--- a/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCaseImpl.java
@@ -217,7 +217,6 @@ public class UserUseCaseImpl implements UserUseCase {
     private UserCardinalDto getUserCardinalDto(Long userId) {
         User user = userGetService.find(userId);
         List<UserCardinal> userCardinals = userCardinalGetService.getUserCardinals(user);
-        log.info("cardinal{}", userCardinals.get(0).getCardinal().getCardinalNumber());
 
         return cardinalMapper.toUserCardinalDto(user, userCardinals);
     }

--- a/src/main/java/leets/weeth/domain/user/domain/repository/CardinalRepository.java
+++ b/src/main/java/leets/weeth/domain/user/domain/repository/CardinalRepository.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 public interface CardinalRepository extends JpaRepository<Cardinal, Long> {
 
     Optional<Cardinal> findByCardinalNumber(Integer cardinal);
+
+    Optional<Cardinal> findByYearAndSemester(Integer year, Integer semester);
 }

--- a/src/main/java/leets/weeth/domain/user/domain/service/CardinalGetService.java
+++ b/src/main/java/leets/weeth/domain/user/domain/service/CardinalGetService.java
@@ -20,6 +20,11 @@ public class CardinalGetService {
                 .orElseThrow(CardinalNotFoundException::new);
     }
 
+    public Cardinal find(Integer year, Integer semester) {
+        return cardinalRepository.findByYearAndSemester(year, semester)
+                .orElseThrow(CardinalNotFoundException::new);
+    }
+
     public List<Cardinal> findAll() {
         return cardinalRepository.findAll();
     }


### PR DESCRIPTION
## PR 내용
- 정기모임 생성을 weeth 서비스 페이지로 이전함에 따라 api를 수정했습니다.
- 공통된 변수를 Schedule 객체로 옮겼고, meeting에서만 쓰이는 code를 meeting에 유지했습니다.
- 연도 일정을 볼 때 요구사항에 맞게 년도-학기를 받아서 저장된 기수에 맞는 데이터를 반환하도록 수정했습니다
<br>

## PR 세부사항
- 단일 API에서 type을 체크해 일정/정기모임을 생성 및 수정할 수 있게 api를 수정했습니다
- 삭제는 개별 api로 받도록 했습니다
- Event와 Meeting 생성시 dto가 완전히 동일하기 때문에 ScheduleDto를 사용해 한 번에 관리할 수 있도록 수정했습니다.
- 사용하지 않는 메서드와 dto는 제거했습니다.
- weekNumber, memberCount 등 사라진 변수들에 대한 dto들도 함께 수정했습니다
<br>

## 관련 스크린샷
<img width="468" alt="image" src="https://github.com/user-attachments/assets/071372e9-ad87-46c5-9899-30cfa3f70412" />

<img width="421" alt="image" src="https://github.com/user-attachments/assets/2541f86d-1139-49fa-9315-c6eb9dcbc186" />

<br>

## 주의사항
- 정기모임 생성시 출석 객체 생성, 삭제 테스트는 완료 됐습니다
- 하지만 제가 빼먹은 케이스가 있을 수 있으니 함께 유심히 봐주시면 감사하겠습니다.
<br>

## 체크 리스트

- [x] 리뷰어 설정
- [x] Assignee 설정
- [x] Label 설정
- [x] 제목 양식 맞췄나요? (ex. #0 Feat: 기능 추가)
- [x] 변경 사항에 대한 테스트