### PR TITLE
Fix #194 parts도 파트 게시글 생성시 동일하게 저장하도록 설정

### DIFF
--- a/src/main/java/leets/weeth/domain/board/application/dto/PostDTO.java
+++ b/src/main/java/leets/weeth/domain/board/application/dto/PostDTO.java
@@ -30,7 +30,6 @@ public class PostDTO {
             @NotNull String title,
             @NotNull String content,
             @NotNull List<Part> parts,
-            @NotNull int week,
             @Valid List<@NotNull FileSaveRequest> files
     ){}
 

--- a/src/main/java/leets/weeth/domain/board/application/mapper/PostMapper.java
+++ b/src/main/java/leets/weeth/domain/board/application/mapper/PostMapper.java
@@ -23,6 +23,7 @@ public interface PostMapper {
             @Mapping(target = "modifiedAt", ignore = true),
             @Mapping(target = "user", source = "user"),
             @Mapping(target = "part", expression = "java(user.getUserPart())"),
+            @Mapping(target = "parts", expression = "java(List.of(user.getUserPart()))"),
             @Mapping(target = "cardinalNumber", expression = "java(latest.getCardinalNumber())")
     })
     Post fromPostDto(PostDTO.Save dto, User user, Cardinal latest);

--- a/src/main/java/leets/weeth/domain/board/presentation/PostController.java
+++ b/src/main/java/leets/weeth/domain/board/presentation/PostController.java
@@ -40,7 +40,7 @@ public class PostController {
     private final PostUsecase postUsecase;
 
     @PostMapping
-    @Operation(summary="게시글 생성")
+    @Operation(summary="파트 게시글 생성 (스터디 로그, 아티클)")
     public CommonResponse<String> save(@RequestBody @Valid PostDTO.Save dto, @Parameter(hidden = true) @CurrentUser Long userId) {
         postUsecase.save(dto, userId);
 


### PR DESCRIPTION
## PR 내용

## 🚨 문제

파트 게시글 생성시 컨버터가 작동안하는 예외케이스 발경

<br>

## 💭 원인

스터디 로그 + 아티클 (파트 게시글) 은 `part`만 저장하고, `parts`를 별도로 저장안해주다보니까 생긴 오류임

<br>

## 🍀 어떻게 해결했나요?

파트 게시글 생성시 `parts` 필드도 동일하게 생성되도록 지정해주었습니다
수정하다보니 `part`와 `parts`를 분리해야할 필요성을 느끼지 못해서, 추후에 해당 부분도 리팩토링하면 좋을거같아요

## 체크 리스트

- [x] 리뷰어 설정
- [x] Assignee 설정
- [x] Label 설정
- [x] 제목 양식 맞췄나요? (ex. #0 Feat: 기능 추가)
- [x] 변경 사항에 대한 테스트