### PR TITLE
Refactor #177 공지사항의 경우 생성일을 반환하도록 수정

### DIFF
--- a/src/main/java/leets/weeth/domain/board/application/mapper/NoticeMapper.java
+++ b/src/main/java/leets/weeth/domain/board/application/mapper/NoticeMapper.java
@@ -23,7 +23,7 @@ public interface NoticeMapper {
             @Mapping(target = "name", source = "notice.user.name"),
             @Mapping(target = "position", source = "notice.user.position"),
             @Mapping(target = "role", source = "notice.user.role"),
-            @Mapping(target = "time", source = "notice.modifiedAt"),
+            @Mapping(target = "time", source = "notice.createdAt"),
             @Mapping(target = "hasFile", expression = "java(fileExists)")
     })
     NoticeDTO.ResponseAll toAll(Notice notice, boolean fileExists);
@@ -32,7 +32,7 @@ public interface NoticeMapper {
             @Mapping(target = "name", source = "notice.user.name"),
             @Mapping(target = "position", source = "notice.user.position"),
             @Mapping(target = "role", source = "notice.user.role"),
-            @Mapping(target = "time", source = "notice.modifiedAt"),
+            @Mapping(target = "time", source = "notice.createdAt"),
             @Mapping(target = "comments", source = "comments")
     })
     NoticeDTO.Response toNoticeDto(Notice notice, List<FileResponse> fileUrls, List<CommentDTO.Response> comments);


### PR DESCRIPTION
## PR 내용
- 공지사항의 경우 기존에 수정일을 반환하고 있었는데, 요구사항 변동으로 "createdAt"을 반환하도록 수정했습니다
- 게시글을 기존과 동일하게 "modifiedAt"이 반환되어 수정시간을 확인할 수 있습니다
<br>

## PR 세부사항
X
<br>

## 관련 스크린샷
x
<br>

## 주의사항
x
<br>

## 체크 리스트

- [x] 리뷰어 설정
- [x] Assignee 설정
- [x] Label 설정
- [x] 제목 양식 맞췄나요? (ex. #0 Feat: 기능 추가)
- [x] 변경 사항에 대한 테스트