### PR TITLE
fix #146 내 패널티 정보 조회 수정

### DIFF
--- a/src/main/java/leets/weeth/domain/penalty/application/usecase/PenaltyUsecaseImpl.java
+++ b/src/main/java/leets/weeth/domain/penalty/application/usecase/PenaltyUsecaseImpl.java
@@ -64,7 +64,7 @@ public class PenaltyUsecaseImpl implements PenaltyUsecase{
     @Override
     public PenaltyDTO.Response find(Long userId) {
         User user = userGetService.find(userId);
-        List<Penalty> penalties = penaltyFindService.findAll();
+        List<Penalty> penalties = penaltyFindService.findAll(userId);
 
         return toPenaltyDto(userId, penalties);
     }


### PR DESCRIPTION
## PR 내용
#145 
본인(특정 Id) 패널티 조회에서 모든 패널티가 조회되는 문제를 수정했습니다
<br>

## PR 세부사항
PenaltyUsecaseImpl에서 본인 패널티 조회시 기존에 있던 userId를 사용하는 올바른 findAll 메서드를 
사용하도록 수정했습니다
<br>

## 관련 스크린샷
![image](https://github.com/user-attachments/assets/2d6313cc-e1cc-4fc7-8112-9baf423ab10f)
<img width="1061" alt="image" src="https://github.com/user-attachments/assets/5e266c01-b8b1-4617-b511-8c52cd2061c4" />

<br>

## 주의사항
조회하는 유저의 패널티와 다른 유저의 패널티 더미데이터로 넣어놓고 테스트 완료했습니다
<br>

## 체크 리스트

- [x] 리뷰어 설정
- [x] Assignee 설정
- [x] Label 설정
- [x] 제목 양식 맞췄나요? (ex. #0 Feat: 기능 추가)
- [x] 변경 사항에 대한 테스트