### PR TITLE
Feat #198 댓글 파일 첨부

### DIFF
--- a/src/main/java/leets/weeth/domain/board/application/usecase/NoticeUsecaseImpl.java
+++ b/src/main/java/leets/weeth/domain/board/application/usecase/NoticeUsecaseImpl.java
@@ -21,6 +21,7 @@ import leets.weeth.domain.user.application.exception.UserNotMatchException;
 import leets.weeth.domain.user.domain.entity.User;
 import leets.weeth.domain.user.domain.service.UserGetService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -32,7 +33,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class NoticeUsecaseImpl implements NoticeUsecase {
@@ -143,7 +144,11 @@ public class NoticeUsecaseImpl implements NoticeUsecase {
                 .map(child -> mapToDtoWithChildren(child, commentMap))
                 .collect(Collectors.toList());
 
-        return commentMapper.toCommentDto(comment, children);
+        List<FileResponse> files = fileGetService.findAllByComment(comment.getId()).stream()
+                .map(fileMapper::toFileResponse)
+                .toList();
+
+        return commentMapper.toCommentDto(comment, children, files);
     }
 
 }

--- a/src/main/java/leets/weeth/domain/board/application/usecase/NoticeUsecaseImpl.java
+++ b/src/main/java/leets/weeth/domain/board/application/usecase/NoticeUsecaseImpl.java
@@ -21,7 +21,6 @@ import leets.weeth.domain.user.application.exception.UserNotMatchException;
 import leets.weeth.domain.user.domain.entity.User;
 import leets.weeth.domain.user.domain.service.UserGetService;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -33,7 +32,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-@Slf4j
+
 @Service
 @RequiredArgsConstructor
 public class NoticeUsecaseImpl implements NoticeUsecase {

--- a/src/main/java/leets/weeth/domain/board/application/usecase/PostUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/board/application/usecase/PostUseCaseImpl.java
@@ -1,10 +1,5 @@
 package leets.weeth.domain.board.application.usecase;
 
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 import leets.weeth.domain.board.application.dto.PartPostDTO;
 import leets.weeth.domain.board.application.dto.PostDTO;
 import leets.weeth.domain.board.application.exception.CategoryAccessDeniedException;
@@ -34,13 +29,15 @@ import leets.weeth.domain.user.domain.service.CardinalGetService;
 import leets.weeth.domain.user.domain.service.UserCardinalGetService;
 import leets.weeth.domain.user.domain.service.UserGetService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
-import org.springframework.data.domain.SliceImpl;
-import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -105,7 +102,6 @@ public class PostUseCaseImpl implements PostUsecase {
         List<FileResponse> response = getFiles(postId).stream()
                 .map(fileMapper::toFileResponse)
                 .toList();
-
 
         return mapper.toPostDto(post, response, filterParentComments(post.getComments()));
     }
@@ -232,7 +228,11 @@ public class PostUseCaseImpl implements PostUsecase {
                 .map(child -> mapToDtoWithChildren(child, commentMap))
                 .collect(Collectors.toList());
 
-        return commentMapper.toCommentDto(comment, children);
+        List<FileResponse> files = fileGetService.findAllByComment(comment.getId()).stream()
+                .map(fileMapper::toFileResponse)
+                .toList();
+
+        return commentMapper.toCommentDto(comment, children, files);
     }
 
     private void validatePageNumber(int pageNumber){

--- a/src/main/java/leets/weeth/domain/comment/application/dto/CommentDTO.java
+++ b/src/main/java/leets/weeth/domain/comment/application/dto/CommentDTO.java
@@ -1,6 +1,10 @@
 package leets.weeth.domain.comment.application.dto;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import leets.weeth.domain.file.application.dto.request.FileSaveRequest;
+import leets.weeth.domain.file.application.dto.response.FileResponse;
 import leets.weeth.domain.user.domain.entity.enums.Position;
 import leets.weeth.domain.user.domain.entity.enums.Role;
 import lombok.Builder;
@@ -13,12 +17,14 @@ public class CommentDTO {
     @Builder
     public record Save(
             Long parentCommentId,
-            @NotBlank String content
+            @NotBlank String content,
+            @Valid List<@NotNull FileSaveRequest> files
     ){}
 
     @Builder
     public record Update(
-            @NotBlank String content
+            @NotBlank String content,
+            @Valid List<@NotNull FileSaveRequest> files
     ){}
 
     @Builder
@@ -29,6 +35,7 @@ public class CommentDTO {
             Role role,
             String content,
             LocalDateTime time, //modifiedAt
+            List<FileResponse> fileUrls,
             List<CommentDTO.Response> children
     ){}
 

--- a/src/main/java/leets/weeth/domain/comment/application/mapper/CommentMapper.java
+++ b/src/main/java/leets/weeth/domain/comment/application/mapper/CommentMapper.java
@@ -4,6 +4,7 @@ import leets.weeth.domain.board.domain.entity.Notice;
 import leets.weeth.domain.board.domain.entity.Post;
 import leets.weeth.domain.comment.application.dto.CommentDTO;
 import leets.weeth.domain.comment.domain.entity.Comment;
+import leets.weeth.domain.file.application.dto.response.FileResponse;
 import leets.weeth.domain.user.domain.entity.User;
 import org.mapstruct.*;
 
@@ -44,5 +45,5 @@ public interface CommentMapper {
     @Mapping(target = "role", source = "comment.user.role")
     @Mapping(target = "time", source = "comment.modifiedAt")
     @Mapping(target = "children", source = "children")
-    CommentDTO.Response toCommentDto(Comment comment, List<CommentDTO.Response> children);
+    CommentDTO.Response toCommentDto(Comment comment, List<CommentDTO.Response> children, List<FileResponse> fileUrls);
 }

--- a/src/main/java/leets/weeth/domain/comment/application/usecase/NoticeCommentUsecaseImpl.java
+++ b/src/main/java/leets/weeth/domain/comment/application/usecase/NoticeCommentUsecaseImpl.java
@@ -3,15 +3,18 @@ package leets.weeth.domain.comment.application.usecase;
 import leets.weeth.domain.board.domain.entity.Notice;
 import leets.weeth.domain.board.domain.service.NoticeFindService;
 import leets.weeth.domain.comment.application.dto.CommentDTO;
+import leets.weeth.domain.comment.application.exception.CommentNotFoundException;
 import leets.weeth.domain.comment.application.mapper.CommentMapper;
 import leets.weeth.domain.comment.domain.entity.Comment;
 import leets.weeth.domain.comment.domain.service.CommentDeleteService;
 import leets.weeth.domain.comment.domain.service.CommentFindService;
 import leets.weeth.domain.comment.domain.service.CommentSaveService;
+import leets.weeth.domain.file.application.mapper.FileMapper;
+import leets.weeth.domain.file.domain.entity.File;
+import leets.weeth.domain.file.domain.service.FileSaveService;
+import leets.weeth.domain.user.application.exception.UserNotMatchException;
 import leets.weeth.domain.user.domain.entity.User;
 import leets.weeth.domain.user.domain.service.UserGetService;
-import leets.weeth.domain.comment.application.exception.CommentNotFoundException;
-import leets.weeth.domain.user.application.exception.UserNotMatchException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,6 +28,9 @@ public class NoticeCommentUsecaseImpl implements NoticeCommentUsecase {
     private final CommentSaveService commentSaveService;
     private final CommentFindService commentFindService;
     private final CommentDeleteService commentDeleteService;
+
+    private final FileSaveService fileSaveService;
+    private final FileMapper fileMapper;
 
     private final NoticeFindService noticeFindService;
 
@@ -43,6 +49,9 @@ public class NoticeCommentUsecaseImpl implements NoticeCommentUsecase {
         }
         Comment comment = commentMapper.fromCommentDto(dto, notice, user, parentComment);
         commentSaveService.save(comment);
+
+        List<File> files = fileMapper.toFileList(dto.files(), comment);
+        fileSaveService.save(files);
 
         // 부모 댓글이 없다면 새 댓글로 추가
         if(parentComment == null) {

--- a/src/main/java/leets/weeth/domain/comment/application/usecase/NoticeCommentUsecaseImpl.java
+++ b/src/main/java/leets/weeth/domain/comment/application/usecase/NoticeCommentUsecaseImpl.java
@@ -11,6 +11,8 @@ import leets.weeth.domain.comment.domain.service.CommentFindService;
 import leets.weeth.domain.comment.domain.service.CommentSaveService;
 import leets.weeth.domain.file.application.mapper.FileMapper;
 import leets.weeth.domain.file.domain.entity.File;
+import leets.weeth.domain.file.domain.service.FileDeleteService;
+import leets.weeth.domain.file.domain.service.FileGetService;
 import leets.weeth.domain.file.domain.service.FileSaveService;
 import leets.weeth.domain.user.application.exception.UserNotMatchException;
 import leets.weeth.domain.user.domain.entity.User;
@@ -30,6 +32,8 @@ public class NoticeCommentUsecaseImpl implements NoticeCommentUsecase {
     private final CommentDeleteService commentDeleteService;
 
     private final FileSaveService fileSaveService;
+    private final FileGetService fileGetService;
+    private final FileDeleteService fileDeleteService;
     private final FileMapper fileMapper;
 
     private final NoticeFindService noticeFindService;
@@ -69,6 +73,12 @@ public class NoticeCommentUsecaseImpl implements NoticeCommentUsecase {
         User user = userGetService.find(userId);
         Notice notice = noticeFindService.find(noticeId);
         Comment comment = validateOwner(commentId, userId);
+
+        List<File> fileList = getFiles(commentId);
+        fileDeleteService.delete(fileList);
+
+        List<File> files = fileMapper.toFileList(dto.files(), comment);
+        fileSaveService.save(files);
 
         comment.update(dto);
     }
@@ -118,4 +128,7 @@ public class NoticeCommentUsecaseImpl implements NoticeCommentUsecase {
         return comment;
     }
 
+    private List<File> getFiles(Long commentId) {
+        return fileGetService.findAllByComment(commentId);
+    }
 }

--- a/src/main/java/leets/weeth/domain/comment/application/usecase/PostCommentUsecaseImpl.java
+++ b/src/main/java/leets/weeth/domain/comment/application/usecase/PostCommentUsecaseImpl.java
@@ -8,6 +8,9 @@ import leets.weeth.domain.comment.domain.entity.Comment;
 import leets.weeth.domain.comment.domain.service.CommentDeleteService;
 import leets.weeth.domain.comment.domain.service.CommentFindService;
 import leets.weeth.domain.comment.domain.service.CommentSaveService;
+import leets.weeth.domain.file.application.mapper.FileMapper;
+import leets.weeth.domain.file.domain.entity.File;
+import leets.weeth.domain.file.domain.service.FileSaveService;
 import leets.weeth.domain.user.domain.entity.User;
 import leets.weeth.domain.user.domain.service.UserGetService;
 import leets.weeth.domain.comment.application.exception.CommentNotFoundException;
@@ -25,6 +28,9 @@ public class PostCommentUsecaseImpl implements PostCommentUsecase {
     private final CommentSaveService commentSaveService;
     private final CommentFindService commentFindService;
     private final CommentDeleteService commentDeleteService;
+
+    private final FileSaveService fileSaveService;
+    private final FileMapper fileMapper;
 
     private final UserGetService userGetService;
 
@@ -44,6 +50,9 @@ public class PostCommentUsecaseImpl implements PostCommentUsecase {
         }
         Comment comment = commentMapper.fromCommentDto(dto, post, user, parentComment);
         commentSaveService.save(comment);
+
+        List<File> files = fileMapper.toFileList(dto.files(), comment);
+        fileSaveService.save(files);
 
         // 부모 댓글이 없다면 새 댓글로 추가
         if (parentComment == null) {

--- a/src/main/java/leets/weeth/domain/comment/application/usecase/PostCommentUsecaseImpl.java
+++ b/src/main/java/leets/weeth/domain/comment/application/usecase/PostCommentUsecaseImpl.java
@@ -3,6 +3,7 @@ package leets.weeth.domain.comment.application.usecase;
 import leets.weeth.domain.board.domain.entity.Post;
 import leets.weeth.domain.board.domain.service.PostFindService;
 import leets.weeth.domain.comment.application.dto.CommentDTO;
+import leets.weeth.domain.comment.application.exception.CommentNotFoundException;
 import leets.weeth.domain.comment.application.mapper.CommentMapper;
 import leets.weeth.domain.comment.domain.entity.Comment;
 import leets.weeth.domain.comment.domain.service.CommentDeleteService;
@@ -10,11 +11,12 @@ import leets.weeth.domain.comment.domain.service.CommentFindService;
 import leets.weeth.domain.comment.domain.service.CommentSaveService;
 import leets.weeth.domain.file.application.mapper.FileMapper;
 import leets.weeth.domain.file.domain.entity.File;
+import leets.weeth.domain.file.domain.service.FileDeleteService;
+import leets.weeth.domain.file.domain.service.FileGetService;
 import leets.weeth.domain.file.domain.service.FileSaveService;
+import leets.weeth.domain.user.application.exception.UserNotMatchException;
 import leets.weeth.domain.user.domain.entity.User;
 import leets.weeth.domain.user.domain.service.UserGetService;
-import leets.weeth.domain.comment.application.exception.CommentNotFoundException;
-import leets.weeth.domain.user.application.exception.UserNotMatchException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -30,6 +32,8 @@ public class PostCommentUsecaseImpl implements PostCommentUsecase {
     private final CommentDeleteService commentDeleteService;
 
     private final FileSaveService fileSaveService;
+    private final FileGetService fileGetService;
+    private final FileDeleteService fileDeleteService;
     private final FileMapper fileMapper;
 
     private final UserGetService userGetService;
@@ -70,6 +74,12 @@ public class PostCommentUsecaseImpl implements PostCommentUsecase {
         User user = userGetService.find(userId);
         Post post = postFindService.find(postId);
         Comment comment = validateOwner(commentId, userId);
+
+        List<File> fileList = getFiles(commentId);
+        fileDeleteService.delete(fileList);
+
+        List<File> files = fileMapper.toFileList(dto.files(), comment);
+        fileSaveService.save(files);
 
         comment.update(dto);
     }
@@ -127,6 +137,10 @@ public class PostCommentUsecaseImpl implements PostCommentUsecase {
             throw new UserNotMatchException();
         }
         return comment;
+    }
+
+    private List<File> getFiles(Long commentId) {
+        return fileGetService.findAllByComment(commentId);
     }
 
 }

--- a/src/main/java/leets/weeth/domain/file/application/mapper/FileMapper.java
+++ b/src/main/java/leets/weeth/domain/file/application/mapper/FileMapper.java
@@ -37,6 +37,7 @@ public interface FileMapper {
     @Mapping(target = "id", ignore = true)
     @Mapping(target = "comment", source = "comment")
     @Mapping(target = "notice", ignore = true) // notice 필드는 매핑하지 않도록 명시
+    @Mapping(target = "post", ignore = true) // post 필드는 매핑하지 않도록 명시
     File toFileWithComment(String fileName, String fileUrl, Comment comment);
 
     @Mapping(target = "fileId", source = "file.id")

--- a/src/main/java/leets/weeth/domain/file/domain/entity/File.java
+++ b/src/main/java/leets/weeth/domain/file/domain/entity/File.java
@@ -4,8 +4,12 @@ import jakarta.persistence.*;
 import leets.weeth.domain.account.domain.entity.Receipt;
 import leets.weeth.domain.board.domain.entity.Notice;
 import leets.weeth.domain.board.domain.entity.Post;
+import leets.weeth.domain.comment.domain.entity.Comment;
 import leets.weeth.global.common.entity.BaseEntity;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
 @Getter
@@ -34,6 +38,10 @@ public class File extends BaseEntity {
     @ManyToOne
     @JoinColumn(name = "receipt_id")
     private Receipt receipt;
+
+    @ManyToOne
+    @JoinColumn(name = "comment_id")
+    private Comment comment;
 
     public void update(String fileName, String fileUrl) {
         this.fileName = fileName;

--- a/src/main/java/leets/weeth/domain/file/domain/repository/FileRepository.java
+++ b/src/main/java/leets/weeth/domain/file/domain/repository/FileRepository.java
@@ -12,4 +12,6 @@ public interface FileRepository extends JpaRepository<File, Long> {
     List<File> findAllByNoticeId(Long noticeId);
 
     List<File> findAllByReceiptId(Long receiptId);
+
+    List<File> findAllByCommentId(Long commentId);
 }

--- a/src/main/java/leets/weeth/domain/file/domain/service/FileGetService.java
+++ b/src/main/java/leets/weeth/domain/file/domain/service/FileGetService.java
@@ -1,6 +1,5 @@
 package leets.weeth.domain.file.domain.service;
 
-import leets.weeth.domain.board.domain.entity.Notice;
 import leets.weeth.domain.file.domain.entity.File;
 import leets.weeth.domain.file.domain.repository.FileRepository;
 import lombok.RequiredArgsConstructor;
@@ -26,4 +25,7 @@ public class FileGetService {
         return fileRepository.findAllByReceiptId(receiptId);
     }
 
+    public List<File> findAllByComment(Long commentId) {
+        return fileRepository.findAllByCommentId(commentId);
+    }
 }


### PR DESCRIPTION
## PR 내용
- 댓글에 파일을 첨부할 수 있도록 기능을 추가했습니다
- 입력 출력 모두 기존 게시글, 공지사항에 파일을 활용할 때와 통일했습니다
- 댓글 수정시 파일도 동일한 로직으로 수정 되도록 구현 했씁니다

<br>

## PR 세부사항
- 기존 파일 첨부와 동일합니다
- fileMapper의 중복을 일부 제거해 리팩토링 진행했습니다

<br>

## 관련 스크린샷
- 파일 첨부
<img width="651" height="610" alt="image" src="https://github.com/user-attachments/assets/4deb98b3-45a6-4c0f-82fd-d31daa7d9084" />

- 댓글 조회
<img width="622" height="611" alt="image" src="https://github.com/user-attachments/assets/07c56858-50a9-4aa7-98c0-e2cc000826bc" />


<br>

## 주의사항

<br>

## 체크 리스트

- [x] 리뷰어 설정
- [x] Assignee 설정
- [x] Label 설정
- [x] 제목 양식 맞췄나요? (ex. #0 Feat: 기능 추가)
- [x] 변경 사항에 대한 테스트