### PR TITLE
Refactor #150 게시판 관련 엔드포인트 수정

### DIFF
--- a/src/main/java/leets/weeth/domain/board/presentation/PostController.java
+++ b/src/main/java/leets/weeth/domain/board/presentation/PostController.java
@@ -19,7 +19,7 @@ import static leets.weeth.domain.board.presentation.ResponseMessage.*;
 @Tag(name = "BOARD", description = "게시판 API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/posts")
+@RequestMapping("/api/v1/boards")
 public class PostController {
 
     private final PostUsecase postUsecase;
@@ -39,25 +39,25 @@ public class PostController {
         return CommonResponse.createSuccess(POST_FIND_ALL_SUCCESS.getMessage(), postUsecase.findPosts(pageNumber, pageSize));
     }
 
-    @GetMapping("/{postId}")
+    @GetMapping("/{boardId}")
     @Operation(summary="특정 게시글 조회")
-    public CommonResponse<PostDTO.Response> findPost(@PathVariable Long postId) {
-        return CommonResponse.createSuccess(POST_FIND_BY_ID_SUCCESS.getMessage(),postUsecase.findPost(postId));
+    public CommonResponse<PostDTO.Response> findPost(@PathVariable Long boardId) {
+        return CommonResponse.createSuccess(POST_FIND_BY_ID_SUCCESS.getMessage(),postUsecase.findPost(boardId));
     }
 
-    @PatchMapping(value = "/{postId}")
+    @PatchMapping(value = "/{boardId}")
     @Operation(summary="특정 게시글 수정")
-    public CommonResponse<String> update(@PathVariable Long postId,
+    public CommonResponse<String> update(@PathVariable Long boardId,
                                          @RequestBody @Valid PostDTO.Update dto,
                                          @Parameter(hidden = true) @CurrentUser Long userId) throws UserNotMatchException {
-        postUsecase.update(postId, dto, userId);
+        postUsecase.update(boardId, dto, userId);
         return CommonResponse.createSuccess(POST_UPDATED_SUCCESS.getMessage());
     }
 
-    @DeleteMapping("/{postId}")
+    @DeleteMapping("/{boardId}")
     @Operation(summary="특정 게시글 삭제")
-    public CommonResponse<String> delete(@PathVariable Long postId, @Parameter(hidden = true) @CurrentUser Long userId) throws UserNotMatchException {
-        postUsecase.delete(postId, userId);
+    public CommonResponse<String> delete(@PathVariable Long boardId, @Parameter(hidden = true) @CurrentUser Long userId) throws UserNotMatchException {
+        postUsecase.delete(boardId, userId);
         return CommonResponse.createSuccess(POST_DELETED_SUCCESS.getMessage());
     }
 

--- a/src/main/java/leets/weeth/domain/comment/presentation/PostCommentController.java
+++ b/src/main/java/leets/weeth/domain/comment/presentation/PostCommentController.java
@@ -16,27 +16,27 @@ import leets.weeth.global.common.response.CommonResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "COMMENT-POST", description = "게시판 댓글 API")
+@Tag(name = "COMMENT-BOARD", description = "게시판 댓글 API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/posts/{postId}/comments")
+@RequestMapping("/api/v1/boards/{boardId}/comments")
 public class PostCommentController {
 
     private final PostCommentUsecase postCommentUsecase;
 
     @PostMapping
     @Operation(summary="게시글 댓글 작성")
-    public CommonResponse<String> savePostComment(@RequestBody @Valid CommentDTO.Save dto, @PathVariable Long postId,
+    public CommonResponse<String> savePostComment(@RequestBody @Valid CommentDTO.Save dto, @PathVariable Long boardId,
                                                   @Parameter(hidden = true) @CurrentUser Long userId) {
-        postCommentUsecase.savePostComment(dto, postId, userId);
+        postCommentUsecase.savePostComment(dto, boardId, userId);
         return CommonResponse.createSuccess(POST_COMMENT_CREATED_SUCCESS.getMessage());
     }
 
     @PatchMapping("/{commentId}")
     @Operation(summary="게시글 댓글 수정")
-    public CommonResponse<String> updatePostComment(@RequestBody @Valid CommentDTO.Update dto, @PathVariable Long postId, @PathVariable Long commentId,
+    public CommonResponse<String> updatePostComment(@RequestBody @Valid CommentDTO.Update dto, @PathVariable Long boardId, @PathVariable Long commentId,
                                                     @Parameter(hidden = true) @CurrentUser Long userId) throws UserNotMatchException {
-        postCommentUsecase.updatePostComment(dto, postId, commentId, userId);
+        postCommentUsecase.updatePostComment(dto, boardId, commentId, userId);
         return CommonResponse.createSuccess(POST_COMMENT_UPDATED_SUCCESS.getMessage());
     }
 


### PR DESCRIPTION
## PR 내용
게시판 관련 엔드포인트 수정
<br>

## PR 세부사항
현재 저희 엔티티 구조가 Post 엔티티는 Board를 상속받고 Board의 id 필드를 그대로 사용하고 있어서, 
내부적인 로직 수정없이 컨트롤러단에서만 수정해주었습니다

개인적인 의견으론 Post와 Board를 5기 QA 후에 리팩토링 할때 한번에 수정하는 것도 좋아보입니다

<br>

## 관련 스크린샷

게시판 관련(생성, 수정, 삭제, 조회 테스트 완료)
![image](https://github.com/user-attachments/assets/f79e8970-2ecd-4dae-afac-4b571656ccb9)
![image](https://github.com/user-attachments/assets/48d4e93f-d90f-4859-8cbb-22fec4ec98ed)
![image](https://github.com/user-attachments/assets/ba0b49ad-a1e3-4959-882a-71c83b923574)

---

게시판 댓글 관련(댓글, 대댓글, 수정, 삭제 테스트 완료)
![image](https://github.com/user-attachments/assets/d7b72c71-008c-497d-bf73-6c22f454bec7)

<br>

## 주의사항
테스트까지 완료했으나, 빠진 부분이나 잘못된거 없는지 꼼꼼히 봐주시면 감사하겠습니당
<br>

## 체크 리스트

- [x] 리뷰어 설정
- [x] Assignee 설정
- [x] Label 설정
- [x] 제목 양식 맞췄나요? (ex. #0 Feat: 기능 추가)
- [x] 변경 사항에 대한 테스트