### PR TITLE
Refactor #154 멤버가 한 명도 없는 경우 예외처리

### DIFF
--- a/src/main/java/leets/weeth/domain/user/domain/service/UserGetService.java
+++ b/src/main/java/leets/weeth/domain/user/domain/service/UserGetService.java
@@ -41,14 +41,6 @@ public class UserGetService {
         return !userRepository.existsByEmail(email);
     }
 
-    public List<User> findAllByStatus(Status status) {
-        return userRepository.findAllByStatusOrderByName(status);
-    }
-
-    public List<User> findAll() {
-        return userRepository.findAllByOrderByNameAsc();
-    }
-
     public List<User> findAll(List<Long> userId) {
         return userRepository.findAllById(userId);
     }
@@ -58,11 +50,23 @@ public class UserGetService {
     }
 
     public Slice<User> findAll(Pageable pageable) {
-        return userRepository.findAllByStatusOrderedByCardinalAndName(Status.ACTIVE, pageable);
+        Slice<User> users = userRepository.findAllByStatusOrderedByCardinalAndName(Status.ACTIVE, pageable);
+
+        if (users.isEmpty()) {
+            throw new UserNotFoundException();
+        }
+
+        return users;
     }
 
     public Slice<User> findAll(Pageable pageable, Cardinal cardinal) {
-        return userRepository.findAllByCardinalOrderByNameAsc(Status.ACTIVE, cardinal, pageable);
+        Slice<User> users = userRepository.findAllByCardinalOrderByNameAsc(Status.ACTIVE, cardinal, pageable);
+
+        if (users.isEmpty()) {
+            throw new UserNotFoundException();
+        }
+
+        return users;
     }
 
     public boolean validateStudentId(String studentId) {


### PR DESCRIPTION
## PR 내용
- 멤버 조회시 findAll 메서드에서 빈 리스트가 오는 경우 예외처리를 추가했습니다.
<br>

## PR 세부사항
- 빈 리스트인지 체크해서 예외를 날려주도록 했습니다
- 멤버 조회시 사용하는 메서드가 기수 없이 전체 조회, 기수 함께 조회 이렇게 2개라서 2가지 모두 동일하게 해주었습니다.
- 공통된 로직을 따로 빼기에는 메서드 별로 관리하는게 나을 것 같아 우선 동일하게 작성해뒀습니다.
<br>

## 관련 스크린샷
<img width="389" alt="image" src="https://github.com/user-attachments/assets/68533dee-614c-4072-a6da-fcad722d9cd6" />

<br>

## 주의사항
- 기존에 사용하지 않던 메서드들을 제거했습니당.
<br>

## 체크 리스트

- [x] 리뷰어 설정
- [x] Assignee 설정
- [x] Label 설정
- [x] 제목 양식 맞췄나요? (ex. #0 Feat: 기능 추가)
- [x] 변경 사항에 대한 테스트