### PR TITLE
Refactor #188 인증서버 수정

### DIFF
--- a/src/main/java/leets/weeth/global/sas/application/exception/ErrorMessage.java
+++ b/src/main/java/leets/weeth/global/sas/application/exception/ErrorMessage.java
@@ -8,7 +8,8 @@ import lombok.Getter;
 public enum ErrorMessage {
 
     USER_INACTIVE("WAE-001", "가입 승인이 허가되지 않은 계정입니다."),
-    USER_NOT_FOUND("WAE-002", "존재하지 않는 유저입니다.");
+    USER_NOT_FOUND("WAE-002", "존재하지 않는 유저입니다."),
+    KAKAO_AUTH_ERROR("WAE-003", "카카오 로그인 예외입니다.");
 
     private final String code;
     private final String description;

--- a/src/main/java/leets/weeth/global/sas/application/exception/KakaoLoginException.java
+++ b/src/main/java/leets/weeth/global/sas/application/exception/KakaoLoginException.java
@@ -1,0 +1,11 @@
+package leets.weeth.global.sas.application.exception;
+
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+
+public class KakaoLoginException extends OAuth2AuthenticationException {
+    public KakaoLoginException(String message) {
+        super(new OAuth2Error(ErrorMessage.KAKAO_AUTH_ERROR.getCode(), message, null));
+
+    }
+}

--- a/src/main/java/leets/weeth/global/sas/application/mapper/OauthMapper.java
+++ b/src/main/java/leets/weeth/global/sas/application/mapper/OauthMapper.java
@@ -3,12 +3,14 @@ package leets.weeth.global.sas.application.mapper;
 import leets.weeth.domain.user.domain.entity.User;
 import leets.weeth.global.sas.application.dto.OauthUserInfoResponse;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import org.mapstruct.MappingConstants;
 import org.mapstruct.ReportingPolicy;
 
 @Mapper(componentModel = MappingConstants.ComponentModel.SPRING, unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface OauthMapper {
 
+    @Mapping(target = "userId", source = "user.id")
     OauthUserInfoResponse toResponse(User user, int cardinal);
 }
 

--- a/src/main/java/leets/weeth/global/sas/config/grant/KakaoAuthenticationProvider.java
+++ b/src/main/java/leets/weeth/global/sas/config/grant/KakaoAuthenticationProvider.java
@@ -4,6 +4,7 @@ import leets.weeth.domain.user.domain.entity.User;
 import leets.weeth.domain.user.domain.service.UserGetService;
 import leets.weeth.global.auth.kakao.KakaoAuthService;
 import leets.weeth.global.auth.kakao.dto.KakaoUserInfoResponse;
+import leets.weeth.global.sas.application.exception.KakaoLoginException;
 import leets.weeth.global.sas.application.exception.UserInActiveException;
 import leets.weeth.global.sas.application.exception.UserNotFoundException;
 import org.springframework.security.core.Authentication;
@@ -12,6 +13,7 @@ import org.springframework.security.oauth2.core.OAuth2Token;
 import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationService;
 import org.springframework.security.oauth2.server.authorization.token.OAuth2TokenGenerator;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
 
 @Component
 public class KakaoAuthenticationProvider extends CustomAuthenticationProvider<KakaoUserInfoResponse> {
@@ -49,7 +51,11 @@ public class KakaoAuthenticationProvider extends CustomAuthenticationProvider<Ka
 
     @Override
     protected KakaoUserInfoResponse getUserInfo(String accessToken) {
-        return kakaoAuthService.getUserInfo(accessToken);
+        try {
+            return kakaoAuthService.getUserInfo(accessToken);
+        } catch (HttpClientErrorException e) {
+            throw new KakaoLoginException(e.getResponseBodyAsString());
+        }
     }
 
     @Override


### PR DESCRIPTION
## PR 내용
- 인증서버 유저 정보 API에서 userId가 매핑되지 않는 문제가 있어 수정했습니다.
- 카카오 custom grant로 요청 시 예외가 클라이언트에게 전달되지 않아, 커스텀 예외를 던져주도록 수정했습니다.
<br>

## PR 세부사항

<br>

## 관련 스크린샷

<br>

## 주의사항

<br>

## 체크 리스트

- [x] 리뷰어 설정
- [x] Assignee 설정
- [x] Label 설정
- [x] 제목 양식 맞췄나요? (ex. #0 Feat: 기능 추가)
- [x] 변경 사항에 대한 테스트