### PR TITLE
Refactor #141 패널티 반환 시 유저 기수도 함께 반환하도록 수정

### DIFF
--- a/src/main/java/leets/weeth/domain/penalty/application/dto/PenaltyDTO.java
+++ b/src/main/java/leets/weeth/domain/penalty/application/dto/PenaltyDTO.java
@@ -24,6 +24,7 @@ public class PenaltyDTO {
         Long userId,
         Integer penaltyCount,
         String name,
+        List<Integer> cardinals,
         List<PenaltyDTO.Penalties> Penalties
     ){}
 

--- a/src/main/java/leets/weeth/domain/penalty/application/mapper/PenaltyMapper.java
+++ b/src/main/java/leets/weeth/domain/penalty/application/mapper/PenaltyMapper.java
@@ -3,12 +3,15 @@ package leets.weeth.domain.penalty.application.mapper;
 import leets.weeth.domain.penalty.application.dto.PenaltyDTO;
 import leets.weeth.domain.penalty.domain.entity.Penalty;
 import leets.weeth.domain.user.domain.entity.User;
+import leets.weeth.domain.user.domain.entity.UserCardinal;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingConstants;
 import org.mapstruct.ReportingPolicy;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Mapper(componentModel = MappingConstants.ComponentModel.SPRING, unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface PenaltyMapper {
@@ -22,10 +25,21 @@ public interface PenaltyMapper {
 
     @Mapping(target = "Penalties", source = "penalties")
     @Mapping(target = "userId", source = "user.id")
-    PenaltyDTO.Response toPenaltyDto(User user, List<PenaltyDTO.Penalties> penalties);
+    @Mapping(target = "cardinals", expression = "java( toCardinalNumbers(userCardinals) )")
+    PenaltyDTO.Response toPenaltyDto(User user, List<PenaltyDTO.Penalties> penalties, List<UserCardinal> userCardinals);
 
     @Mapping(target = "time", source = "modifiedAt")
     @Mapping(target = "penaltyId", source = "id")
     PenaltyDTO.Penalties toPenalties(Penalty penalty);
+
+    default List<Integer> toCardinalNumbers(List<UserCardinal> userCardinals) {
+        if (userCardinals == null || userCardinals.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return userCardinals.stream()
+                .map(uc -> uc.getCardinal().getCardinalNumber())
+                .collect(Collectors.toList());
+    }
 
 }

--- a/src/main/java/leets/weeth/domain/penalty/application/usecase/PenaltyUsecaseImpl.java
+++ b/src/main/java/leets/weeth/domain/penalty/application/usecase/PenaltyUsecaseImpl.java
@@ -8,6 +8,8 @@ import leets.weeth.domain.penalty.domain.service.PenaltyDeleteService;
 import leets.weeth.domain.penalty.domain.service.PenaltyFindService;
 import leets.weeth.domain.penalty.domain.service.PenaltySaveService;
 import leets.weeth.domain.user.domain.entity.User;
+import leets.weeth.domain.user.domain.entity.UserCardinal;
+import leets.weeth.domain.user.domain.service.UserCardinalGetService;
 import leets.weeth.domain.user.domain.service.UserGetService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -26,6 +28,8 @@ public class PenaltyUsecaseImpl implements PenaltyUsecase{
     private final PenaltyDeleteService penaltyDeleteService;
 
     private final UserGetService userGetService;
+
+    private final UserCardinalGetService userCardinalGetService;
 
     private final PenaltyMapper mapper;
 
@@ -80,11 +84,13 @@ public class PenaltyUsecaseImpl implements PenaltyUsecase{
 
     private PenaltyDTO.Response toPenaltyDto(Long userId, List<Penalty> penalties) {
         User user = userGetService.find(userId);
+        List<UserCardinal> userCardinals = userCardinalGetService.getUserCardinals(user);
+
         List<PenaltyDTO.Penalties> penaltyDTOs = penalties.stream()
                 .map(mapper::toPenalties)
                 .toList();
 
-        return mapper.toPenaltyDto(user, penaltyDTOs);
+        return mapper.toPenaltyDto(user, penaltyDTOs, userCardinals);
     }
 
 }

--- a/src/main/java/leets/weeth/domain/penalty/presentation/PenaltyAdminController.java
+++ b/src/main/java/leets/weeth/domain/penalty/presentation/PenaltyAdminController.java
@@ -37,7 +37,7 @@ public class PenaltyAdminController {
     @GetMapping
     @Operation(summary="전체 패널티 조회")
     public CommonResponse<List<PenaltyDTO.Response>> findAll(){
-        return CommonResponse.createSuccess(PENALTY_FIND_ALL_SUCCESS.getMessage(),penaltyUsecase.find());
+        return CommonResponse.createSuccess(PENALTY_FIND_ALL_SUCCESS.getMessage(), penaltyUsecase.find());
     }
 
     @DeleteMapping


### PR DESCRIPTION
## PR 내용
- 어드민 페이지에서 패널티를 조회할 때 유저의 기수도 함께 반환하도록 수정했습니다.

<br>

## PR 세부사항
- 유저 정보를 조회하는 것과 동일한 방식으로 매퍼를 수정해서 구현했습니다
<br>

## 관련 스크린샷
<img width="405" alt="image" src="https://github.com/user-attachments/assets/6190ffbc-3fd2-461c-bbcd-9e69a49f5741" />

<br>

## 주의사항

<br>

## 체크 리스트

- [x] 리뷰어 설정
- [x] Assignee 설정
- [x] Label 설정
- [x] 제목 양식 맞췄나요? (ex. #0 Feat: 기능 추가)
- [x] 변경 사항에 대한 테스트