### PR TITLE
fix #152 출석 횟수와 동시에 결석횟수 처리하도록 수정

### DIFF
--- a/src/main/java/leets/weeth/domain/attendance/application/usecase/AttendanceUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/attendance/application/usecase/AttendanceUseCaseImpl.java
@@ -113,9 +113,11 @@ public class AttendanceUseCaseImpl implements AttendanceUseCase {
             if (attendance.getStatus() == Status.ATTEND) {
                 attendance.close();
                 user.removeAttend();
+                user.absent();
             } else {
                 attendance.attend();
                 user.removeAbsent();
+                user.attend();
             }
         });
     }


### PR DESCRIPTION
## PR 내용
출석 횟수와 동시에 결석횟수 처리하도록 수정
<br>

## PR 세부사항
어드민 페이지에서에서 단일 출석 변경 로직에서 출석률이 0으로 초기화 되어 재계산 되지않는 문제 발생하여 
출석 횟수와 동시에 결석횟수 처리하도록 수정하여 해결하였습니다

<br>

## 관련 스크린샷

결석(ABSENT) 상태인 출석 객체
![image](https://github.com/user-attachments/assets/233d3dd6-c328-47de-a010-5792f6367b80)
![image](https://github.com/user-attachments/assets/1867234c-fa81-4f5e-81d9-d6f94aecdd48)

결석 횟수 1, 출석률 0%
![image](https://github.com/user-attachments/assets/fe5ae694-2ef1-4b49-9034-871630d0215c)

---

출석으로 상태 변경 후
![image](https://github.com/user-attachments/assets/c1355927-7836-418d-9f34-b679b9323185)

ATTEND로 변경됨
![image](https://github.com/user-attachments/assets/942af628-c4ff-4249-89a8-ebe02a23cdcb)

출석 횟수 1, 출석률 100%
![image](https://github.com/user-attachments/assets/033a91b5-49ad-4034-8fb3-bd78f97b9ac1)


<br>

## 주의사항

ATTEND-> ABSENT 로 바꾸는 케이스도 테스트 완료했습니당

<br>

## 체크 리스트

- [x] 리뷰어 설정
- [x] Assignee 설정
- [x] Label 설정
- [x] 제목 양식 맞췄나요? (ex. #0 Feat: 기능 추가)
- [x] 변경 사항에 대한 테스트