### PR TITLE
Refactor #119 댓글 중복 조회 수정

### DIFF
--- a/src/main/java/leets/weeth/domain/board/application/mapper/NoticeMapper.java
+++ b/src/main/java/leets/weeth/domain/board/application/mapper/NoticeMapper.java
@@ -4,15 +4,11 @@ import leets.weeth.domain.board.application.dto.NoticeDTO;
 import leets.weeth.domain.board.domain.entity.Notice;
 import leets.weeth.domain.comment.application.dto.CommentDTO;
 import leets.weeth.domain.comment.application.mapper.CommentMapper;
-import leets.weeth.domain.comment.domain.entity.Comment;
 import leets.weeth.domain.file.application.dto.response.FileResponse;
-import leets.weeth.domain.file.domain.service.FileGetService;
 import leets.weeth.domain.user.domain.entity.User;
 import org.mapstruct.*;
 
-import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Mapper(componentModel = MappingConstants.ComponentModel.SPRING, uses = CommentMapper.class, unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface NoticeMapper {
@@ -36,7 +32,8 @@ public interface NoticeMapper {
             @Mapping(target = "name", source = "notice.user.name"),
             @Mapping(target = "position", source = "notice.user.position"),
             @Mapping(target = "role", source = "notice.user.role"),
-            @Mapping(target = "time", source = "notice.modifiedAt")
+            @Mapping(target = "time", source = "notice.modifiedAt"),
+            @Mapping(target = "comments", source = "comments")
     })
     NoticeDTO.Response toNoticeDto(Notice notice, List<FileResponse> fileUrls, List<CommentDTO.Response> comments);
 

--- a/src/main/java/leets/weeth/domain/board/application/mapper/PostMapper.java
+++ b/src/main/java/leets/weeth/domain/board/application/mapper/PostMapper.java
@@ -4,15 +4,11 @@ import leets.weeth.domain.board.application.dto.PostDTO;
 import leets.weeth.domain.board.domain.entity.Post;
 import leets.weeth.domain.comment.application.dto.CommentDTO;
 import leets.weeth.domain.comment.application.mapper.CommentMapper;
-import leets.weeth.domain.comment.domain.entity.Comment;
 import leets.weeth.domain.file.application.dto.response.FileResponse;
-import leets.weeth.domain.file.domain.service.FileGetService;
 import leets.weeth.domain.user.domain.entity.User;
 import org.mapstruct.*;
 
-import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Mapper(componentModel = MappingConstants.ComponentModel.SPRING, uses = CommentMapper.class, unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface PostMapper {
@@ -37,7 +33,8 @@ public interface PostMapper {
             @Mapping(target = "name", source = "post.user.name"),
             @Mapping(target = "position", source = "post.user.position"),
             @Mapping(target = "role", source = "post.user.role"),
-            @Mapping(target = "time", source = "post.modifiedAt")
+            @Mapping(target = "time", source = "post.modifiedAt"),
+            @Mapping(target = "comments", source = "comments")
     })
     PostDTO.Response toPostDto(Post post, List<FileResponse> fileUrls, List<CommentDTO.Response> comments);
 

--- a/src/main/java/leets/weeth/domain/board/application/usecase/NoticeUsecaseImpl.java
+++ b/src/main/java/leets/weeth/domain/board/application/usecase/NoticeUsecaseImpl.java
@@ -143,7 +143,7 @@ public class NoticeUsecaseImpl implements NoticeUsecase {
                 .map(child -> mapToDtoWithChildren(child, commentMap))
                 .collect(Collectors.toList());
 
-        return commentMapper.toCommentDtoWithChildren(comment, children);
+        return commentMapper.toCommentDto(comment, children);
     }
 
 }

--- a/src/main/java/leets/weeth/domain/board/application/usecase/NoticeUsecaseImpl.java
+++ b/src/main/java/leets/weeth/domain/board/application/usecase/NoticeUsecaseImpl.java
@@ -9,6 +9,7 @@ import leets.weeth.domain.board.domain.service.NoticeFindService;
 import leets.weeth.domain.board.domain.service.NoticeSaveService;
 import leets.weeth.domain.board.domain.service.NoticeUpdateService;
 import leets.weeth.domain.comment.application.dto.CommentDTO;
+import leets.weeth.domain.comment.application.mapper.CommentMapper;
 import leets.weeth.domain.comment.domain.entity.Comment;
 import leets.weeth.domain.file.application.dto.response.FileResponse;
 import leets.weeth.domain.file.application.mapper.FileMapper;
@@ -16,7 +17,6 @@ import leets.weeth.domain.file.domain.entity.File;
 import leets.weeth.domain.file.domain.service.FileDeleteService;
 import leets.weeth.domain.file.domain.service.FileGetService;
 import leets.weeth.domain.file.domain.service.FileSaveService;
-import leets.weeth.domain.file.domain.service.FileUpdateService;
 import leets.weeth.domain.user.application.exception.UserNotMatchException;
 import leets.weeth.domain.user.domain.entity.User;
 import leets.weeth.domain.user.domain.service.UserGetService;
@@ -30,6 +30,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Service
@@ -45,10 +46,10 @@ public class NoticeUsecaseImpl implements NoticeUsecase {
 
     private final FileSaveService fileSaveService;
     private final FileGetService fileGetService;
-    private final FileUpdateService fileUpdateService;
     private final FileDeleteService fileDeleteService;
 
     private final NoticeMapper mapper;
+    private final CommentMapper commentMapper;
     private final FileMapper fileMapper;
 
     @Override
@@ -126,37 +127,23 @@ public class NoticeUsecaseImpl implements NoticeUsecase {
     }
 
     private List<CommentDTO.Response> filterParentComments(List<Comment> comments) {
-        if (comments == null || comments.isEmpty()) {
-            return Collections.emptyList();
-        }
+        Map<Long, List<Comment>> commentMap = comments.stream()
+                .filter(comment -> comment.getParent() != null)
+                .collect(Collectors.groupingBy(comment -> comment.getParent().getId()));
 
-        // 부모 댓글만 필터링하고, 각 부모 댓글에 대해 자식 댓글을 매핑
         return comments.stream()
-            .filter(comment -> comment.getParent() == null) // 부모 댓글만 필터링
-            .map(this::mapCommentWithChildren) // 자식 댓글 포함하여 매핑
-            .toList();
+                .filter(comment -> comment.getParent() == null) // 부모 댓글만 가져오기
+                .map(parent -> mapToDtoWithChildren(parent, commentMap))
+                .toList();
     }
 
-    private CommentDTO.Response mapCommentWithChildren(Comment comment) {
-        if (comment == null) {
-            return null;
-        }
+    private CommentDTO.Response mapToDtoWithChildren(Comment comment, Map<Long, List<Comment>> commentMap) {
+        List<CommentDTO.Response> children = commentMap.getOrDefault(comment.getId(), Collections.emptyList())
+                .stream()
+                .map(child -> mapToDtoWithChildren(child, commentMap))
+                .collect(Collectors.toList());
 
-        // 기본 댓글 정보 매핑
-        CommentDTO.Response.ResponseBuilder response = CommentDTO.Response.builder();
-
-        response.name(comment.getUser().getName());
-        response.time(comment.getModifiedAt());
-        response.id(comment.getId());
-        response.content(comment.getContent());
-
-        // 자식 댓글들을 재귀적으로 매핑하여 children 필드에 설정
-        List<CommentDTO.Response> childrenResponses = comment.getChildren().stream()
-            .map(this::mapCommentWithChildren) // 자식 댓글도 동일하게 처리
-            .collect(Collectors.toList());
-        response.children(childrenResponses);
-
-        return response.build();
+        return commentMapper.toCommentDtoWithChildren(comment, children);
     }
 
 }

--- a/src/main/java/leets/weeth/domain/board/application/usecase/PostUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/board/application/usecase/PostUseCaseImpl.java
@@ -146,7 +146,7 @@ public class PostUseCaseImpl implements PostUsecase {
                 .map(child -> mapToDtoWithChildren(child, commentMap))
                 .collect(Collectors.toList());
 
-        return commentMapper.toCommentDtoWithChildren(comment, children);
+        return commentMapper.toCommentDto(comment, children);
     }
 
 }

--- a/src/main/java/leets/weeth/domain/comment/application/mapper/CommentMapper.java
+++ b/src/main/java/leets/weeth/domain/comment/application/mapper/CommentMapper.java
@@ -44,5 +44,5 @@ public interface CommentMapper {
     @Mapping(target = "role", source = "comment.user.role")
     @Mapping(target = "time", source = "comment.modifiedAt")
     @Mapping(target = "children", source = "children")
-    CommentDTO.Response toCommentDtoWithChildren(Comment comment, List<CommentDTO.Response> children);
+    CommentDTO.Response toCommentDto(Comment comment, List<CommentDTO.Response> children);
 }

--- a/src/main/java/leets/weeth/domain/comment/application/mapper/CommentMapper.java
+++ b/src/main/java/leets/weeth/domain/comment/application/mapper/CommentMapper.java
@@ -7,6 +7,8 @@ import leets.weeth.domain.comment.domain.entity.Comment;
 import leets.weeth.domain.user.domain.entity.User;
 import org.mapstruct.*;
 
+import java.util.List;
+
 @Mapper(componentModel = MappingConstants.ComponentModel.SPRING, unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface CommentMapper {
 
@@ -36,9 +38,11 @@ public interface CommentMapper {
     })
     Comment fromCommentDto(CommentDTO.Save dto, Notice notice, User user, Comment parent);
 
+
     @Mapping(target = "name", source = "comment.user.name")
     @Mapping(target = "position", source = "comment.user.position")
     @Mapping(target = "role", source = "comment.user.role")
-    @Mapping(target = "time", source = "modifiedAt")
-    CommentDTO.Response toCommentDto(Comment comment);
+    @Mapping(target = "time", source = "comment.modifiedAt")
+    @Mapping(target = "children", source = "children")
+    CommentDTO.Response toCommentDtoWithChildren(Comment comment, List<CommentDTO.Response> children);
 }


### PR DESCRIPTION
## PR 내용
- 기존 댓글이 중복 조회되는 문제를 수정했습니다.
- 수정 하면서 자식 댓글을 가져올 때 댓글 개수만큼 추가 쿼리가 날아가는 문제를 해결했습니다.
- 약 10ms 정도의 조회 성능을 개선할 수 있었습니다.
<br>

## PR 세부사항
- 재귀적으로 자식 댓글을 찾아 매핑하는 로직은 유사하나 Map을 사용하여 전체 댓글을 메모리에 올린 후 추가 쿼리가 날아가지 않게 수정했습니다.
- Post, Notice mapper에서는 별도의 매핑 로직 없이 그대로 받아서 처리하도록 수정했습니다
<br>

## 관련 스크린샷
- 중복 조회를 해결한 모습
<img width="411" alt="image" src="https://github.com/user-attachments/assets/43a34ff6-ad7c-419e-992e-b34ebcb47818" />

- 댓글 개수만큼 추가 쿼리가 날아가는 모습
<img width="829" alt="image" src="https://github.com/user-attachments/assets/927c8aad-66b5-4405-8aa3-382036d40696" />

- 수정 후 쿼리 3번으로 줄은 모습
<img width="831" alt="image" src="https://github.com/user-attachments/assets/1b761e46-633b-495f-a556-f4b8a4eb02dc" />

<br>

## 주의사항
x
<br>

## 체크 리스트

- [x] 리뷰어 설정
- [x] Assignee 설정
- [x] Label 설정
- [x] 제목 양식 맞췄나요? (ex. #0 Feat: 기능 추가)
- [x] 변경 사항에 대한 테스트