### PR TITLE
Refactor #186 현재 활동 중인 인원의 출결 기록만 보이도록 수정

### DIFF
--- a/src/main/java/leets/weeth/domain/attendance/domain/repository/AttendanceRepository.java
+++ b/src/main/java/leets/weeth/domain/attendance/domain/repository/AttendanceRepository.java
@@ -2,15 +2,15 @@ package leets.weeth.domain.attendance.domain.repository;
 
 import leets.weeth.domain.attendance.domain.entity.Attendance;
 import leets.weeth.domain.schedule.domain.entity.Meeting;
+import leets.weeth.domain.user.domain.entity.enums.Status;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface AttendanceRepository extends JpaRepository<Attendance, Long> {
-    List<Attendance> findAllByMeeting(Meeting meeting);
+    List<Attendance> findAllByMeetingAndUserStatus(Meeting meeting, Status status);
 
     @Modifying
     @Query("DELETE FROM Attendance a WHERE a.meeting = :meeting")

--- a/src/main/java/leets/weeth/domain/attendance/domain/service/AttendanceGetService.java
+++ b/src/main/java/leets/weeth/domain/attendance/domain/service/AttendanceGetService.java
@@ -4,6 +4,7 @@ import leets.weeth.domain.attendance.application.exception.AttendanceNotFoundExc
 import leets.weeth.domain.attendance.domain.entity.Attendance;
 import leets.weeth.domain.attendance.domain.repository.AttendanceRepository;
 import leets.weeth.domain.schedule.domain.entity.Meeting;
+import leets.weeth.domain.user.domain.entity.enums.Status;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -16,7 +17,7 @@ public class AttendanceGetService {
     private final AttendanceRepository attendanceRepository;
 
     public List<Attendance> findAllByMeeting(Meeting meeting) {
-        return attendanceRepository.findAllByMeeting(meeting);
+        return attendanceRepository.findAllByMeetingAndUserStatus(meeting, Status.ACTIVE);
     }
     public Attendance findByAttendanceId(Long attendanceId) {
         return attendanceRepository.findById(attendanceId)


### PR DESCRIPTION
## PR 내용
- 임원 요구사항에 있던대로 탈퇴, 추방, 대기 중인 인원을 제외하고 현재 활동 중인 인원의 출결만 보이도록 수정했습니다

<br>

## PR 세부사항
- Status.ACTIVE만 가져오도록 수정
<br>

## 관련 스크린샷
<img width="302" alt="image" src="https://github.com/user-attachments/assets/4b5166f0-20d9-42e8-9979-e5d3bfa36b6a" />

-> 관리자 상태를 WAITING으로 바꾼 후 

<img width="304" alt="image" src="https://github.com/user-attachments/assets/8231674c-3aec-43e2-9c43-6647b9e29425" />

마지막에 표시되던 관리자가 없어진 모습
<br>

## 주의사항

<br>

## 체크 리스트

- [x] 리뷰어 설정
- [x] Assignee 설정
- [x] Label 설정
- [x] 제목 양식 맞췄나요? (ex. #0 Feat: 기능 추가)
- [x] 변경 사항에 대한 테스트