### PR TITLE
Fix #199 게시판 반환 시간 수정

### DIFF
--- a/src/main/java/leets/weeth/domain/board/application/dto/NoticeDTO.java
+++ b/src/main/java/leets/weeth/domain/board/application/dto/NoticeDTO.java
@@ -38,7 +38,7 @@ public class NoticeDTO {
             Role role,
             String title,
             String content,
-            LocalDateTime time,//modifiedAt
+            LocalDateTime time, //createdAt
             Integer commentCount,
             List<CommentDTO.Response> comments,
             List<FileResponse> fileUrls

--- a/src/main/java/leets/weeth/domain/board/application/dto/PostDTO.java
+++ b/src/main/java/leets/weeth/domain/board/application/dto/PostDTO.java
@@ -56,8 +56,7 @@ public class PostDTO {
     ){}
 
     @Builder
-    public record
-    ResponseAll(
+    public record ResponseAll(
             Long id,
             String name,
             Position position,

--- a/src/main/java/leets/weeth/domain/board/application/dto/PostDTO.java
+++ b/src/main/java/leets/weeth/domain/board/application/dto/PostDTO.java
@@ -2,8 +2,6 @@ package leets.weeth.domain.board.application.dto;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import java.time.LocalDateTime;
-import java.util.List;
 import leets.weeth.domain.board.domain.entity.enums.Category;
 import leets.weeth.domain.board.domain.entity.enums.Part;
 import leets.weeth.domain.comment.application.dto.CommentDTO;
@@ -12,6 +10,9 @@ import leets.weeth.domain.file.application.dto.response.FileResponse;
 import leets.weeth.domain.user.domain.entity.enums.Position;
 import leets.weeth.domain.user.domain.entity.enums.Role;
 import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 public class PostDTO {
 
@@ -48,14 +49,15 @@ public class PostDTO {
             Role role,
             String title,
             String content,
-            LocalDateTime time,//modifiedAt
+            LocalDateTime time, //createdAt
             Integer commentCount,
             List<CommentDTO.Response> comments,
             List<FileResponse> fileUrls
     ){}
 
     @Builder
-    public record ResponseAll(
+    public record
+    ResponseAll(
             Long id,
             String name,
             Position position,

--- a/src/main/java/leets/weeth/domain/board/application/mapper/PostMapper.java
+++ b/src/main/java/leets/weeth/domain/board/application/mapper/PostMapper.java
@@ -1,6 +1,5 @@
 package leets.weeth.domain.board.application.mapper;
 
-import java.util.List;
 import leets.weeth.domain.board.application.dto.PostDTO;
 import leets.weeth.domain.board.domain.entity.Post;
 import leets.weeth.domain.comment.application.dto.CommentDTO;
@@ -8,11 +7,9 @@ import leets.weeth.domain.comment.application.mapper.CommentMapper;
 import leets.weeth.domain.file.application.dto.response.FileResponse;
 import leets.weeth.domain.user.domain.entity.Cardinal;
 import leets.weeth.domain.user.domain.entity.User;
-import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
-import org.mapstruct.MappingConstants;
-import org.mapstruct.Mappings;
-import org.mapstruct.ReportingPolicy;
+import org.mapstruct.*;
+
+import java.util.List;
 
 @Mapper(componentModel = MappingConstants.ComponentModel.SPRING, uses = CommentMapper.class, unmappedTargetPolicy = ReportingPolicy.IGNORE, imports = { java.time.LocalDateTime.class })
 public interface PostMapper {
@@ -42,7 +39,7 @@ public interface PostMapper {
             @Mapping(target = "name", source = "post.user.name"),
             @Mapping(target = "position", source = "post.user.position"),
             @Mapping(target = "role", source = "post.user.role"),
-            @Mapping(target = "time", source = "post.modifiedAt"),
+            @Mapping(target = "time", source = "post.createdAt"),
             @Mapping(target = "hasFile", expression = "java(fileExists)"),
             @Mapping(target = "isNew", expression = "java(post.getCreatedAt().isAfter(LocalDateTime.now().minusHours(24)))")
     })
@@ -54,7 +51,7 @@ public interface PostMapper {
             @Mapping(target = "parts",         source = "post.parts"),
             @Mapping(target = "week",          source = "post.week"),
             @Mapping(target = "commentCount",  source = "post.commentCount"),
-            @Mapping(target = "time",          source = "post.modifiedAt"),
+            @Mapping(target = "time",          source = "post.createdAt"),
             @Mapping(target = "hasFile",       expression = "java(fileExists)"),
             @Mapping(target = "isNew",         expression = "java(post.getCreatedAt().isAfter(LocalDateTime.now().minusHours(24)))")
     })
@@ -64,7 +61,7 @@ public interface PostMapper {
             @Mapping(target = "name", source = "post.user.name"),
             @Mapping(target = "position", source = "post.user.position"),
             @Mapping(target = "role", source = "post.user.role"),
-            @Mapping(target = "time", source = "post.modifiedAt"),
+            @Mapping(target = "time", source = "post.createdAt"),
             @Mapping(target = "comments", source = "comments")
     })
     PostDTO.Response toPostDto(Post post, List<FileResponse> fileUrls, List<CommentDTO.Response> comments);


### PR DESCRIPTION
## PR 내용
원인: 댓글이 추가되는 경우 게시글의 comment count도 업데이트 되어 수정시간 최신화
- 생성 시간을 반환하는 것으로 수정했습니다
<br>

## PR 세부사항

<br>

## 관련 스크린샷

<br>

## 주의사항
- 게시판 분리 작업과 함께 됨에 따라 side effect가 없는지 봐주시면 감사하겠습니다
<br>

## 체크 리스트

- [x] 리뷰어 설정
- [x] Assignee 설정
- [x] Label 설정
- [x] 제목 양식 맞췄나요? (ex. #0 Feat: 기능 추가)
- [x] 변경 사항에 대한 테스트