### PR TITLE
Refactor #158 기수 정보 조회 시 기수 크기로 정렬한 후 반환

### DIFF
--- a/src/main/java/leets/weeth/domain/user/domain/repository/CardinalRepository.java
+++ b/src/main/java/leets/weeth/domain/user/domain/repository/CardinalRepository.java
@@ -14,4 +14,6 @@ public interface CardinalRepository extends JpaRepository<Cardinal, Long> {
     Optional<Cardinal> findByYearAndSemester(Integer year, Integer semester);
 
     List<Cardinal> findAllByStatus(CardinalStatus cardinalStatus);
+
+    List<Cardinal> findAllByOrderByCardinalNumberDesc();
 }

--- a/src/main/java/leets/weeth/domain/user/domain/repository/UserCardinalRepository.java
+++ b/src/main/java/leets/weeth/domain/user/domain/repository/UserCardinalRepository.java
@@ -1,6 +1,5 @@
 package leets.weeth.domain.user.domain.repository;
 
-import leets.weeth.domain.user.domain.entity.Cardinal;
 import leets.weeth.domain.user.domain.entity.User;
 import leets.weeth.domain.user.domain.entity.UserCardinal;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,9 +9,9 @@ import java.util.List;
 
 public interface UserCardinalRepository extends JpaRepository<UserCardinal, Long> {
 
-    List<UserCardinal> findAllByUser(User user);
+    List<UserCardinal> findAllByUserOrderByCardinalCardinalNumberDesc(User user);
 
-    @Query("SELECT uc FROM UserCardinal uc WHERE uc.user IN :users")
+    @Query("SELECT uc FROM UserCardinal uc WHERE uc.user IN :users ORDER BY uc.user.id, uc.cardinal.cardinalNumber DESC")
     List<UserCardinal> findAllByUsers(List<User> users);
 
 	List<UserCardinal> findAllByOrderByUser_NameAsc();

--- a/src/main/java/leets/weeth/domain/user/domain/service/CardinalGetService.java
+++ b/src/main/java/leets/weeth/domain/user/domain/service/CardinalGetService.java
@@ -37,7 +37,7 @@ public class CardinalGetService {
     }
 
     public List<Cardinal> findAll() {
-        return cardinalRepository.findAll();
+        return cardinalRepository.findAllByOrderByCardinalNumberDesc();
     }
 
     public List<Cardinal> findInProgress() {

--- a/src/main/java/leets/weeth/domain/user/domain/service/UserCardinalGetService.java
+++ b/src/main/java/leets/weeth/domain/user/domain/service/UserCardinalGetService.java
@@ -18,7 +18,7 @@ public class UserCardinalGetService {
     private final UserCardinalRepository userCardinalRepository;
 
     public List<UserCardinal> getUserCardinals(User user) {
-        return userCardinalRepository.findAllByUser(user);
+        return userCardinalRepository.findAllByUserOrderByCardinalCardinalNumberDesc(user);
     }
 
     public List<UserCardinal> findAll() {


### PR DESCRIPTION
## PR 내용
- 프론트 페이지에서 기수가 정렬되지 않게 보이는 문제가 있어서, 서버에서 전역적으로 정렬된 상태로 보내도록 수정했습니다.
<br>

## PR 세부사항
- 메모리 상에 올려두고 정렬을 하기엔 응답속도 저하가 생길거라 판단해 쿼리 단에서 정렬해서 가져오도록 수정 했습니다
<br>

## 관련 스크린샷
- 작업 전
<img width="430" alt="image" src="https://github.com/user-attachments/assets/b8b124fb-f324-4421-9453-e21d76e79bab" />

- 작업 후 
<img width="453" alt="image" src="https://github.com/user-attachments/assets/a65c9d60-803e-486a-bbff-82881edcaf4c" />

<br>

## 주의사항
X
<br>

## 체크 리스트

- [x] 리뷰어 설정
- [x] Assignee 설정
- [x] Label 설정
- [x] 제목 양식 맞췄나요? (ex. #0 Feat: 기능 추가)
- [x] 변경 사항에 대한 테스트