### PR TITLE
Refactor #137 멤버 관리 API 리스트로 수정

### DIFF
--- a/src/main/java/leets/weeth/domain/attendance/presentation/AttendanceAdminController.java
+++ b/src/main/java/leets/weeth/domain/attendance/presentation/AttendanceAdminController.java
@@ -31,9 +31,9 @@ public class AttendanceAdminController {
         return CommonResponse.createSuccess(ATTENDANCE_CLOSE_SUCCESS.getMessage());
     }
 
-    @GetMapping("/meetings/{cardinal}")
+    @GetMapping("/meetings")
     @Operation(summary = "정기모임 조회")
-    public CommonResponse<List<MeetingDTO.Info>> getMeetings(@PathVariable Integer cardinal) {
+    public CommonResponse<List<MeetingDTO.Info>> getMeetings(@RequestParam(required = false) Integer cardinal) {
         List<MeetingDTO.Info> response = meetingUseCase.find(cardinal);
 
         return CommonResponse.createSuccess(MEETING_FIND_SUCCESS.getMessage(), response);

--- a/src/main/java/leets/weeth/domain/schedule/application/dto/MeetingDTO.java
+++ b/src/main/java/leets/weeth/domain/schedule/application/dto/MeetingDTO.java
@@ -23,6 +23,7 @@ public class MeetingDTO {
 
     public record Info(
             Long id,
+            Integer cardinal,
             String title,
             LocalDateTime start
     ) {}

--- a/src/main/java/leets/weeth/domain/schedule/application/usecase/MeetingUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/schedule/application/usecase/MeetingUseCaseImpl.java
@@ -58,7 +58,15 @@ public class MeetingUseCaseImpl implements MeetingUseCase {
 
     @Override
     public List<Info> find(Integer cardinal) {
-        List<Meeting> meetings = meetingGetService.find(cardinal);
+        List<Meeting> meetings;
+
+        if (cardinal == null) {
+            meetings = meetingGetService.findAll();
+
+        } else {
+            meetings = meetingGetService.findMeetingByCardinal(cardinal);
+
+        }
 
         return meetings.stream()
                 .map(mapper::toInfo)

--- a/src/main/java/leets/weeth/domain/schedule/domain/repository/MeetingRepository.java
+++ b/src/main/java/leets/weeth/domain/schedule/domain/repository/MeetingRepository.java
@@ -12,5 +12,9 @@ public interface MeetingRepository extends JpaRepository<Meeting, Long> {
 
     List<Meeting> findAllByCardinalOrderByStartAsc(int cardinal);
 
+    List<Meeting> findAllByCardinalOrderByStartDesc(int cardinal);
+
     List<Meeting> findAllByCardinal(int cardinal);
+
+    List<Meeting> findAllByOrderByStartDesc();
 }

--- a/src/main/java/leets/weeth/domain/schedule/domain/service/MeetingGetService.java
+++ b/src/main/java/leets/weeth/domain/schedule/domain/service/MeetingGetService.java
@@ -33,8 +33,12 @@ public class MeetingGetService {
         return meetingRepository.findAllByCardinalOrderByStartAsc(cardinal);
     }
 
+    public List<Meeting> findMeetingByCardinal(Integer cardinal) {
+        return meetingRepository.findAllByCardinalOrderByStartDesc(cardinal);
+    }
+
     public List<Meeting> findAll() {
-        return meetingRepository.findAll();
+        return meetingRepository.findAllByOrderByStartDesc();
     }
 
     public List<ScheduleDTO.Response> findByCardinal(Integer cardinal) {

--- a/src/main/java/leets/weeth/domain/user/application/dto/request/UserRequestDto.java
+++ b/src/main/java/leets/weeth/domain/user/application/dto/request/UserRequestDto.java
@@ -3,6 +3,9 @@ package leets.weeth.domain.user.application.dto.request;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import leets.weeth.domain.user.domain.entity.enums.Role;
+
+import java.util.List;
 
 public class UserRequestDto {
 
@@ -48,6 +51,23 @@ public class UserRequestDto {
             @Email @NotBlank String email,
             @NotBlank String passWord,
             @NotNull Long kakaoId
+    ) {
+    }
+
+    public record UserRoleUpdate(
+            @NotNull Long userId,
+            @NotNull Role role
+    ) {
+    }
+
+    public record UserApplyOB(
+            @NotNull Long userId,
+            @NotNull Integer cardinal
+    ) {
+    }
+
+    public record UserId(
+            @NotNull List<Long> userId
     ) {
     }
 

--- a/src/main/java/leets/weeth/domain/user/application/usecase/UserManageUseCase.java
+++ b/src/main/java/leets/weeth/domain/user/application/usecase/UserManageUseCase.java
@@ -22,5 +22,5 @@ public interface UserManageUseCase {
 
     void applyOB(List<UserApplyOB> request);
 
-    void reset(Long userId);
+    void reset(UserId userId);
 }

--- a/src/main/java/leets/weeth/domain/user/application/usecase/UserManageUseCase.java
+++ b/src/main/java/leets/weeth/domain/user/application/usecase/UserManageUseCase.java
@@ -5,20 +5,22 @@ import leets.weeth.domain.user.domain.entity.enums.UsersOrderBy;
 
 import java.util.List;
 
+import static leets.weeth.domain.user.application.dto.request.UserRequestDto.*;
+
 public interface UserManageUseCase {
 
 
     List<UserResponseDto.AdminResponse> findAllByAdmin(UsersOrderBy orderBy);
 
-    void accept(Long userId);
+    void accept(UserId userIds);
 
-    void update(Long userId, String role);
+    void update(List<UserRoleUpdate> request);
 
     void leave(Long userId);
 
-    void ban(Long userId);
+    void ban(UserId userIds);
 
-    void applyOB(Long userId, Integer cardinal);
+    void applyOB(List<UserApplyOB> request);
 
     void reset(Long userId);
 }

--- a/src/main/java/leets/weeth/domain/user/application/usecase/UserManageUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/user/application/usecase/UserManageUseCaseImpl.java
@@ -151,9 +151,12 @@ public class UserManageUseCaseImpl implements UserManageUseCase {
     }
 
     @Override
-    public void reset(Long userId) {
-        User user = userGetService.find(userId);
-        userUpdateService.reset(user, passwordEncoder);
+    @Transactional
+    public void reset(UserId userId) {
+
+        List<User> users = userGetService.findAll(userId.userId());
+
+        users.forEach(user -> userUpdateService.reset(user, passwordEncoder));
     }
 
 }

--- a/src/main/java/leets/weeth/domain/user/application/usecase/UserManageUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/user/application/usecase/UserManageUseCaseImpl.java
@@ -17,15 +17,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
-import java.util.Comparator;
-import java.util.EnumSet;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 
+import static leets.weeth.domain.user.application.dto.request.UserRequestDto.*;
 import static leets.weeth.domain.user.application.dto.response.UserResponseDto.AdminResponse;
-import static leets.weeth.domain.user.domain.entity.enums.UsersOrderBy.*;
-import java.util.LinkedHashMap;
+import static leets.weeth.domain.user.domain.entity.enums.UsersOrderBy.CARDINAL_DESCENDING;
+import static leets.weeth.domain.user.domain.entity.enums.UsersOrderBy.NAME_ASCENDING;
 
 @Service
 @RequiredArgsConstructor
@@ -52,36 +50,36 @@ public class UserManageUseCaseImpl implements UserManageUseCase {
         }
 
         Map<User, List<UserCardinal>> userCardinalMap = userCardinalGetService.findAll()
-            .stream()
-            .collect(Collectors.groupingBy(UserCardinal::getUser, LinkedHashMap::new, Collectors.toList()));
+                .stream()
+                .collect(Collectors.groupingBy(UserCardinal::getUser, LinkedHashMap::new, Collectors.toList()));
 
         if (orderBy.equals(NAME_ASCENDING)) {
             return userCardinalMap.entrySet()
-                .stream()
-                .sorted(Comparator
-                    .comparingInt(((Map.Entry<User, List<UserCardinal>> entry) -> (StatusPriority.fromStatus(entry.getKey().getStatus())).getPriority())))
-                .map(entry -> {
-                    List<UserCardinal> userCardinals = userCardinalGetService.getUserCardinals(entry.getKey());
-                    return mapper.toAdminResponse(entry.getKey(), userCardinals);
-                })
-                .toList();
+                    .stream()
+                    .sorted(Comparator
+                            .comparingInt(((Map.Entry<User, List<UserCardinal>> entry) -> (StatusPriority.fromStatus(entry.getKey().getStatus())).getPriority())))
+                    .map(entry -> {
+                        List<UserCardinal> userCardinals = userCardinalGetService.getUserCardinals(entry.getKey());
+                        return mapper.toAdminResponse(entry.getKey(), userCardinals);
+                    })
+                    .toList();
         }
 
-        if(orderBy.equals(CARDINAL_DESCENDING)){
+        if (orderBy.equals(CARDINAL_DESCENDING)) {
 
             return userCardinalMap.entrySet()
-                .stream()
-                .sorted(Comparator
-                    .comparingInt(((Map.Entry<User, List<UserCardinal>> entry) -> (StatusPriority.fromStatus(entry.getKey().getStatus())).getPriority()))
-                    .thenComparing(entry -> entry.getValue().stream()
-                        .map(uc -> uc.getCardinal().getCardinalNumber())
-                        .max(Integer::compare)
-                        .orElse(-1), Comparator.reverseOrder()))
-                .map(entry -> {
-                    List<UserCardinal> userCardinals = userCardinalGetService.getUserCardinals(entry.getKey());
-                    return mapper.toAdminResponse(entry.getKey(), userCardinals);
-                })
-                .toList();
+                    .stream()
+                    .sorted(Comparator
+                            .comparingInt(((Map.Entry<User, List<UserCardinal>> entry) -> (StatusPriority.fromStatus(entry.getKey().getStatus())).getPriority()))
+                            .thenComparing(entry -> entry.getValue().stream()
+                                    .map(uc -> uc.getCardinal().getCardinalNumber())
+                                    .max(Integer::compare)
+                                    .orElse(-1), Comparator.reverseOrder()))
+                    .map(entry -> {
+                        List<UserCardinal> userCardinals = userCardinalGetService.getUserCardinals(entry.getKey());
+                        return mapper.toAdminResponse(entry.getKey(), userCardinals);
+                    })
+                    .toList();
         }
 
         return null;
@@ -89,23 +87,29 @@ public class UserManageUseCaseImpl implements UserManageUseCase {
 
     @Override
     @Transactional
-    public void accept(Long userId) {
-        User user = userGetService.find(userId);
+    public void accept(UserId userIds) {
+        List<User> users = userGetService.findAll(userIds.userId());
 
-        Integer cardinal = userCardinalGetService.getCurrentCardinal(user).getCardinalNumber();
+        users.forEach(user -> {
+            Integer cardinal = userCardinalGetService.getCurrentCardinal(user).getCardinalNumber();
 
-        if (user.isInactive()) {
-            userUpdateService.accept(user);
-            List<Meeting> meetings = meetingGetService.find(cardinal);
-            attendanceSaveService.init(user, meetings);
-        }
+            if (user.isInactive()) {
+                userUpdateService.accept(user);
+                List<Meeting> meetings = meetingGetService.find(cardinal);
+                attendanceSaveService.init(user, meetings);
+            }
+        });
     }
 
     @Override
-    public void update(Long userId, String role) {
-        User user = userGetService.find(userId);
-        userUpdateService.update(user, role);
-        jwtRedisService.updateRole(user.getId(), role);
+    @Transactional
+    public void update(List<UserRoleUpdate> requests) {
+        requests.forEach(request -> {
+            User user = userGetService.find(request.userId());
+
+            userUpdateService.update(user, request.role().name());
+            jwtRedisService.updateRole(user.getId(), request.role().name());
+        });
     }
 
     @Override
@@ -117,28 +121,33 @@ public class UserManageUseCaseImpl implements UserManageUseCase {
     }
 
     @Override
-    public void ban(Long userId) {
-        User user = userGetService.find(userId);
-        jwtRedisService.delete(user.getId());
-        userDeleteService.ban(user);
+    public void ban(UserId userIds) {
+        List<User> users = userGetService.findAll(userIds.userId());
+
+        users.forEach(user -> {
+            jwtRedisService.delete(user.getId());
+            userDeleteService.ban(user);
+        });
     }
 
     @Override
     @Transactional
-    public void applyOB(Long userId, Integer cardinal) {
-        User user = userGetService.find(userId);
-        Cardinal nextCardinal = cardinalGetService.find(cardinal);
+    public void applyOB(List<UserApplyOB> requests) {
+        requests.forEach(request -> {
+            User user = userGetService.find(request.userId());
+            Cardinal nextCardinal = cardinalGetService.find(request.cardinal());
 
-        if (userCardinalGetService.notContains(user, nextCardinal)) {
-            if (userCardinalGetService.isCurrent(user, nextCardinal)) {
-                user.initAttendance();
-                List<Meeting> meetings = meetingGetService.find(cardinal);
-                attendanceSaveService.init(user, meetings);
+            if (userCardinalGetService.notContains(user, nextCardinal)) {
+                if (userCardinalGetService.isCurrent(user, nextCardinal)) {
+                    user.initAttendance();
+                    List<Meeting> meetings = meetingGetService.find(request.cardinal());
+                    attendanceSaveService.init(user, meetings);
+                }
+                UserCardinal userCardinal = new UserCardinal(user, nextCardinal);
+
+                userCardinalSaveService.save(userCardinal);
             }
-            UserCardinal userCardinal = new UserCardinal(user, nextCardinal);
-
-            userCardinalSaveService.save(userCardinal);
-        }
+        });
     }
 
     @Override

--- a/src/main/java/leets/weeth/domain/user/domain/service/UserGetService.java
+++ b/src/main/java/leets/weeth/domain/user/domain/service/UserGetService.java
@@ -49,6 +49,10 @@ public class UserGetService {
         return userRepository.findAllByOrderByNameAsc();
     }
 
+    public List<User> findAll(List<Long> userId) {
+        return userRepository.findAllById(userId);
+    }
+
     public List<User> findAllByCardinal(Cardinal cardinal) {
         return userRepository.findAllByCardinalAndStatus(cardinal, Status.ACTIVE);
     }

--- a/src/main/java/leets/weeth/domain/user/presentation/UserAdminController.java
+++ b/src/main/java/leets/weeth/domain/user/presentation/UserAdminController.java
@@ -58,7 +58,7 @@ public class UserAdminController {
 
     @PatchMapping("/reset")
     @Operation(summary = "회원 비밀번호 초기화")
-    public CommonResponse<Void> resetPassword(@RequestParam Long userId) {
+    public CommonResponse<Void> resetPassword(@RequestBody UserId userId) {
         userManageUseCase.reset(userId);
         return CommonResponse.createSuccess(USER_PASSWORD_RESET_SUCCESS.getMessage());
     }

--- a/src/main/java/leets/weeth/domain/user/presentation/UserAdminController.java
+++ b/src/main/java/leets/weeth/domain/user/presentation/UserAdminController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+import static leets.weeth.domain.user.application.dto.request.UserRequestDto.*;
 import static leets.weeth.domain.user.application.dto.response.UserResponseDto.AdminResponse;
 import static leets.weeth.domain.user.presentation.ResponseMessage.*;
 
@@ -29,29 +30,29 @@ public class UserAdminController {
 
     @PatchMapping
     @Operation(summary = "가입 신청 승인")
-    public CommonResponse<Void> accept(@RequestParam Long userId) {
+    public CommonResponse<Void> accept(@RequestBody UserId userId) {
         userManageUseCase.accept(userId);
         return CommonResponse.createSuccess(USER_ACCEPT_SUCCESS.getMessage());
     }
 
     @DeleteMapping
     @Operation(summary = "유저 추방")
-    public CommonResponse<Void> ban(@RequestParam Long userId) {
+    public CommonResponse<Void> ban(@RequestBody UserId userId) {
         userManageUseCase.ban(userId);
         return CommonResponse.createSuccess(USER_BAN_SUCCESS.getMessage());
     }
 
     @PatchMapping("/role")
     @Operation(summary = "관리자로 승격/강등")
-    public CommonResponse<Void> update(@RequestParam Long userId, @RequestParam String role) {
-        userManageUseCase.update(userId, role);
+    public CommonResponse<Void> update(@RequestBody List<UserRoleUpdate> request) {
+        userManageUseCase.update(request);
         return CommonResponse.createSuccess(USER_ROLE_UPDATE_SUCCESS.getMessage());
     }
 
     @PatchMapping("/apply")
     @Operation(summary = "다음 기수도 이어서 진행")
-    public CommonResponse<Void> applyOB(@RequestParam Long userId, @RequestParam Integer cardinal) {
-        userManageUseCase.applyOB(userId, cardinal);
+    public CommonResponse<Void> applyOB(@RequestBody List<UserApplyOB> request) {
+        userManageUseCase.applyOB(request);
         return CommonResponse.createSuccess(USER_APPLY_OB_SUCCESS.getMessage());
     }
 


### PR DESCRIPTION
## PR 내용
- 어드민 페이지에서 여러 유저를 선택해서 요청을 보내게 되는 API를 리스트로 받도록 수정했습니다.
- 가입 승인,  관리자로 승격/강등,  다음 기수 진행,  유저 추방,  비밀번호 초기화를 리스트로 받도록 수정했습니다.
<br>

## PR 세부사항
- List<Long> userIds로 받으려고 했는데, 이렇게 되면 프론트에서 어떤 값을 보내는지 구분이 명확하지 않아서, 전부 body로 dto를 받도록 구현했습니다
<br>

## 관련 스크린샷
- 가입승인
<img width="355" alt="image" src="https://github.com/user-attachments/assets/997864d5-e102-4378-9f60-d382b69b4330" />

- 관리자로 승격/강등
<img width="381" alt="image" src="https://github.com/user-attachments/assets/05016ed6-b3cc-4691-aebb-c512a50d5828" />

- 다음 기수 진행
<img width="417" alt="image" src="https://github.com/user-attachments/assets/77c4052d-3b44-4d96-a2ab-8e055daed249" />

- 유저 추방
<img width="327" alt="image" src="https://github.com/user-attachments/assets/7ab2c1c7-6bbe-4f55-a7f4-c47814e9ad2f" />

- 비밀번호 초기화
<img width="412" alt="image" src="https://github.com/user-attachments/assets/f7653dc7-6242-44aa-a1b0-7910d5015522" />

<br>

## 주의사항
- 브랜치가 꼬였는지 이전 작업 커밋이 같이 포함이 됐네염.. 왜이러지 
<br>

## 체크 리스트

- [x] 리뷰어 설정
- [x] Assignee 설정
- [x] Label 설정
- [x] 제목 양식 맞췄나요? (ex. #0 Feat: 기능 추가)
- [x] 변경 사항에 대한 테스트