### PR TITLE
Refactor #176 유저의 최신 기수 출석 정보만 반환하도록 수정

### DIFF
--- a/src/main/java/leets/weeth/domain/attendance/application/usecase/AttendanceUseCase.java
+++ b/src/main/java/leets/weeth/domain/attendance/application/usecase/AttendanceUseCase.java
@@ -15,7 +15,7 @@ public interface AttendanceUseCase {
 
     Main find(Long userId);
 
-    Detail findAll(Long userId);
+    Detail findAllDetailsByCurrentCardinal(Long userId);
 
     List<AttendanceInfo> findAllAttendanceByMeeting(Long meetingId);
 

--- a/src/main/java/leets/weeth/domain/attendance/application/usecase/AttendanceUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/attendance/application/usecase/AttendanceUseCaseImpl.java
@@ -11,7 +11,9 @@ import leets.weeth.domain.attendance.domain.service.AttendanceUpdateService;
 import leets.weeth.domain.schedule.application.exception.MeetingNotFoundException;
 import leets.weeth.domain.schedule.domain.entity.Meeting;
 import leets.weeth.domain.schedule.domain.service.MeetingGetService;
+import leets.weeth.domain.user.domain.entity.Cardinal;
 import leets.weeth.domain.user.domain.entity.User;
+import leets.weeth.domain.user.domain.service.UserCardinalGetService;
 import leets.weeth.domain.user.domain.service.UserGetService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -27,9 +29,12 @@ import java.util.List;
 public class AttendanceUseCaseImpl implements AttendanceUseCase {
 
     private final UserGetService userGetService;
+    private final UserCardinalGetService userCardinalGetService;
+
     private final AttendanceGetService attendanceGetService;
     private final AttendanceUpdateService attendanceUpdateService;
     private final AttendanceMapper mapper;
+
     private final MeetingGetService meetingGetService;
 
     @Override
@@ -64,14 +69,13 @@ public class AttendanceUseCaseImpl implements AttendanceUseCase {
         return mapper.toMainDto(user, todayMeeting);
     }
 
-    /*
-    todo 후에 쿼리 최적화, 기수별 정렬 추가
-     */
     @Override
     public AttendanceDTO.Detail findAll(Long userId) {
         User user = userGetService.find(userId);
+        Cardinal currentCardinal = userCardinalGetService.getCurrentCardinal(user);
 
         List<AttendanceDTO.Response> responses = user.getAttendances().stream()
+                .filter(attendance -> attendance.getMeeting().getCardinal().equals(currentCardinal.getCardinalNumber()))
                 .sorted(Comparator.comparing(attendance -> attendance.getMeeting().getStart()))
                 .map(mapper::toResponseDto)
                 .toList();

--- a/src/main/java/leets/weeth/domain/attendance/application/usecase/AttendanceUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/attendance/application/usecase/AttendanceUseCaseImpl.java
@@ -69,8 +69,7 @@ public class AttendanceUseCaseImpl implements AttendanceUseCase {
         return mapper.toMainDto(user, todayMeeting);
     }
 
-    @Override
-    public AttendanceDTO.Detail findAll(Long userId) {
+    public AttendanceDTO.Detail findAllDetailsByCurrentCardinal(Long userId) {
         User user = userGetService.find(userId);
         Cardinal currentCardinal = userCardinalGetService.getCurrentCardinal(user);
 

--- a/src/main/java/leets/weeth/domain/attendance/presentation/AttendanceController.java
+++ b/src/main/java/leets/weeth/domain/attendance/presentation/AttendanceController.java
@@ -40,6 +40,6 @@ public class AttendanceController {
     @GetMapping("/detail")
     @Operation(summary="출석 내역 상세조회")
     public CommonResponse<Detail> findAll(@Parameter(hidden = true) @CurrentUser Long userId) {
-        return CommonResponse.createSuccess(ATTENDANCE_FIND_ALL_SUCCESS.getMessage(), attendanceUseCase.findAll(userId));
+        return CommonResponse.createSuccess(ATTENDANCE_FIND_ALL_SUCCESS.getMessage(), attendanceUseCase.findAllDetailsByCurrentCardinal(userId));
     }
 }


### PR DESCRIPTION
## PR 내용
- 현재 출석 상세 조회 페이지에서 모든 기수의 정보가 반환이 되고 있어서, 본인의 최신 기수 정보만 반환하도록 수정했습니다. 
<br>

## PR 세부사항
- 기존 코드에 filter를 추가해 해당 유저의 currentCardinal을 가져와서 meeting.cardinal과 비교해 동일한 정보만 반환하도록 구현했습니다
- 다대일을 지우고 DB 단에서 가져오도록 리팩토링해도 좋겠지만, 현재 로직에 문제가 없고 api 응답 속도도 기준 안에 있어서 우선 필터링만 추가 했습니다
<br>

## 관련 스크린샷
- 작업 전 -> 4기 관련 정보에 5기 정보가 함께 반환
<img width="399" alt="image" src="https://github.com/user-attachments/assets/49121cfd-18bb-4293-a836-3b4fff10c6d5" />

- 작업 후 -> 현재 5기라 5기 정보만 반환
<img width="486" alt="image" src="https://github.com/user-attachments/assets/3ad8564e-6192-49d2-bd57-5ad384b0b8b4" />

<br>

## 주의사항
X
<br>

## 체크 리스트

- [x] 리뷰어 설정
- [x] Assignee 설정
- [x] Label 설정
- [x] 제목 양식 맞췄나요? (ex. #0 Feat: 기능 추가)
- [x] 변경 사항에 대한 테스트