### PR TITLE
Refactor #121 출석마감 자동화

### DIFF
--- a/src/main/java/leets/weeth/WeethApplication.java
+++ b/src/main/java/leets/weeth/WeethApplication.java
@@ -5,12 +5,14 @@ import io.swagger.v3.oas.annotations.servers.Server;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 
 //@OpenAPIDefinition(servers = {
 //        @Server(url="https://api.weeth.site", description = "Default Api Server url"),
 //        @Server(url="http://localhost:8080", description = "Local Api url")
 //})
+@EnableScheduling
 @EnableJpaAuditing
 @EnableWebSecurity
 @SpringBootApplication

--- a/src/main/java/leets/weeth/domain/attendance/domain/service/AttendanceScheduler.java
+++ b/src/main/java/leets/weeth/domain/attendance/domain/service/AttendanceScheduler.java
@@ -1,0 +1,39 @@
+package leets.weeth.domain.attendance.domain.service;
+
+import java.time.LocalDate;
+import java.util.List;
+import leets.weeth.domain.attendance.domain.entity.Attendance;
+import leets.weeth.domain.schedule.domain.entity.Meeting;
+import leets.weeth.domain.schedule.domain.repository.MeetingRepository;
+import leets.weeth.domain.user.domain.entity.Cardinal;
+import leets.weeth.domain.user.domain.repository.CardinalRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AttendanceScheduler {
+
+    private final CardinalRepository cardinalRepository;
+    private final MeetingRepository meetingRepository;
+    private final AttendanceGetService attendanceGetService;
+    private final AttendanceUpdateService attendanceUpdateService;
+
+    @Scheduled(cron = "0 0 22 * * THU")
+    public void autoCloseAttendance() {
+        LocalDate today = LocalDate.now();
+        Cardinal currentCardinal = cardinalRepository.findTopByOrderByCardinalNumberDesc();
+
+        List<Meeting> meetings = meetingRepository.findAllByCardinalOrderByStartAsc(currentCardinal.getCardinalNumber());
+
+        meetings.stream()
+                .filter(meeting -> meeting.getStart().toLocalDate().isEqual(today) &&
+                        meeting.getEnd().toLocalDate().isEqual(today))
+                .findAny()
+                .ifPresent(meeting -> {
+                    List<Attendance> attendanceList = attendanceGetService.findAllByMeeting(meeting);
+                    attendanceUpdateService.close(attendanceList);
+                });
+    }
+}

--- a/src/main/java/leets/weeth/domain/attendance/domain/service/AttendanceScheduler.java
+++ b/src/main/java/leets/weeth/domain/attendance/domain/service/AttendanceScheduler.java
@@ -20,7 +20,7 @@ public class AttendanceScheduler {
     private final AttendanceGetService attendanceGetService;
     private final AttendanceUpdateService attendanceUpdateService;
 
-    @Scheduled(cron = "0 0 22 * * THU")
+    @Scheduled(cron = "0 0 22 * * THU", zone = "Asia/Seoul")
     public void autoCloseAttendance() {
         LocalDate today = LocalDate.now();
         Cardinal currentCardinal = cardinalRepository.findTopByOrderByCardinalNumberDesc();

--- a/src/main/java/leets/weeth/domain/attendance/domain/service/AttendanceScheduler.java
+++ b/src/main/java/leets/weeth/domain/attendance/domain/service/AttendanceScheduler.java
@@ -1,9 +1,9 @@
 package leets.weeth.domain.attendance.domain.service;
 
-import java.time.LocalDate;
 import java.util.List;
 import leets.weeth.domain.attendance.domain.entity.Attendance;
 import leets.weeth.domain.schedule.domain.entity.Meeting;
+import leets.weeth.domain.schedule.domain.entity.enums.MeetingStatus;
 import leets.weeth.domain.schedule.domain.repository.MeetingRepository;
 import leets.weeth.domain.user.domain.entity.Cardinal;
 import leets.weeth.domain.user.domain.repository.CardinalRepository;
@@ -22,16 +22,14 @@ public class AttendanceScheduler {
 
     @Scheduled(cron = "0 0 22 * * THU", zone = "Asia/Seoul")
     public void autoCloseAttendance() {
-        LocalDate today = LocalDate.now();
         Cardinal currentCardinal = cardinalRepository.findTopByOrderByCardinalNumberDesc();
 
         List<Meeting> meetings = meetingRepository.findAllByCardinalOrderByStartAsc(currentCardinal.getCardinalNumber());
 
         meetings.stream()
-                .filter(meeting -> meeting.getStart().toLocalDate().isEqual(today) &&
-                        meeting.getEnd().toLocalDate().isEqual(today))
-                .findAny()
-                .ifPresent(meeting -> {
+                .filter(meeting -> meeting.getMeetingStatus() == MeetingStatus.OPEN)
+                .forEach(meeting -> {
+                    meeting.close();
                     List<Attendance> attendanceList = attendanceGetService.findAllByMeeting(meeting);
                     attendanceUpdateService.close(attendanceList);
                 });

--- a/src/main/java/leets/weeth/domain/schedule/domain/entity/Meeting.java
+++ b/src/main/java/leets/weeth/domain/schedule/domain/entity/Meeting.java
@@ -1,7 +1,11 @@
 package leets.weeth.domain.schedule.domain.entity;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.PrePersist;
 import leets.weeth.domain.schedule.application.dto.MeetingDTO;
+import leets.weeth.domain.schedule.domain.entity.enums.MeetingStatus;
 import leets.weeth.domain.user.domain.entity.User;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -22,11 +26,21 @@ public class Meeting extends Schedule {
 
     private Integer code;
 
+    @Enumerated(EnumType.STRING)
+    private MeetingStatus meetingStatus;
+
     public void update(MeetingDTO.Update dto, User user) {
         this.updateUpperClass(dto, user);
         this.weekNumber = dto.weekNumber();
         this.cardinal = dto.cardinal();
     }
 
+    @PrePersist
+    public void init() {
+        this.meetingStatus = MeetingStatus.OPEN;
+    }
 
+    public void close() {
+        this.meetingStatus = MeetingStatus.CLOSE;
+    }
 }

--- a/src/main/java/leets/weeth/domain/schedule/domain/entity/enums/MeetingStatus.java
+++ b/src/main/java/leets/weeth/domain/schedule/domain/entity/enums/MeetingStatus.java
@@ -1,0 +1,6 @@
+package leets.weeth.domain.schedule.domain.entity.enums;
+
+public enum MeetingStatus {
+    OPEN, 
+    CLOSE
+}

--- a/src/main/java/leets/weeth/domain/user/domain/repository/CardinalRepository.java
+++ b/src/main/java/leets/weeth/domain/user/domain/repository/CardinalRepository.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 public interface CardinalRepository extends JpaRepository<Cardinal, Long> {
 
     Optional<Cardinal> findByCardinalNumber(Integer cardinal);
+
+    Cardinal findTopByOrderByCardinalNumberDesc();
 }


### PR DESCRIPTION
## PR 내용
출석마감이 자동적으로 처리되도록 자동화
<br>

## PR 세부사항
동아리 딱 끝나는 시간에 맞추기 보다는, 매주 목요일 22시마다 실행되도록 @Scheduled 어노테이션으로 설정해주었습니다
기존 수동 마감 로직과는 별개로 구현된 내용으로, 출석 마감이 자동화 + 수동로 진행된다고 생각해주시면 됩니다

AttendanceUseCaseImpl에 구현해도 무방하긴하지만 서비스단 목적상 비즈니스 로직이라 스케쥴링이랑 분리가 되어야할거같다는 생각에
별도의 AttendanceScheduler를 생성해 구현하였습니다

정기 모임에 AttendStatus 상태를 추가해서, 정기 모임 생성할때 상태 open 상태로 생성해줘서, open 상태인 출석 객체를 close로 마감해주는 방식으로 변경했습니다.  스케줄링을 돌릴 때 오늘 날짜를 포함한 이전 정기 모임 중 출석 마감을 하지 않은 정기모임들을 가져와서, 그 정기모임에 속한 출석들을 마감해주는 플로우라고 생각해주시면 됩니다

<br>

## 관련 스크린샷

![image](https://github.com/user-attachments/assets/6e93d245-e454-4a29-b7a5-6825ad6a38c3)
생성시에는 OPEN으로 설정

![image](https://github.com/user-attachments/assets/5afc6589-2ea8-4eb0-b4fb-a8d7683bb48c)
Pending 상태인 출석상태

<img width="665" alt="image" src="https://github.com/user-attachments/assets/47dee10e-c1b6-448f-a40f-22c2ff022578" />
autoCloseAttendance 실행 후

![image](https://github.com/user-attachments/assets/7f20979c-b8ca-471c-a69d-2dc01b506014)
ABSENT로 변경

<img width="1391" alt="image" src="https://github.com/user-attachments/assets/d3b18f93-b263-43c9-9df7-3b1216ac19a9" />


<br>

## 주의사항
목요일마다 해당하는 정기모임이 있을거지만 목요일에 해당하는 정기모임이 없는거 또한 정상적인 플로우라고 생각해서, 따로 예외처리를 해주지않는 방식으로 구현했습니다. 그리고 해당 부분을 추가로 찾아보니 스케줄러 로직에  예외를 던지는 방식은 권장되지 않는다는 것도 알게되어 별도의 예외처리는 해주지 않았습니다

로직에 대한 테스트는 @Scheduled(cron = "0 0 22 * * THU") 어노테이션 부분을 주석처리하고, 별도의 컨트롤러를 만들어서 단위테스트로 진행하였습니다. 더미데이터 생성 후 테스트 진행하였는데, 정기모임 날짜가 OPEN 상태일때에만, 해당 객체에만 적용되어 마감되는 것을 확인했고, 출석 마감 후 PENDING 상태였던 status가 올바르게 ABSENT로 변경되는거 또한 확인했습니다

<br>

## 체크 리스트

- [x] 리뷰어 설정
- [x] Assignee 설정
- [x] Label 설정
- [x] 제목 양식 맞췄나요? (ex. #0 Feat: 기능 추가)
- [x] 변경 사항에 대한 테스트