### PR TITLE
Fix #136 어드민 페이지 정기모임 조회 수정

### DIFF
--- a/src/main/java/leets/weeth/domain/attendance/presentation/AttendanceAdminController.java
+++ b/src/main/java/leets/weeth/domain/attendance/presentation/AttendanceAdminController.java
@@ -31,9 +31,9 @@ public class AttendanceAdminController {
         return CommonResponse.createSuccess(ATTENDANCE_CLOSE_SUCCESS.getMessage());
     }
 
-    @GetMapping("/meetings/{cardinal}")
+    @GetMapping("/meetings")
     @Operation(summary = "정기모임 조회")
-    public CommonResponse<List<MeetingDTO.Info>> getMeetings(@PathVariable Integer cardinal) {
+    public CommonResponse<List<MeetingDTO.Info>> getMeetings(@RequestParam(required = false) Integer cardinal) {
         List<MeetingDTO.Info> response = meetingUseCase.find(cardinal);
 
         return CommonResponse.createSuccess(MEETING_FIND_SUCCESS.getMessage(), response);

--- a/src/main/java/leets/weeth/domain/schedule/application/dto/MeetingDTO.java
+++ b/src/main/java/leets/weeth/domain/schedule/application/dto/MeetingDTO.java
@@ -23,6 +23,7 @@ public class MeetingDTO {
 
     public record Info(
             Long id,
+            Integer cardinal,
             String title,
             LocalDateTime start
     ) {}

--- a/src/main/java/leets/weeth/domain/schedule/application/usecase/MeetingUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/schedule/application/usecase/MeetingUseCaseImpl.java
@@ -58,7 +58,15 @@ public class MeetingUseCaseImpl implements MeetingUseCase {
 
     @Override
     public List<Info> find(Integer cardinal) {
-        List<Meeting> meetings = meetingGetService.find(cardinal);
+        List<Meeting> meetings;
+
+        if (cardinal == null) {
+            meetings = meetingGetService.findAll();
+
+        } else {
+            meetings = meetingGetService.findMeetingByCardinal(cardinal);
+
+        }
 
         return meetings.stream()
                 .map(mapper::toInfo)

--- a/src/main/java/leets/weeth/domain/schedule/domain/repository/MeetingRepository.java
+++ b/src/main/java/leets/weeth/domain/schedule/domain/repository/MeetingRepository.java
@@ -12,5 +12,9 @@ public interface MeetingRepository extends JpaRepository<Meeting, Long> {
 
     List<Meeting> findAllByCardinalOrderByStartAsc(int cardinal);
 
+    List<Meeting> findAllByCardinalOrderByStartDesc(int cardinal);
+
     List<Meeting> findAllByCardinal(int cardinal);
+
+    List<Meeting> findAllByOrderByStartDesc();
 }

--- a/src/main/java/leets/weeth/domain/schedule/domain/service/MeetingGetService.java
+++ b/src/main/java/leets/weeth/domain/schedule/domain/service/MeetingGetService.java
@@ -33,8 +33,12 @@ public class MeetingGetService {
         return meetingRepository.findAllByCardinalOrderByStartAsc(cardinal);
     }
 
+    public List<Meeting> findMeetingByCardinal(Integer cardinal) {
+        return meetingRepository.findAllByCardinalOrderByStartDesc(cardinal);
+    }
+
     public List<Meeting> findAll() {
-        return meetingRepository.findAll();
+        return meetingRepository.findAllByOrderByStartDesc();
     }
 
     public List<ScheduleDTO.Response> findByCardinal(Integer cardinal) {


### PR DESCRIPTION
## PR 내용
- 이전에 구현했던 어드민 페이지 정기모임 조회를 일부 수정했습니다.
- 우선 요구사항에 맞게 기수가 없이 요청된 경우 모든 정기모임을 조회하도록 했습니다.
- 날짜를 최신순으로 수정했습니다.
- 확장을 위해 기수를 반환하도록 추가했습니다
<br>

## PR 세부사항

<br>

## 관련 스크린샷
<img width="425" alt="image" src="https://github.com/user-attachments/assets/5f9013b1-3e8f-4617-ae1f-6ac7724a7e24" />

<br>

## 주의사항

<br>

## 체크 리스트

- [x] 리뷰어 설정
- [x] Assignee 설정
- [x] Label 설정
- [x] 제목 양식 맞췄나요? (ex. #0 Feat: 기능 추가)
- [x] 변경 사항에 대한 테스트