### PR TITLE
Refactor #204 검색 API 분리

### DIFF
--- a/src/main/java/leets/weeth/domain/board/application/dto/PostDTO.java
+++ b/src/main/java/leets/weeth/domain/board/application/dto/PostDTO.java
@@ -79,6 +79,7 @@ public class PostDTO {
     public record ResponseAll(
             Long id,
             String name,
+            Part part,
             Position position,
             Role role,
             String title,

--- a/src/main/java/leets/weeth/domain/board/application/usecase/NoticeUsecase.java
+++ b/src/main/java/leets/weeth/domain/board/application/usecase/NoticeUsecase.java
@@ -17,4 +17,5 @@ public interface NoticeUsecase {
 
     void delete(Long noticeId, Long userId) throws UserNotMatchException;
 
+    Slice<NoticeDTO.ResponseAll> searchNotice(String keyword, int pageNumber, int pageSize);
 }

--- a/src/main/java/leets/weeth/domain/board/application/usecase/NoticeUsecaseImpl.java
+++ b/src/main/java/leets/weeth/domain/board/application/usecase/NoticeUsecaseImpl.java
@@ -1,6 +1,11 @@
 package leets.weeth.domain.board.application.usecase;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import leets.weeth.domain.board.application.dto.NoticeDTO;
+import leets.weeth.domain.board.application.exception.NoSearchResultException;
 import leets.weeth.domain.board.application.exception.PageNotFoundException;
 import leets.weeth.domain.board.application.mapper.NoticeMapper;
 import leets.weeth.domain.board.domain.entity.Notice;
@@ -27,11 +32,6 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -83,6 +83,22 @@ public class NoticeUsecaseImpl implements NoticeUsecase {
         Pageable pageable = PageRequest.of(pageNumber, pageSize, Sort.by(Sort.Direction.DESC, "id")); // id를 기준으로 내림차순
         Slice<Notice> notices = noticeFindService.findRecentNotices(pageable);
         return notices.map(notice->mapper.toAll(notice, checkFileExistsByNotice(notice.id)));
+    }
+
+    @Override
+    public Slice<NoticeDTO.ResponseAll> searchNotice(String keyword, int pageNumber, int pageSize) {
+        validatePageNumber(pageNumber);
+
+        keyword = keyword.strip();
+
+        Pageable pageable = PageRequest.of(pageNumber, pageSize, Sort.by(Sort.Direction.DESC, "id"));
+        Slice<Notice> notices = noticeFindService.search(keyword, pageable);
+
+        if (notices.isEmpty()){
+            throw new NoSearchResultException();
+        }
+
+        return notices.map(notice -> mapper.toAll(notice, checkFileExistsByNotice(notice.id)));
     }
 
     @Override
@@ -150,4 +166,9 @@ public class NoticeUsecaseImpl implements NoticeUsecase {
         return commentMapper.toCommentDto(comment, children, files);
     }
 
+    private void validatePageNumber(int pageNumber){
+        if (pageNumber < 0) {
+            throw new PageNotFoundException();
+        }
+    }
 }

--- a/src/main/java/leets/weeth/domain/board/application/usecase/PostUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/board/application/usecase/PostUseCaseImpl.java
@@ -176,6 +176,22 @@ public class PostUseCaseImpl implements PostUsecase {
     }
 
     @Override
+    public Slice<PostDTO.ResponseEducationAll> searchEducation(String keyword, int pageNumber, int pageSize) {
+        validatePageNumber(pageNumber);
+
+        keyword = keyword.strip();
+
+        Pageable pageable = PageRequest.of(pageNumber, pageSize, Sort.by(Sort.Direction.DESC, "id"));
+        Slice<Post> posts = postFindService.searchEducation(keyword, pageable);
+
+        if(posts.isEmpty()){
+            throw new NoSearchResultException();
+        }
+
+        return posts.map(post->mapper.toEducationAll(post, checkFileExistsByPost(post.id)));
+    }
+
+    @Override
     @Transactional
     public void update(Long postId, PostDTO.Update dto, Long userId) {
         Post post = validateOwner(postId, userId);

--- a/src/main/java/leets/weeth/domain/board/application/usecase/PostUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/board/application/usecase/PostUseCaseImpl.java
@@ -125,22 +125,21 @@ public class PostUseCaseImpl implements PostUsecase {
     }
 
     @Override
-    public Slice<PostDTO.ResponseEducationAll> findEducationPosts(Long userId, Integer cardinalNumber, int pageNumber, int pageSize) {
+    public Slice<PostDTO.ResponseEducationAll> findEducationPosts(Long userId, Part part, Integer cardinalNumber, int pageNumber, int pageSize) {
         User user = userGetService.find(userId);
+        Pageable pageable = PageRequest.of(pageNumber, pageSize, Sort.by(Sort.Direction.DESC, "id"));
 
         if (user.hasRole(Role.ADMIN)) {
 
-            return postFindService.findByCategory(Category.Education, pageNumber, pageSize)
+            return postFindService.findByCategory(part, Category.Education, pageNumber, pageSize)
                     .map(post -> mapper.toEducationAll(post, checkFileExistsByPost(post.getId())));
         }
-
-        Pageable pageable = PageRequest.of(pageNumber, pageSize, Sort.by(Sort.Direction.DESC, "id"));
 
         if (cardinalNumber != null) {
             if (userCardinalGetService.notContains(user, cardinalGetService.findByUserSide(cardinalNumber))) {
                 return new SliceImpl<>(Collections.emptyList(), pageable, false);
             }
-            Slice<Post> posts = postFindService.findEducationByCardinal(cardinalNumber, pageable);
+            Slice<Post> posts = postFindService.findEducationByCardinal(part, cardinalNumber, pageable);
             return posts.map(post -> mapper.toEducationAll(post, checkFileExistsByPost(post.getId())));
         }
 
@@ -148,7 +147,7 @@ public class PostUseCaseImpl implements PostUsecase {
         if (userCardinals.isEmpty()) {
             return new SliceImpl<>(Collections.emptyList(), pageable, false);
         }
-        Slice<Post> posts = postFindService.findEducationByCardinals(userCardinals, pageable);
+        Slice<Post> posts = postFindService.findEducationByCardinals(part, userCardinals, pageable);
 
         return posts.map(post -> mapper.toEducationAll(post, checkFileExistsByPost(post.getId())));
     }

--- a/src/main/java/leets/weeth/domain/board/application/usecase/PostUsecase.java
+++ b/src/main/java/leets/weeth/domain/board/application/usecase/PostUsecase.java
@@ -19,7 +19,7 @@ public interface PostUsecase {
 
     Slice<PostDTO.ResponseAll> findPartPosts(PartPostDTO dto, int pageNumber, int pageSize);
 
-    Slice<PostDTO.ResponseEducationAll> findEducationPosts(Long userId, Integer cardinalNumber, int pageNumber, int pageSize);
+    Slice<PostDTO.ResponseEducationAll> findEducationPosts(Long userId, Part part, Integer cardinalNumber, int pageNumber, int pageSize);
 
     PostDTO.ResponseStudyNames findStudyNames(Part part);
 

--- a/src/main/java/leets/weeth/domain/board/application/usecase/PostUsecase.java
+++ b/src/main/java/leets/weeth/domain/board/application/usecase/PostUsecase.java
@@ -30,4 +30,6 @@ public interface PostUsecase {
     void delete(Long postId, Long userId) throws UserNotMatchException;
 
     Slice<PostDTO.ResponseAll> searchPost(String keyword, int pageNumber, int pageSize);
+
+    Slice<PostDTO.ResponseEducationAll> searchEducation(String keyword, int pageNumber, int pageSize);
 }

--- a/src/main/java/leets/weeth/domain/board/domain/repository/NoticeRepository.java
+++ b/src/main/java/leets/weeth/domain/board/domain/repository/NoticeRepository.java
@@ -4,10 +4,19 @@ import leets.weeth.domain.board.domain.entity.Notice;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 
 public interface NoticeRepository extends JpaRepository<Notice, Long> {
 
     Slice<Notice> findPageBy(Pageable page);
 
+    @Query("""
+        SELECT n FROM Notice n
+        WHERE (LOWER(n.title)   LIKE LOWER(CONCAT('%', :kw, '%'))
+            OR LOWER(n.content) LIKE LOWER(CONCAT('%', :kw, '%')))
+        ORDER BY n.id DESC
+    """)
+    Slice<Notice> search(@Param("kw") String kw, Pageable pageable);
 }

--- a/src/main/java/leets/weeth/domain/board/domain/repository/PostRepository.java
+++ b/src/main/java/leets/weeth/domain/board/domain/repository/PostRepository.java
@@ -38,18 +38,46 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     """)
 	Slice<Post> findByPartAndOptionalFilters(@Param("part") Part part, @Param("category") Category category, @Param("cardinal") Integer cardinal, @Param("studyName") String studyName, @Param("week") Integer week, Pageable pageable);
 
-	Slice<Post> findByCategoryAndCardinalNumber(Category category, Integer cardinalNumber, Pageable pageable);
+	@Query("""
+		SELECT p
+		  FROM Post p
+		 WHERE p.category = :category
+		   AND (
+				 :partName = 'ALL'
+			  OR FUNCTION('FIND_IN_SET', :partName, FUNCTION('REPLACE', p.parts, ' ', '')) > 0
+			  OR FUNCTION('FIND_IN_SET', 'ALL',    FUNCTION('REPLACE', p.parts, ' ', '')) > 0
+			 )
+	  ORDER BY p.id DESC
+	""")
+	Slice<Post> findByCategoryWithPart(@Param("partName") String partName, @Param("category") Category category, Pageable pageable);
+
+	@Query("""
+		SELECT p
+		  FROM Post p
+		 WHERE p.category = :category
+		   AND p.cardinalNumber = :cardinal
+		   AND (
+				 :partName = 'ALL'
+			  OR FUNCTION('FIND_IN_SET', :partName, FUNCTION('REPLACE', p.parts, ' ', '')) > 0
+			  OR FUNCTION('FIND_IN_SET', 'ALL',    FUNCTION('REPLACE', p.parts, ' ', '')) > 0
+			 )
+	  ORDER BY p.id DESC
+	""")
+	Slice<Post> findByCategoryAndCardinalNumberWithPart(@Param("partName") String partName, @Param("category") Category category, @Param("cardinal") Integer cardinal, Pageable pageable);
 
 	@Query("""
 		SELECT p
 		  FROM Post p
 		 WHERE p.category = :category
 		   AND p.cardinalNumber IN :cardinals
+		   AND (
+				 :partName = 'ALL'
+			  OR FUNCTION('FIND_IN_SET', :partName, FUNCTION('REPLACE', p.parts, ' ', '')) > 0
+			  OR FUNCTION('FIND_IN_SET', 'ALL',    FUNCTION('REPLACE', p.parts, ' ', '')) > 0
+			 )
 	  ORDER BY p.id DESC
 	""")
-	Slice<Post> findByCategoryAndCardinalIn(@Param("category") Category category, @Param("cardinals") Collection<Integer> cardinals, Pageable pageable);
-
-	Slice<Post> findByCategory(Category category, Pageable pageable);
+	Slice<Post> findByCategoryAndCardinalInWithPart(@Param("partName") String partName, @Param("category") Category category, @Param("cardinals") Collection<Integer> cardinals, Pageable pageable);
 
 	Slice<Post> findByTitleContainingOrContentContainingIgnoreCase(String keyword1, String keyword2, Pageable pageable);
 }

--- a/src/main/java/leets/weeth/domain/board/domain/repository/PostRepository.java
+++ b/src/main/java/leets/weeth/domain/board/domain/repository/PostRepository.java
@@ -44,8 +44,8 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 		 WHERE p.category = :category
 		   AND (
 				 :partName = 'ALL'
-			  OR FUNCTION('FIND_IN_SET', :partName, FUNCTION('REPLACE', p.parts, ' ', '')) > 0
-			  OR FUNCTION('FIND_IN_SET', 'ALL',    FUNCTION('REPLACE', p.parts, ' ', '')) > 0
+			  OR FUNCTION('FIND_IN_SET', :partName, p.parts) > 0
+			  OR FUNCTION('FIND_IN_SET', 'ALL',    p.parts) > 0
 			 )
 	  ORDER BY p.id DESC
 	""")
@@ -58,8 +58,8 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 		   AND p.cardinalNumber = :cardinal
 		   AND (
 				 :partName = 'ALL'
-			  OR FUNCTION('FIND_IN_SET', :partName, FUNCTION('REPLACE', p.parts, ' ', '')) > 0
-			  OR FUNCTION('FIND_IN_SET', 'ALL',    FUNCTION('REPLACE', p.parts, ' ', '')) > 0
+			  OR FUNCTION('FIND_IN_SET', :partName, p.parts) > 0
+			  OR FUNCTION('FIND_IN_SET', 'ALL',    p.parts) > 0
 			 )
 	  ORDER BY p.id DESC
 	""")
@@ -72,8 +72,8 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 		   AND p.cardinalNumber IN :cardinals
 		   AND (
 				 :partName = 'ALL'
-			  OR FUNCTION('FIND_IN_SET', :partName, FUNCTION('REPLACE', p.parts, ' ', '')) > 0
-			  OR FUNCTION('FIND_IN_SET', 'ALL',    FUNCTION('REPLACE', p.parts, ' ', '')) > 0
+			  OR FUNCTION('FIND_IN_SET', :partName, p.parts) > 0
+			  OR FUNCTION('FIND_IN_SET', 'ALL',    p.parts) > 0
 			 )
 	  ORDER BY p.id DESC
 	""")

--- a/src/main/java/leets/weeth/domain/board/domain/repository/PostRepository.java
+++ b/src/main/java/leets/weeth/domain/board/domain/repository/PostRepository.java
@@ -14,7 +14,47 @@ import org.springframework.data.repository.query.Param;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
 
-	Slice<Post> findPageBy(Pageable page);
+	@Query("""
+        SELECT p FROM Post p
+        WHERE p.category IN (
+            leets.weeth.domain.board.domain.entity.enums.Category.StudyLog,
+            leets.weeth.domain.board.domain.entity.enums.Category.Article
+        )
+        ORDER BY p.id DESC
+    """)
+	Slice<Post> findRecentPart(Pageable pageable);
+
+	@Query("""
+        SELECT p FROM Post p
+        WHERE p.category = leets.weeth.domain.board.domain.entity.enums.Category.Education
+        ORDER BY p.id DESC
+    """)
+	Slice<Post> findRecentEducation(Pageable pageable);
+
+	@Query("""
+        SELECT p FROM Post p
+        WHERE p.category IN (
+            leets.weeth.domain.board.domain.entity.enums.Category.StudyLog,
+            leets.weeth.domain.board.domain.entity.enums.Category.Article
+        )
+          AND (
+                LOWER(p.title)   LIKE LOWER(CONCAT('%', :kw, '%'))
+             OR LOWER(p.content) LIKE LOWER(CONCAT('%', :kw, '%'))
+          )
+        ORDER BY p.id DESC
+    """)
+	Slice<Post> searchPart(@Param("kw") String kw, Pageable pageable);
+
+	@Query("""
+        SELECT p FROM Post p
+        WHERE p.category = leets.weeth.domain.board.domain.entity.enums.Category.Education
+          AND (
+                LOWER(p.title)   LIKE LOWER(CONCAT('%', :kw, '%'))
+             OR LOWER(p.content) LIKE LOWER(CONCAT('%', :kw, '%'))
+          )
+        ORDER BY p.id DESC
+    """)
+	Slice<Post> searchEducation(@Param("kw") String kw, Pageable pageable);
 
 	@Query("""
 		SELECT DISTINCT p.studyName
@@ -78,6 +118,4 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 	  ORDER BY p.id DESC
 	""")
 	Slice<Post> findByCategoryAndCardinalInWithPart(@Param("partName") String partName, @Param("category") Category category, @Param("cardinals") Collection<Integer> cardinals, Pageable pageable);
-
-	Slice<Post> findByTitleContainingOrContentContainingIgnoreCase(String keyword1, String keyword2, Pageable pageable);
 }

--- a/src/main/java/leets/weeth/domain/board/domain/service/NoticeFindService.java
+++ b/src/main/java/leets/weeth/domain/board/domain/service/NoticeFindService.java
@@ -1,14 +1,13 @@
 package leets.weeth.domain.board.domain.service;
 
+import java.util.List;
+import leets.weeth.domain.board.application.exception.NoticeNotFoundException;
 import leets.weeth.domain.board.domain.entity.Notice;
 import leets.weeth.domain.board.domain.repository.NoticeRepository;
-import leets.weeth.domain.board.application.exception.NoticeNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -30,4 +29,10 @@ public class NoticeFindService {
         return noticeRepository.findPageBy(pageable);
     }
 
+    public Slice<Notice> search(String keyword, Pageable pageable) {
+        if(keyword == null || keyword.isEmpty()){
+            return findRecentNotices(pageable);
+        }
+        return noticeRepository.search(keyword.strip(), pageable);
+    }
 }

--- a/src/main/java/leets/weeth/domain/board/domain/service/PostFindService.java
+++ b/src/main/java/leets/weeth/domain/board/domain/service/PostFindService.java
@@ -36,7 +36,25 @@ public class PostFindService {
     }
 
     public Slice<Post> findRecentPosts(Pageable pageable) {
-        return postRepository.findPageBy(pageable);
+        return postRepository.findRecentPart(pageable);
+    }
+
+    public Slice<Post> findRecentEducationPosts(Pageable pageable) {
+        return postRepository.findRecentEducation(pageable);
+    }
+
+    public Slice<Post> search(String keyword, Pageable pageable) {
+        if(keyword == null || keyword.isEmpty()){
+            return findRecentPosts(pageable);
+        }
+        return postRepository.searchPart(keyword.strip(), pageable);
+    }
+
+    public Slice<Post> searchEducation(String keyword, Pageable pageable) {
+        if(keyword == null || keyword.isEmpty()){
+            return findRecentEducationPosts(pageable);
+        }
+        return postRepository.searchEducation(keyword.strip(), pageable);
     }
 
     public Slice<Post> findByPartAndOptionalFilters(Part part, Category category, Integer cardinalNumber, String  studyName, Integer week, Pageable pageable) {
@@ -67,14 +85,4 @@ public class PostFindService {
 
         return postRepository.findByCategoryWithPart(partName, category, pageable);
     }
-
-    public Slice<Post> search(String keyword, Pageable pageable) {
-        if(keyword == null || keyword.isEmpty()){
-            return findRecentPosts(pageable);
-        }
-        else{
-            return postRepository.findByTitleContainingOrContentContainingIgnoreCase(keyword, keyword, pageable);
-        }
-    }
-
 }

--- a/src/main/java/leets/weeth/domain/board/domain/service/PostFindService.java
+++ b/src/main/java/leets/weeth/domain/board/domain/service/PostFindService.java
@@ -46,24 +46,26 @@ public class PostFindService {
         );
     }
 
-    public Slice<Post> findEducationByCardinals(Collection<Integer> cardinals, Pageable pageable) {
+    public Slice<Post> findEducationByCardinals(Part part, Collection<Integer> cardinals, Pageable pageable) {
         if (cardinals == null || cardinals.isEmpty()) {
             return new SliceImpl<>(Collections.emptyList(), pageable, false);
         }
-        return postRepository.findByCategoryAndCardinalIn(Category.Education, cardinals, pageable);
+        String partName = (part != null ? part.name() : Part.ALL.name());
+
+        return postRepository.findByCategoryAndCardinalInWithPart(partName, Category.Education, cardinals, pageable);
     }
 
-    public Slice<Post> findEducationByCardinal(int cardinalNumber, Pageable pageable) {
+    public Slice<Post> findEducationByCardinal(Part part, int cardinalNumber, Pageable pageable) {
+        String partName = (part != null ? part.name() : Part.ALL.name());
 
-        return postRepository.findByCategoryAndCardinalNumber(
-                Category.Education, cardinalNumber, pageable
-        );
+        return postRepository.findByCategoryAndCardinalNumberWithPart(partName, Category.Education, cardinalNumber, pageable);
     }
 
-    public Slice<Post> findByCategory(Category category, int pageNumber, int pageSize) {
+    public Slice<Post> findByCategory(Part part, Category category, int pageNumber, int pageSize) {
         Pageable pageable = PageRequest.of(pageNumber, pageSize, Sort.by(Sort.Direction.DESC, "id"));
+        String partName = (part != null ? part.name() : Part.ALL.name());
 
-        return postRepository.findByCategory(category, pageable);
+        return postRepository.findByCategoryWithPart(partName, category, pageable);
     }
 
     public Slice<Post> search(String keyword, Pageable pageable) {

--- a/src/main/java/leets/weeth/domain/board/presentation/NoticeController.java
+++ b/src/main/java/leets/weeth/domain/board/presentation/NoticeController.java
@@ -3,6 +3,7 @@ package leets.weeth.domain.board.presentation;
 
 import static leets.weeth.domain.board.presentation.ResponseMessage.NOTICE_FIND_ALL_SUCCESS;
 import static leets.weeth.domain.board.presentation.ResponseMessage.NOTICE_FIND_BY_ID_SUCCESS;
+import static leets.weeth.domain.board.presentation.ResponseMessage.NOTICE_SEARCH_SUCCESS;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -11,7 +12,11 @@ import leets.weeth.domain.board.application.usecase.NoticeUsecase;
 import leets.weeth.global.common.response.CommonResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Slice;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 
 @Tag(name = "NOTICE", description = "공지사항 API")
@@ -24,8 +29,7 @@ public class NoticeController {
 
     @GetMapping
     @Operation(summary="공지사항 목록 조회 [무한스크롤]")
-    public CommonResponse<Slice<NoticeDTO.ResponseAll>> findNotices(@RequestParam("pageNumber") int pageNumber,
-                                                                   @RequestParam("pageSize") int pageSize) {
+    public CommonResponse<Slice<NoticeDTO.ResponseAll>> findNotices(@RequestParam("pageNumber") int pageNumber, @RequestParam("pageSize") int pageSize) {
         return CommonResponse.createSuccess(NOTICE_FIND_ALL_SUCCESS.getMessage(), noticeUsecase.findNotices(pageNumber, pageSize));
     }
 
@@ -33,5 +37,11 @@ public class NoticeController {
     @Operation(summary="특정 공지사항 조회")
     public CommonResponse<NoticeDTO.Response> findNoticeById(@PathVariable Long noticeId) {
         return CommonResponse.createSuccess(NOTICE_FIND_BY_ID_SUCCESS.getMessage(), noticeUsecase.findNotice(noticeId));
+    }
+
+    @GetMapping("/search")
+    @Operation(summary="공지사항 검색 [무한스크롤]")
+    public CommonResponse<Slice<NoticeDTO.ResponseAll>> findNotice(@RequestParam String keyword, @RequestParam("pageNumber") int pageNumber, @RequestParam("pageSize") int pageSize) {
+        return CommonResponse.createSuccess(NOTICE_SEARCH_SUCCESS.getMessage(), noticeUsecase.searchNotice(keyword, pageNumber, pageSize));
     }
 }

--- a/src/main/java/leets/weeth/domain/board/presentation/PostController.java
+++ b/src/main/java/leets/weeth/domain/board/presentation/PostController.java
@@ -75,7 +75,7 @@ public class PostController {
     @GetMapping("/{boardId}")
     @Operation(summary="특정 게시글 조회")
     public CommonResponse<PostDTO.Response> findPost(@PathVariable Long boardId) {
-        return CommonResponse.createSuccess(POST_FIND_BY_ID_SUCCESS.getMessage(),postUsecase.findPost(boardId));
+        return CommonResponse.createSuccess(POST_FIND_BY_ID_SUCCESS.getMessage(), postUsecase.findPost(boardId));
     }
 
     @GetMapping("/part/studies")
@@ -89,14 +89,14 @@ public class PostController {
     @Operation(summary="파트 게시글 검색 [무한스크롤]")
     public CommonResponse<Slice<PostDTO.ResponseAll>> findPost(@RequestParam String keyword, @RequestParam("pageNumber") int pageNumber,
                                                                     @RequestParam("pageSize") int pageSize) {
-        return CommonResponse.createSuccess(POST_SEARCH_SUCCESS.getMessage(),postUsecase.searchPost(keyword, pageNumber, pageSize));
+        return CommonResponse.createSuccess(POST_SEARCH_SUCCESS.getMessage(), postUsecase.searchPost(keyword, pageNumber, pageSize));
     }
 
     @GetMapping("/search/education")
     @Operation(summary="교육자료 검색 [무한스크롤]")
     public CommonResponse<Slice<PostDTO.ResponseEducationAll>> findEducation(@RequestParam String keyword, @RequestParam("pageNumber") int pageNumber,
                                                                @RequestParam("pageSize") int pageSize) {
-        return CommonResponse.createSuccess(EDUCATION_SEARCH_SUCCESS.getMessage(),postUsecase.searchEducation(keyword, pageNumber, pageSize));
+        return CommonResponse.createSuccess(EDUCATION_SEARCH_SUCCESS.getMessage(), postUsecase.searchEducation(keyword, pageNumber, pageSize));
     }
 
     @PatchMapping(value = "/{boardId}/part")
@@ -114,5 +114,4 @@ public class PostController {
         postUsecase.delete(boardId, userId);
         return CommonResponse.createSuccess(POST_DELETED_SUCCESS.getMessage());
     }
-
 }

--- a/src/main/java/leets/weeth/domain/board/presentation/PostController.java
+++ b/src/main/java/leets/weeth/domain/board/presentation/PostController.java
@@ -1,11 +1,13 @@
 package leets.weeth.domain.board.presentation;
 
+import static leets.weeth.domain.board.presentation.ResponseMessage.EDUCATION_SEARCH_SUCCESS;
 import static leets.weeth.domain.board.presentation.ResponseMessage.POST_CREATED_SUCCESS;
 import static leets.weeth.domain.board.presentation.ResponseMessage.POST_DELETED_SUCCESS;
 import static leets.weeth.domain.board.presentation.ResponseMessage.POST_EDU_FIND_SUCCESS;
 import static leets.weeth.domain.board.presentation.ResponseMessage.POST_FIND_ALL_SUCCESS;
 import static leets.weeth.domain.board.presentation.ResponseMessage.POST_FIND_BY_ID_SUCCESS;
 import static leets.weeth.domain.board.presentation.ResponseMessage.POST_PART_FIND_ALL_SUCCESS;
+import static leets.weeth.domain.board.presentation.ResponseMessage.POST_SEARCH_SUCCESS;
 import static leets.weeth.domain.board.presentation.ResponseMessage.POST_UPDATED_SUCCESS;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -83,11 +85,18 @@ public class PostController {
         return CommonResponse.createSuccess(ResponseMessage.POST_STUDY_NAMES_FIND_SUCCESS.getMessage(), postUsecase.findStudyNames(part));
     }
 
-    @GetMapping("/search")
-    @Operation(summary="게시글 검색 [무한스크롤]")
+    @GetMapping("/search/part")
+    @Operation(summary="파트 게시글 검색 [무한스크롤]")
     public CommonResponse<Slice<PostDTO.ResponseAll>> findPost(@RequestParam String keyword, @RequestParam("pageNumber") int pageNumber,
                                                                     @RequestParam("pageSize") int pageSize) {
-        return CommonResponse.createSuccess(POST_FIND_BY_ID_SUCCESS.getMessage(),postUsecase.searchPost(keyword, pageNumber, pageSize));
+        return CommonResponse.createSuccess(POST_SEARCH_SUCCESS.getMessage(),postUsecase.searchPost(keyword, pageNumber, pageSize));
+    }
+
+    @GetMapping("/search/education")
+    @Operation(summary="교육자료 검색 [무한스크롤]")
+    public CommonResponse<Slice<PostDTO.ResponseEducationAll>> findEducation(@RequestParam String keyword, @RequestParam("pageNumber") int pageNumber,
+                                                               @RequestParam("pageSize") int pageSize) {
+        return CommonResponse.createSuccess(EDUCATION_SEARCH_SUCCESS.getMessage(),postUsecase.searchEducation(keyword, pageNumber, pageSize));
     }
 
     @PatchMapping(value = "/{boardId}/part")

--- a/src/main/java/leets/weeth/domain/board/presentation/PostController.java
+++ b/src/main/java/leets/weeth/domain/board/presentation/PostController.java
@@ -65,9 +65,9 @@ public class PostController {
 
     @GetMapping("/education")
     @Operation(summary="교육자료 조회 [무한스크롤]")
-    public CommonResponse<Slice<PostDTO.ResponseEducationAll>> findEducationMaterials(@RequestParam(required = false) Integer cardinalNumber, @RequestParam("pageNumber") int pageNumber, @RequestParam("pageSize") int pageSize, @Parameter(hidden = true) @CurrentUser Long userId) {
+    public CommonResponse<Slice<PostDTO.ResponseEducationAll>> findEducationMaterials(@RequestParam Part part, @RequestParam(required = false) Integer cardinalNumber, @RequestParam("pageNumber") int pageNumber, @RequestParam("pageSize") int pageSize, @Parameter(hidden = true) @CurrentUser Long userId) {
 
-        return CommonResponse.createSuccess(POST_EDU_FIND_SUCCESS.getMessage(), postUsecase.findEducationPosts(userId, cardinalNumber, pageNumber, pageSize));
+        return CommonResponse.createSuccess(POST_EDU_FIND_SUCCESS.getMessage(), postUsecase.findEducationPosts(userId, part, cardinalNumber, pageNumber, pageSize));
     }
 
     @GetMapping("/{boardId}")

--- a/src/main/java/leets/weeth/domain/board/presentation/ResponseMessage.java
+++ b/src/main/java/leets/weeth/domain/board/presentation/ResponseMessage.java
@@ -12,6 +12,7 @@ public enum ResponseMessage {
     //NoticeController 관련
     NOTICE_FIND_ALL_SUCCESS("공지사항 목록이 성공적으로 조회되었습니다."),
     NOTICE_FIND_BY_ID_SUCCESS("공지사항이 성공적으로 조회되었습니다."),
+    NOTICE_SEARCH_SUCCESS("공지사항 검색 결과가 성공적으로 조회되었습니다."),
     //PostController 관련
     POST_CREATED_SUCCESS("게시글이 성공적으로 생성되었습니다."),
     POST_UPDATED_SUCCESS("파트 게시글이 성공적으로 수정되었습니다."),
@@ -19,7 +20,9 @@ public enum ResponseMessage {
     POST_FIND_ALL_SUCCESS("게시글 목록이 성공적으로 조회되었습니다."),
     POST_PART_FIND_ALL_SUCCESS("파트별 게시글 목록이 성공적으로 조회되었습니다."),
     POST_EDU_FIND_SUCCESS("교육 게시글 목록이 성공적으로 조회되었습니다."),
-    POST_FIND_BY_ID_SUCCESS("게시글이 성공적으로 조회되었습니다."),
+    POST_FIND_BY_ID_SUCCESS("파트 게시글이 성공적으로 조회되었습니다."),
+    POST_SEARCH_SUCCESS("파트 게시글 검색 결과가 성공적으로 조회되었습니다."),
+    EDUCATION_SEARCH_SUCCESS("교육 자료 검색 결과가 성공적으로 조회되었습니다."),
     POST_STUDY_NAMES_FIND_SUCCESS("스터디 이름 목록이 성공적으로 조회되었습니다."),
 
     EDUCATION_UPDATED_SUCCESS("교육자료가 성공적으로 수정되었습니다.");


### PR DESCRIPTION
## PR 내용

- [x] 교육자료 목록조회 요청 dto 파트 추가
- [x] 검색 API에서 parts 추가로 반환
- [x] 스터디 로그 + 아티클 / 교육자료 / 공지사항 검색 API 총 3개로 분리

<br>

## PR 세부사항

기존에 교육자료 조회시 파트를 입력받고있지 않던 부분도 함께 수정했습니다

검색 API 분리는 총 3개로 나눠서 진행 했고, 검색 플로우는 기존과 동일하게 검색 결과가 없을 경우 예외처리, 빈 검색어일 경우에는 기존과 동일한 플로우로 설계했습니다

<br>

## 관련 스크린샷

<br>

## 주의사항

기존에 발생하던 공지사항 검색결과가 안나오는 이슈도 API를 분리해줌으로써 해결할 수 있었습니다

<br>

## 체크 리스트

- [x] 리뷰어 설정
- [x] Assignee 설정
- [x] Label 설정
- [x] 제목 양식 맞췄나요? (ex. #0 Feat: 기능 추가)
- [x] 변경 사항에 대한 테스트