### PR TITLE
Refactor 144 어드민 페이지 기수 직접입력 수정

### DIFF
--- a/src/main/java/leets/weeth/domain/account/application/usecase/AccountUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/account/application/usecase/AccountUseCaseImpl.java
@@ -12,8 +12,10 @@ import leets.weeth.domain.account.domain.service.AccountSaveService;
 import leets.weeth.domain.file.application.dto.response.FileResponse;
 import leets.weeth.domain.file.application.mapper.FileMapper;
 import leets.weeth.domain.file.domain.service.FileGetService;
+import leets.weeth.domain.user.domain.service.CardinalGetService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -24,6 +26,7 @@ public class AccountUseCaseImpl implements AccountUseCase {
     private final AccountGetService accountGetService;
     private final AccountSaveService accountSaveService;
     private final FileGetService fileGetService;
+    private final CardinalGetService cardinalGetService;
     private final AccountMapper accountMapper;
     private final ReceiptMapper receiptMapper;
     private final FileMapper fileMapper;
@@ -40,8 +43,11 @@ public class AccountUseCaseImpl implements AccountUseCase {
     }
 
     @Override
+    @Transactional
     public void save(AccountDTO.Save dto) {
         validate(dto);
+        cardinalGetService.findByAdminSide(dto.cardinal());
+
         accountSaveService.save(accountMapper.from(dto));
     }
 

--- a/src/main/java/leets/weeth/domain/account/application/usecase/ReceiptUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/account/application/usecase/ReceiptUseCaseImpl.java
@@ -11,6 +11,7 @@ import leets.weeth.domain.file.domain.entity.File;
 import leets.weeth.domain.file.domain.service.FileDeleteService;
 import leets.weeth.domain.file.domain.service.FileGetService;
 import leets.weeth.domain.file.domain.service.FileSaveService;
+import leets.weeth.domain.user.domain.service.CardinalGetService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -30,6 +31,8 @@ public class ReceiptUseCaseImpl implements ReceiptUseCase {
     private final FileSaveService fileSaveService;
     private final FileDeleteService fileDeleteService;
 
+    private final CardinalGetService cardinalGetService;
+
     private final ReceiptMapper mapper;
     private final FileMapper fileMapper;
 
@@ -37,6 +40,8 @@ public class ReceiptUseCaseImpl implements ReceiptUseCase {
     @Override
     @Transactional
     public void save(ReceiptDTO.Save dto) {
+        cardinalGetService.findByAdminSide(dto.cardinal());
+
         Account account = accountGetService.find(dto.cardinal());
         Receipt receipt = receiptSaveService.save(mapper.from(dto, account));
         account.spend(receipt);

--- a/src/main/java/leets/weeth/domain/schedule/application/usecase/EventUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/schedule/application/usecase/EventUseCaseImpl.java
@@ -37,7 +37,7 @@ public class EventUseCaseImpl implements EventUseCase {
     @Transactional
     public void save(ScheduleDTO.Save dto, Long userId) {
         User user = userGetService.find(userId);
-        cardinalGetService.find(dto.cardinal());
+        cardinalGetService.findByUserSide(dto.cardinal());
 
         eventSaveService.save(mapper.from(dto, user));
     }

--- a/src/main/java/leets/weeth/domain/schedule/application/usecase/MeetingUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/schedule/application/usecase/MeetingUseCaseImpl.java
@@ -77,7 +77,7 @@ public class MeetingUseCaseImpl implements MeetingUseCase {
     @Transactional
     public void save(ScheduleDTO.Save dto, Long userId) {
         User user = userGetService.find(userId);
-        Cardinal cardinal = cardinalGetService.find(dto.cardinal());
+        Cardinal cardinal = cardinalGetService.findByUserSide(dto.cardinal());
 
         List<User> userList = userGetService.findAllByCardinal(cardinal);
 

--- a/src/main/java/leets/weeth/domain/user/application/dto/request/CardinalSaveRequest.java
+++ b/src/main/java/leets/weeth/domain/user/application/dto/request/CardinalSaveRequest.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.NotNull;
 public record CardinalSaveRequest (
         @NotNull Integer cardinalNumber,
         @NotNull Integer year,
-        @NotNull Integer semester
+        @NotNull Integer semester,
+        boolean inProgress
 ){
 }

--- a/src/main/java/leets/weeth/domain/user/application/dto/request/CardinalUpdateRequest.java
+++ b/src/main/java/leets/weeth/domain/user/application/dto/request/CardinalUpdateRequest.java
@@ -4,7 +4,6 @@ import jakarta.validation.constraints.NotNull;
 
 public record CardinalUpdateRequest(
         @NotNull Long id,
-        @NotNull Integer cardinalNumber,
         @NotNull Integer year,
         @NotNull Integer semester,
         boolean inProgress

--- a/src/main/java/leets/weeth/domain/user/application/dto/request/CardinalUpdateRequest.java
+++ b/src/main/java/leets/weeth/domain/user/application/dto/request/CardinalUpdateRequest.java
@@ -1,0 +1,11 @@
+package leets.weeth.domain.user.application.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record CardinalUpdateRequest(
+        @NotNull Long id,
+        @NotNull Integer cardinalNumber,
+        @NotNull Integer year,
+        @NotNull Integer semester
+) {
+}

--- a/src/main/java/leets/weeth/domain/user/application/dto/request/CardinalUpdateRequest.java
+++ b/src/main/java/leets/weeth/domain/user/application/dto/request/CardinalUpdateRequest.java
@@ -6,6 +6,7 @@ public record CardinalUpdateRequest(
         @NotNull Long id,
         @NotNull Integer cardinalNumber,
         @NotNull Integer year,
-        @NotNull Integer semester
+        @NotNull Integer semester,
+        boolean inProgress
 ) {
 }

--- a/src/main/java/leets/weeth/domain/user/application/dto/response/CardinalResponse.java
+++ b/src/main/java/leets/weeth/domain/user/application/dto/response/CardinalResponse.java
@@ -1,5 +1,7 @@
 package leets.weeth.domain.user.application.dto.response;
 
+import leets.weeth.domain.user.domain.entity.enums.CardinalStatus;
+
 import java.time.LocalDateTime;
 
 public record CardinalResponse(
@@ -7,6 +9,7 @@ public record CardinalResponse(
         Integer cardinalNumber,
         Integer year,
         Integer semester,
+        CardinalStatus status,
         LocalDateTime createdAt,
         LocalDateTime modifiedAt
 ) {

--- a/src/main/java/leets/weeth/domain/user/application/usecase/CardinalUseCase.java
+++ b/src/main/java/leets/weeth/domain/user/application/usecase/CardinalUseCase.java
@@ -35,7 +35,7 @@ public class CardinalUseCase {
 
     @Transactional
     public void update(CardinalUpdateRequest dto) {
-        Cardinal cardinal = cardinalGetService.findByAdminSide(dto.cardinalNumber());
+        Cardinal cardinal = cardinalGetService.findById(dto.id());
 
         cardinal.update(dto);
 

--- a/src/main/java/leets/weeth/domain/user/application/usecase/CardinalUseCase.java
+++ b/src/main/java/leets/weeth/domain/user/application/usecase/CardinalUseCase.java
@@ -1,7 +1,7 @@
 package leets.weeth.domain.user.application.usecase;
 
-import io.swagger.v3.oas.annotations.tags.Tag;
 import leets.weeth.domain.user.application.dto.request.CardinalSaveRequest;
+import leets.weeth.domain.user.application.dto.request.CardinalUpdateRequest;
 import leets.weeth.domain.user.application.dto.response.CardinalResponse;
 import leets.weeth.domain.user.application.mapper.CardinalMapper;
 import leets.weeth.domain.user.domain.entity.Cardinal;
@@ -27,6 +27,13 @@ public class CardinalUseCase {
         cardinalGetService.validateCardinal(dto.cardinalNumber());
 
         cardinalSaveService.save(cardinalMapper.from(dto));
+    }
+
+    @Transactional
+    public void update(CardinalUpdateRequest dto) {
+        Cardinal cardinal = cardinalGetService.find(dto.cardinalNumber());
+
+        cardinal.update(dto);
     }
 
     public List<CardinalResponse> findAll() {

--- a/src/main/java/leets/weeth/domain/user/application/usecase/CardinalUseCase.java
+++ b/src/main/java/leets/weeth/domain/user/application/usecase/CardinalUseCase.java
@@ -35,7 +35,7 @@ public class CardinalUseCase {
 
     @Transactional
     public void update(CardinalUpdateRequest dto) {
-        Cardinal cardinal = cardinalGetService.find(dto.cardinalNumber());
+        Cardinal cardinal = cardinalGetService.findByAdminSide(dto.cardinalNumber());
 
         cardinal.update(dto);
 

--- a/src/main/java/leets/weeth/domain/user/application/usecase/CardinalUseCase.java
+++ b/src/main/java/leets/weeth/domain/user/application/usecase/CardinalUseCase.java
@@ -26,7 +26,11 @@ public class CardinalUseCase {
     public void save(CardinalSaveRequest dto) {
         cardinalGetService.validateCardinal(dto.cardinalNumber());
 
-        cardinalSaveService.save(cardinalMapper.from(dto));
+        Cardinal cardinal = cardinalSaveService.save(cardinalMapper.from(dto));
+
+        if (dto.inProgress()) {
+            updateCardinalStatus(cardinal);
+        }
     }
 
     @Transactional
@@ -34,6 +38,10 @@ public class CardinalUseCase {
         Cardinal cardinal = cardinalGetService.find(dto.cardinalNumber());
 
         cardinal.update(dto);
+
+        if (dto.inProgress()) {
+            updateCardinalStatus(cardinal);
+        }
     }
 
     public List<CardinalResponse> findAll() {
@@ -41,5 +49,15 @@ public class CardinalUseCase {
         return cardinals.stream()
                 .map(cardinalMapper::to)
                 .toList();
+    }
+
+    private void updateCardinalStatus(Cardinal cardinal) {
+        List<Cardinal> cardinals = cardinalGetService.findInProgress();
+
+        if (!cardinals.isEmpty()) {
+            cardinals.forEach(Cardinal::done);
+        }
+
+        cardinal.inProgress();
     }
 }

--- a/src/main/java/leets/weeth/domain/user/application/usecase/UserManageUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/user/application/usecase/UserManageUseCaseImpl.java
@@ -135,7 +135,7 @@ public class UserManageUseCaseImpl implements UserManageUseCase {
     public void applyOB(List<UserApplyOB> requests) {
         requests.forEach(request -> {
             User user = userGetService.find(request.userId());
-            Cardinal nextCardinal = cardinalGetService.find(request.cardinal());
+            Cardinal nextCardinal = cardinalGetService.findByAdminSide(request.cardinal());
 
             if (userCardinalGetService.notContains(user, nextCardinal)) {
                 if (userCardinalGetService.isCurrent(user, nextCardinal)) {

--- a/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/user/application/usecase/UserUseCaseImpl.java
@@ -107,7 +107,7 @@ public class UserUseCaseImpl implements UserUseCase {
             users = userGetService.findAll(pageable);
 
         } else {
-            Cardinal inputCardinal = cardinalGetService.find(cardinal);
+            Cardinal inputCardinal = cardinalGetService.findByUserSide(cardinal);
             users = userGetService.findAll(pageable, inputCardinal);
         }
 
@@ -149,7 +149,7 @@ public class UserUseCaseImpl implements UserUseCase {
     public void apply(SignUp dto) {
         validate(dto);
 
-        Cardinal cardinal = cardinalGetService.find(dto.cardinal());
+        Cardinal cardinal = cardinalGetService.findByUserSide(dto.cardinal());
         User user = mapper.from(dto, passwordEncoder);
         UserCardinal userCardinal = new UserCardinal(user, cardinal);
 
@@ -162,7 +162,7 @@ public class UserUseCaseImpl implements UserUseCase {
     public void socialRegister(Register dto) {
         validate(dto);
 
-        Cardinal cardinal = cardinalGetService.find(dto.cardinal());
+        Cardinal cardinal = cardinalGetService.findByUserSide(dto.cardinal());
 
         User user = mapper.from(dto);
         UserCardinal userCardinal = new UserCardinal(user, cardinal);

--- a/src/main/java/leets/weeth/domain/user/domain/entity/Cardinal.java
+++ b/src/main/java/leets/weeth/domain/user/domain/entity/Cardinal.java
@@ -2,8 +2,10 @@ package leets.weeth.domain.user.domain.entity;
 
 import jakarta.persistence.*;
 import leets.weeth.domain.user.application.dto.request.CardinalUpdateRequest;
+import leets.weeth.domain.user.domain.entity.enums.CardinalStatus;
 import leets.weeth.global.common.entity.BaseEntity;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
@@ -26,9 +28,21 @@ public class Cardinal extends BaseEntity {
 
     private Integer semester;
 
+    @Builder.Default
+    @Enumerated(EnumType.STRING)
+    CardinalStatus status = CardinalStatus.DONE;
+
     public void update(CardinalUpdateRequest dto) {
         this.year = dto.year();
         this.semester = dto.semester();
+    }
+
+    public void inProgress() {
+        this.status = CardinalStatus.IN_PROGRESS;
+    }
+
+    public void done() {
+        this.status = CardinalStatus.DONE;
     }
 
 }

--- a/src/main/java/leets/weeth/domain/user/domain/entity/Cardinal.java
+++ b/src/main/java/leets/weeth/domain/user/domain/entity/Cardinal.java
@@ -1,6 +1,7 @@
 package leets.weeth.domain.user.domain.entity;
 
 import jakarta.persistence.*;
+import leets.weeth.domain.user.application.dto.request.CardinalUpdateRequest;
 import leets.weeth.global.common.entity.BaseEntity;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -24,4 +25,10 @@ public class Cardinal extends BaseEntity {
     private Integer year;
 
     private Integer semester;
+
+    public void update(CardinalUpdateRequest dto) {
+        this.year = dto.year();
+        this.semester = dto.semester();
+    }
+
 }

--- a/src/main/java/leets/weeth/domain/user/domain/entity/enums/CardinalStatus.java
+++ b/src/main/java/leets/weeth/domain/user/domain/entity/enums/CardinalStatus.java
@@ -1,0 +1,5 @@
+package leets.weeth.domain.user.domain.entity.enums;
+
+public enum CardinalStatus {
+    IN_PROGRESS, DONE
+}

--- a/src/main/java/leets/weeth/domain/user/domain/repository/CardinalRepository.java
+++ b/src/main/java/leets/weeth/domain/user/domain/repository/CardinalRepository.java
@@ -1,8 +1,10 @@
 package leets.weeth.domain.user.domain.repository;
 
 import leets.weeth.domain.user.domain.entity.Cardinal;
+import leets.weeth.domain.user.domain.entity.enums.CardinalStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface CardinalRepository extends JpaRepository<Cardinal, Long> {
@@ -10,4 +12,6 @@ public interface CardinalRepository extends JpaRepository<Cardinal, Long> {
     Optional<Cardinal> findByCardinalNumber(Integer cardinal);
 
     Optional<Cardinal> findByYearAndSemester(Integer year, Integer semester);
+
+    List<Cardinal> findAllByStatus(CardinalStatus cardinalStatus);
 }

--- a/src/main/java/leets/weeth/domain/user/domain/service/CardinalGetService.java
+++ b/src/main/java/leets/weeth/domain/user/domain/service/CardinalGetService.java
@@ -3,6 +3,7 @@ package leets.weeth.domain.user.domain.service;
 import leets.weeth.domain.user.application.exception.CardinalNotFoundException;
 import leets.weeth.domain.user.application.exception.DuplicateCardinalException;
 import leets.weeth.domain.user.domain.entity.Cardinal;
+import leets.weeth.domain.user.domain.entity.enums.CardinalStatus;
 import leets.weeth.domain.user.domain.repository.CardinalRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -27,6 +28,10 @@ public class CardinalGetService {
 
     public List<Cardinal> findAll() {
         return cardinalRepository.findAll();
+    }
+
+    public List<Cardinal> findInProgress() {
+        return cardinalRepository.findAllByStatus(CardinalStatus.IN_PROGRESS);
     }
 
     public void validateCardinal(Integer cardinal) {

--- a/src/main/java/leets/weeth/domain/user/domain/service/CardinalGetService.java
+++ b/src/main/java/leets/weeth/domain/user/domain/service/CardinalGetService.java
@@ -31,6 +31,11 @@ public class CardinalGetService {
                 .orElseThrow(CardinalNotFoundException::new);
     }
 
+    public Cardinal findById(long cardinalId) {
+        return cardinalRepository.findById(cardinalId)
+                .orElseThrow(CardinalNotFoundException::new);
+    }
+
     public List<Cardinal> findAll() {
         return cardinalRepository.findAll();
     }

--- a/src/main/java/leets/weeth/domain/user/domain/service/CardinalGetService.java
+++ b/src/main/java/leets/weeth/domain/user/domain/service/CardinalGetService.java
@@ -16,7 +16,12 @@ public class CardinalGetService {
 
     private final CardinalRepository cardinalRepository;
 
-    public Cardinal find(Integer cardinal) {
+    public Cardinal findByAdminSide(Integer cardinal) {
+        return cardinalRepository.findByCardinalNumber(cardinal)
+                .orElse(cardinalRepository.save(Cardinal.builder().cardinalNumber(cardinal).build()));
+    }
+
+    public Cardinal findByUserSide(Integer cardinal) {
         return cardinalRepository.findByCardinalNumber(cardinal)
                 .orElseThrow(CardinalNotFoundException::new);
     }

--- a/src/main/java/leets/weeth/domain/user/domain/service/CardinalSaveService.java
+++ b/src/main/java/leets/weeth/domain/user/domain/service/CardinalSaveService.java
@@ -11,7 +11,7 @@ public class CardinalSaveService {
 
     private final CardinalRepository cardinalRepository;
 
-    public void save(Cardinal cardinal) {
-        cardinalRepository.save(cardinal);
+    public Cardinal save(Cardinal cardinal) {
+        return cardinalRepository.save(cardinal);
     }
 }

--- a/src/main/java/leets/weeth/domain/user/presentation/CardinalController.java
+++ b/src/main/java/leets/weeth/domain/user/presentation/CardinalController.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import leets.weeth.domain.user.application.dto.request.CardinalSaveRequest;
+import leets.weeth.domain.user.application.dto.request.CardinalUpdateRequest;
 import leets.weeth.domain.user.application.dto.response.CardinalResponse;
 import leets.weeth.domain.user.application.usecase.CardinalUseCase;
 import leets.weeth.global.common.response.CommonResponse;
@@ -12,8 +13,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-import static leets.weeth.domain.user.presentation.ResponseMessage.CARDINAL_FIND_ALL_SUCCESS;
-import static leets.weeth.domain.user.presentation.ResponseMessage.CARDINAL_SAVE_SUCCESS;
+import static leets.weeth.domain.user.presentation.ResponseMessage.*;
 
 @Tag(name = "CARDINAL")
 @RestController
@@ -29,6 +29,14 @@ public class CardinalController {
         List<CardinalResponse> response = cardinalUseCase.findAll();
 
         return CommonResponse.createSuccess(CARDINAL_FIND_ALL_SUCCESS.getMessage(), response);
+    }
+
+    @PatchMapping("/admin/cardinals")
+    @Operation(summary = "[admin] 기수 정보 수정 API")
+    public CommonResponse<Void> updateCardinals(@RequestBody CardinalUpdateRequest dto) {
+        cardinalUseCase.update(dto);
+
+        return CommonResponse.createSuccess(CARDINAL_UPDATE_SUCCESS.getMessage());
     }
 
     @PostMapping("/admin/cardinals")

--- a/src/main/java/leets/weeth/domain/user/presentation/ResponseMessage.java
+++ b/src/main/java/leets/weeth/domain/user/presentation/ResponseMessage.java
@@ -28,7 +28,8 @@ public enum ResponseMessage {
 
     // CardinalController 관련
     CARDINAL_FIND_ALL_SUCCESS("전체 기수 조회에 성공했습니다."),
-    CARDINAL_SAVE_SUCCESS("기수 저장에 성공했습니다.");
+    CARDINAL_SAVE_SUCCESS("기수 저장에 성공했습니다."),
+    CARDINAL_UPDATE_SUCCESS("기수 수정에 성공했습니다.");
 
     private final String message;
 }


### PR DESCRIPTION
## PR 내용
- 어드민 페이지에서 기수 변경, 총 회비 등록 등 없는 기수를 직접 입력하는 경우 임시 Cardinal 객체를 생성하도록 수정했습니다.
- 임시 생성된 객체는 CardinalNumber만 지니며, 년도, 학기 정보를 지니지 않고, 어드민 페이지에서 해당 값을 넣어서 수정하는 경우 완전한 객체가 됩니다.
- 이 로직은 어드민 페이지에서 기수를 입력하는 경우만 동작하기 때문에 `findByAdminSide, findByUserSide`로 메서드를 구분하였습니다. 차후 해당 메서드 사용시 이를 인지해주시기 바랍니다. (`findByUserSide`는 기존 `find` 메서드처럼 잘못 입력되면 예외를 반환합니다.)

- 차후 기능 확장을 고려해 CardinalGetService를 수정해 전역적으로 해당 로직을 처리할 수 있게 구현했습니다. 약간의 책임이 많아지는 문제는 있지만, 이 방식 외의 더 좋은 방식이 떠오르지 않았습니다..
- 또 요구사항에 맞게 "현재 진행 중"인 기수를 구분하기 위해 status를 추가했습니다.
- 현재 진행 중인 기수는 하나 밖에 없기 때문에 이를 보장할 수 있게 구현했습니다.

<br>

## PR 세부사항
- 기수 입력을 사용하는 부분. 아래 부분에 모두 `CardinalGetService`를 의존하도록 수정했습니다.
  - 기수변경
  - 계좌
  - 영수증
  - 일정
  - 정기모임
  - 회원가입
  - 기수 저장

- 기수 수정 시 Cardinal id를 받고, 잘못된 입력으로 임시 객체의 CardinalNumber를 수정하지 못하도록 dto에서 제거했습니다.
<br>

## 관련 스크린샷
<img width="412" alt="image" src="https://github.com/user-attachments/assets/82e313b9-58d0-4a55-816b-089f8f25c67a" />

<img width="395" alt="image" src="https://github.com/user-attachments/assets/c4443608-c280-4d52-a123-a68f9bb42216" />

<img width="438" alt="image" src="https://github.com/user-attachments/assets/57ff99fa-da85-42c7-bd27-01c859408555" />

<br>

## 주의사항

<br>

## 체크 리스트

- [x] 리뷰어 설정
- [x] Assignee 설정
- [x] Label 설정
- [x] 제목 양식 맞췄나요? (ex. #0 Feat: 기능 추가)
- [x] 변경 사항에 대한 테스트