### PR TITLE
Fix #130 일정/정기모임 기수 반환

### DIFF
--- a/src/main/java/leets/weeth/domain/schedule/application/dto/EventDTO.java
+++ b/src/main/java/leets/weeth/domain/schedule/application/dto/EventDTO.java
@@ -11,6 +11,7 @@ public class EventDTO {
             String location,
             String requiredItem,
             String name,
+            Integer cardinal,
             LocalDateTime start,
             LocalDateTime end,
             LocalDateTime createdAt,

--- a/src/main/java/leets/weeth/domain/schedule/application/dto/MeetingDTO.java
+++ b/src/main/java/leets/weeth/domain/schedule/application/dto/MeetingDTO.java
@@ -14,6 +14,7 @@ public class MeetingDTO {
             String location,
             String requiredItem,
             String name,
+            Integer cardinal,
             Integer code,
             LocalDateTime start,
             LocalDateTime end,

--- a/src/main/java/leets/weeth/domain/schedule/presentation/MeetingController.java
+++ b/src/main/java/leets/weeth/domain/schedule/presentation/MeetingController.java
@@ -1,6 +1,7 @@
 package leets.weeth.domain.schedule.presentation;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import leets.weeth.domain.schedule.application.dto.MeetingDTO;
 import leets.weeth.domain.schedule.application.usecase.MeetingUseCase;
@@ -24,7 +25,7 @@ public class MeetingController {
 
     @GetMapping("/{meetingId}")
     @Operation(summary="정기모임 상세 조회")
-    public CommonResponse<MeetingDTO.Response> find(@CurrentUser Long userId,
+    public CommonResponse<MeetingDTO.Response> find(@Parameter(hidden = true) @CurrentUser Long userId,
                                                     @PathVariable Long meetingId) {
         return CommonResponse.createSuccess(MEETING_FIND_SUCCESS.getMessage(),meetingUseCase.find(userId, meetingId));
     }


### PR DESCRIPTION
## PR 내용
- 일정/정기모임 상세 조회시 기수도 함께 반환하도록 수정했습니다
<br>

## PR 세부사항
- 정기모임 상세 조회 API에 @CurrentUser가 무시가 안 되어있어서 설정을 추가했습니다.
<br>

## 관련 스크린샷
<img width="398" alt="image" src="https://github.com/user-attachments/assets/3bdca966-3418-4cf8-a802-20cb79f8c283" />

<br>

## 주의사항

<br>

## 체크 리스트

- [x] 리뷰어 설정
- [x] Assignee 설정
- [x] Label 설정
- [x] 제목 양식 맞췄나요? (ex. #0 Feat: 기능 추가)
- [x] 변경 사항에 대한 테스트