### PR TITLE
Feat #128 정기모임 리스트

### DIFF
--- a/src/main/java/leets/weeth/domain/attendance/presentation/AttendanceAdminController.java
+++ b/src/main/java/leets/weeth/domain/attendance/presentation/AttendanceAdminController.java
@@ -1,25 +1,19 @@
 package leets.weeth.domain.attendance.presentation;
 
-import static leets.weeth.domain.attendance.presentation.ResponseMessage.ATTENDANCE_CLOSE_SUCCESS;
-import static leets.weeth.domain.attendance.presentation.ResponseMessage.ATTENDANCE_FIND_DETAIL_SUCCESS;
-import static leets.weeth.domain.attendance.presentation.ResponseMessage.ATTENDANCE_UPDATED_SUCCESS;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.util.List;
 import leets.weeth.domain.attendance.application.dto.AttendanceDTO;
 import leets.weeth.domain.attendance.application.usecase.AttendanceUseCase;
+import leets.weeth.domain.schedule.application.dto.MeetingDTO;
+import leets.weeth.domain.schedule.application.usecase.MeetingUseCase;
 import leets.weeth.global.common.response.CommonResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
+import java.util.List;
+
+import static leets.weeth.domain.attendance.presentation.ResponseMessage.*;
 
 @Tag(name = "ATTENDANCE ADMIN", description = "[ADMIN] 출석 어드민 API")
 @RestController
@@ -28,12 +22,21 @@ import java.time.LocalDate;
 public class AttendanceAdminController {
 
     private final AttendanceUseCase attendanceUseCase;
+    private final MeetingUseCase meetingUseCase;
 
     @PatchMapping
     @Operation(summary="출석 마감")
     public CommonResponse<Void> close(@RequestParam LocalDate now, @RequestParam Integer cardinal) {
         attendanceUseCase.close(now, cardinal);
         return CommonResponse.createSuccess(ATTENDANCE_CLOSE_SUCCESS.getMessage());
+    }
+
+    @GetMapping("/meetings/{cardinal}")
+    @Operation(summary = "정기모임 조회")
+    public CommonResponse<List<MeetingDTO.Info>> getMeetings(@PathVariable Integer cardinal) {
+        List<MeetingDTO.Info> response = meetingUseCase.find(cardinal);
+
+        return CommonResponse.createSuccess(MEETING_FIND_SUCCESS.getMessage(), response);
     }
 
     @GetMapping("/{meetingId}")

--- a/src/main/java/leets/weeth/domain/attendance/presentation/ResponseMessage.java
+++ b/src/main/java/leets/weeth/domain/attendance/presentation/ResponseMessage.java
@@ -10,6 +10,7 @@ public enum ResponseMessage {
     ATTENDANCE_CLOSE_SUCCESS("출석이 성공적으로 마감되었습니다."),
     ATTENDANCE_UPDATED_SUCCESS("개별 출석 상태가 성공적으로 수정되었습니다."),
     ATTENDANCE_FIND_DETAIL_SUCCESS("모든 인원의 정기모임 출석 정보가 성공적으로 조회되었습니다."),
+    MEETING_FIND_SUCCESS("기수별 정기모임 리스트를 성공적으로 조회했습니다."),
 
     //AttendanceController 관련
     ATTENDANCE_CHECKIN_SUCCESS("출석이 성공적으로 처리되었습니다."),

--- a/src/main/java/leets/weeth/domain/penalty/presentation/PenaltyAdminController.java
+++ b/src/main/java/leets/weeth/domain/penalty/presentation/PenaltyAdminController.java
@@ -1,19 +1,16 @@
 package leets.weeth.domain.penalty.presentation;
 
-import static leets.weeth.domain.penalty.presentation.ResponseMessage.PENALTY_ASSIGN_SUCCESS;
-import static leets.weeth.domain.penalty.presentation.ResponseMessage.PENALTY_DELETE_SUCCESS;
-import static leets.weeth.domain.penalty.presentation.ResponseMessage.PENALTY_FIND_ALL_SUCCESS;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import leets.weeth.domain.penalty.application.dto.PenaltyDTO;
 import leets.weeth.domain.penalty.application.usecase.PenaltyUsecase;
-
 import leets.weeth.global.common.response.CommonResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+
+import static leets.weeth.domain.penalty.presentation.ResponseMessage.*;
 
 @Tag(name = "PENALTY ADMIN", description = "[ADMIN] 패널티 어드민 API")
 @RestController
@@ -24,14 +21,14 @@ public class PenaltyAdminController {
     private final PenaltyUsecase penaltyUsecase;
 
     @PostMapping
-    @Operation(summary="전체 패널티 조회")
+    @Operation(summary="패널티 부여")
     public CommonResponse<String> assignPenalty(@RequestBody PenaltyDTO.Save dto){
         penaltyUsecase.save(dto);
         return CommonResponse.createSuccess(PENALTY_ASSIGN_SUCCESS.getMessage());
     }
 
     @GetMapping
-    @Operation(summary="패널티 부여")
+    @Operation(summary="전체 패널티 조회")
     public CommonResponse<List<PenaltyDTO.Response>> findAll(){
         return CommonResponse.createSuccess(PENALTY_FIND_ALL_SUCCESS.getMessage(),penaltyUsecase.find());
     }

--- a/src/main/java/leets/weeth/domain/schedule/application/dto/MeetingDTO.java
+++ b/src/main/java/leets/weeth/domain/schedule/application/dto/MeetingDTO.java
@@ -21,4 +21,10 @@ public class MeetingDTO {
             LocalDateTime modifiedAt
     ) {}
 
+    public record Info(
+            Long id,
+            String title,
+            LocalDateTime start
+    ) {}
+
 }

--- a/src/main/java/leets/weeth/domain/schedule/application/mapper/MeetingMapper.java
+++ b/src/main/java/leets/weeth/domain/schedule/application/mapper/MeetingMapper.java
@@ -1,6 +1,5 @@
 package leets.weeth.domain.schedule.application.mapper;
 
-import leets.weeth.domain.schedule.application.dto.MeetingDTO;
 import leets.weeth.domain.schedule.application.dto.ScheduleDTO;
 import leets.weeth.domain.schedule.domain.entity.Meeting;
 import leets.weeth.domain.user.domain.entity.User;
@@ -8,6 +7,7 @@ import org.mapstruct.*;
 
 import java.util.Random;
 
+import static leets.weeth.domain.schedule.application.dto.MeetingDTO.Info;
 import static leets.weeth.domain.schedule.application.dto.MeetingDTO.Response;
 
 @Mapper(componentModel = MappingConstants.ComponentModel.SPRING, unmappedTargetPolicy = ReportingPolicy.IGNORE)
@@ -17,8 +17,10 @@ public interface MeetingMapper {
     @Mapping(target = "code", ignore = true)
     Response to(Meeting meeting);
 
+    Info toInfo(Meeting meeting);
+
     @Mapping(target = "name", source = "user.name")
-    MeetingDTO.Response toAdminResponse(Meeting meeting);
+    Response toAdminResponse(Meeting meeting);
 
     @Mappings({
             @Mapping(target = "id", ignore = true),

--- a/src/main/java/leets/weeth/domain/schedule/application/usecase/MeetingUseCase.java
+++ b/src/main/java/leets/weeth/domain/schedule/application/usecase/MeetingUseCase.java
@@ -2,11 +2,16 @@ package leets.weeth.domain.schedule.application.usecase;
 
 import leets.weeth.domain.schedule.application.dto.ScheduleDTO;
 
+import java.util.List;
+
+import static leets.weeth.domain.schedule.application.dto.MeetingDTO.Info;
 import static leets.weeth.domain.schedule.application.dto.MeetingDTO.Response;
 
 public interface MeetingUseCase {
 
     Response find(Long userId, Long eventId);
+
+    List<Info> find(Integer cardinal);
 
     void save(ScheduleDTO.Save dto, Long userId);
 

--- a/src/main/java/leets/weeth/domain/schedule/application/usecase/MeetingUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/schedule/application/usecase/MeetingUseCaseImpl.java
@@ -24,6 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+import static leets.weeth.domain.schedule.application.dto.MeetingDTO.Info;
 import static leets.weeth.domain.schedule.application.dto.MeetingDTO.Response;
 
 @Slf4j
@@ -53,6 +54,15 @@ public class MeetingUseCaseImpl implements MeetingUseCase {
         }
 
         return mapper.to(meeting);
+    }
+
+    @Override
+    public List<Info> find(Integer cardinal) {
+        List<Meeting> meetings = meetingGetService.find(cardinal);
+
+        return meetings.stream()
+                .map(mapper::toInfo)
+                .toList();
     }
 
     @Override


### PR DESCRIPTION
## PR 내용
- 아래 화면에서 필요한 기수별 정기모임 리스트를 조회하는 API를 구현했습니다
<img width="605" alt="image" src="https://github.com/user-attachments/assets/b17764bb-9c0c-4fab-b5ca-0357889ad9af" />

<br>

## PR 세부사항
<img width="432" alt="image" src="https://github.com/user-attachments/assets/afc59114-dd1d-408b-b996-65342006baf2" />

- 추가로 스웨거에 설명이 반대로 써져있던 부분을 수정했습니다
<br>

## 관련 스크린샷

<br>

## 주의사항

<br>

## 체크 리스트

- [x] 리뷰어 설정
- [x] Assignee 설정
- [x] Label 설정
- [x] 제목 양식 맞췄나요? (ex. #0 Feat: 기능 추가)
- [x] 변경 사항에 대한 테스트