### PR TITLE
Refactor #120 회원가입 시 email 추가

### DIFF
--- a/src/main/java/leets/weeth/domain/user/application/dto/request/UserRequestDto.java
+++ b/src/main/java/leets/weeth/domain/user/application/dto/request/UserRequestDto.java
@@ -27,6 +27,7 @@ public class UserRequestDto {
             @NotNull Long kakaoId,
             @NotBlank String name,
             @NotBlank String studentId,
+            @NotBlank String email,
             @NotNull String department,
             @NotBlank String tel,
             @NotNull Integer cardinal,


### PR DESCRIPTION
## PR 내용
- 소셜 회원가입시 email을 같이 받아서 저장하도록 수정했습니다.
- 카카오 로그인 연동 중 jwt 토큰에 email이 없으면 문제가 발생하는 것을 발견했습니다.
- 아직 미정이지만 다음 회의 때도 얘기해볼 문제로, email이 유지가 됐으면 좋겠다는 의견도 있었습니다.
<br>

## PR 세부사항
- 매퍼에서 email을 잘 매핑하고 있는 것을 확인 했습니다!
<br>

## 관련 스크린샷

<br>

## 주의사항
- 아직 요구사항이 확정되진 않았으나, 변동될 가능성이 99프로라고 판단해 일단 작업 먼저 했습니당.
<br>

## 체크 리스트

- [x] 리뷰어 설정
- [x] Assignee 설정
- [x] Label 설정
- [x] 제목 양식 맞췄나요? (ex. #0 Feat: 기능 추가)
- [x] 변경 사항에 대한 테스트