### PR TITLE
 Refactor #165 어드민 단일 출석 변경 수정 

### DIFF
--- a/src/main/java/leets/weeth/domain/attendance/application/usecase/AttendanceUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/attendance/application/usecase/AttendanceUseCaseImpl.java
@@ -110,7 +110,9 @@ public class AttendanceUseCaseImpl implements AttendanceUseCase {
             Attendance attendance = attendanceGetService.findByAttendanceId(update.attendanceId());
             User user = attendance.getUser();
 
-            if (attendance.getStatus() == Status.ATTEND) {
+            Status newStatus = Status.valueOf(update.status());
+
+            if (newStatus == Status.ABSENT) {
                 attendance.close();
                 user.removeAttend();
                 user.absent();

--- a/src/main/java/leets/weeth/domain/attendance/presentation/AttendanceAdminController.java
+++ b/src/main/java/leets/weeth/domain/attendance/presentation/AttendanceAdminController.java
@@ -2,6 +2,7 @@ package leets.weeth.domain.attendance.presentation;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import leets.weeth.domain.attendance.application.dto.AttendanceDTO;
 import leets.weeth.domain.attendance.application.usecase.AttendanceUseCase;
 import leets.weeth.domain.schedule.application.dto.MeetingDTO;
@@ -47,7 +48,7 @@ public class AttendanceAdminController {
 
     @PatchMapping("/status")
     @Operation(summary = "모든 인원 정기모임 개별 출석 상태 수정")
-    public CommonResponse<Void> updateAttendanceStatus(@RequestBody List<AttendanceDTO.UpdateStatus> attendanceUpdates) {
+    public CommonResponse<Void> updateAttendanceStatus(@RequestBody @Valid List<AttendanceDTO.UpdateStatus> attendanceUpdates) {
         attendanceUseCase.updateAttendanceStatus(attendanceUpdates);
         return CommonResponse.createSuccess(ATTENDANCE_UPDATED_SUCCESS.getMessage());
     }


### PR DESCRIPTION
## PR 내용
어드민 단일 출석 변경 수정 
<br>

## PR 세부사항
attendance를 getStatus로 가져오기보다는, DTO로 입력받는 status에 따라서 (ATTEND, ABSENT) 변경되도록 수정하였고,
테스트까지 완료했습니다

로직상은 변경된거없이 이전과 동일하지만, 어드민이 명시적으로 입력하는 값에 따라 변경된다는 점만 수정됐습니다

<br>

## 관련 스크린샷
<img width="310" alt="image" src="https://github.com/user-attachments/assets/7ed6e759-2999-4928-b15b-3fb7f1ad253f" />

<br>

## 주의사항
없습니당
<br>

## 체크 리스트

- [x] 리뷰어 설정
- [x] Assignee 설정
- [x] Label 설정
- [x] 제목 양식 맞췄나요? (ex. #0 Feat: 기능 추가)
- [x] 변경 사항에 대한 테스트