### PR TITLE
Fix #171 출석 상세 정보 조회 시 시작 날짜 기준 오름차순으로 정렬해서 반환

### DIFF
--- a/src/main/java/leets/weeth/domain/attendance/application/usecase/AttendanceUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/attendance/application/usecase/AttendanceUseCaseImpl.java
@@ -19,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Comparator;
 import java.util.List;
 
 @Service
@@ -64,18 +65,20 @@ public class AttendanceUseCaseImpl implements AttendanceUseCase {
     }
 
     /*
-    todo 출석 끝난 후 다음 기수 진행 시 다음 기수의 출석 정보만 나오는지 확인 필요
+    todo 후에 쿼리 최적화, 기수별 정렬 추가
      */
     @Override
     public AttendanceDTO.Detail findAll(Long userId) {
         User user = userGetService.find(userId);
 
         List<AttendanceDTO.Response> responses = user.getAttendances().stream()
+                .sorted(Comparator.comparing(attendance -> attendance.getMeeting().getStart()))
                 .map(mapper::toResponseDto)
                 .toList();
 
         return mapper.toDetailDto(user, responses);
     }
+
     @Override
     public List<AttendanceDTO.AttendanceInfo> findAllAttendanceByMeeting(Long meetingId) {
         Meeting meeting = meetingGetService.find(meetingId);
@@ -86,6 +89,7 @@ public class AttendanceUseCaseImpl implements AttendanceUseCase {
                 .map(mapper::toAttendanceInfoDto)
                 .toList();
     }
+
     @Override
     public void close(LocalDate now, Integer cardinal) {
         List<Meeting> meetings = meetingGetService.find(cardinal);
@@ -103,6 +107,7 @@ public class AttendanceUseCaseImpl implements AttendanceUseCase {
 
         attendanceUpdateService.close(attendanceList);
     }
+
     @Override
     @Transactional
     public void updateAttendanceStatus(List<AttendanceDTO.UpdateStatus> attendanceUpdates) {


### PR DESCRIPTION
## PR 내용
#170 이슈를 보시면 DB 삽입 순서대로 정기모임 정보를 주고 있어서 만약에 순서대로 입력하지 않으면 정렬이 깨지는 문제가 발생할 수 있어 이를 수정했습니다.
<br>

## PR 세부사항
- 기존 코드가 다대일을 유지한 상태의 코드라서 최적화를 진행하진 못했습니다. 우선 버그 픽스 후에 다대일 매핑을 제거하면서 최적화 해보도록 하겠습니다.
<br>

## 관련 스크린샷
<img width="316" alt="image" src="https://github.com/user-attachments/assets/08c5ba4b-d8f3-4c2b-9080-266fe7f32c0d" />

<br>

## 주의사항

<br>

## 체크 리스트

- [x] 리뷰어 설정
- [x] Assignee 설정
- [x] Label 설정
- [x] 제목 양식 맞췄나요? (ex. #0 Feat: 기능 추가)
- [x] 변경 사항에 대한 테스트